### PR TITLE
Fixing HLS playback.

### DIFF
--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -248,7 +248,7 @@ void MediaSource::monitorSourceBuffers()
     // https://dvcs.w3.org/hg/html-media/raw-file/default/media-source/media-source.html#buffer-monitoring
 
     // Note, the behavior if activeSourceBuffers is empty is undefined.
-    if (!m_activeSourceBuffers) {
+    if (!m_activeSourceBuffers || m_activeSourceBuffers->length() == 0) {
         m_private->setReadyState(MediaPlayer::HaveNothing);
         return;
     }

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerMSE.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerMSE.h
@@ -62,7 +62,7 @@ public:
     bool changePipelineState(GstState) override;
 
     void durationChanged() override;
-    MediaTime durationMediaTime() const override { return m_mediaTimeDuration; }
+    MediaTime durationMediaTime() const override;
     float duration() const override;
     float mediaTimeForTimeValue(float timeValue) const;
     void setRate(float) override;


### PR DESCRIPTION
Fixed following:
1. Fixed to set infinity duration to MediaSourceClientGStreamerMSE. See SourceBuffer::sourceBufferPrivateDidReceiveInitializationSegment. When no valid duration found in Initialization Segment Received it sets infinity as a duration and makes it as a live stream.
2. In case if current duration is infinity in MediaPlayerPrivateGStreamerMSE::maxTimeSeekable() added a fix to fetch the highest end time value from buffered attribute to return proper filled TimeRange object in HTMLMediaElement.seekable().
3. Fixed MediaSource::monitorSourceBuffers() to prevent assigning HAVE_ENOUGH_DATA to media player which led to send loadeddata event before initialization segment received, and no valid duration, seekable and other attributes returned.
