### PR TITLE
[GStreamer][MSE] Removes the use of timeouts to detect data starve and last sample stages

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerMSE.cpp
@@ -1544,6 +1544,7 @@ void AppendPipeline::setAppendStage(AppendStage newAppendStage)
         case NotStarted:
             ok = true;
             if (m_pendingBuffer) {
+                TRACE_MEDIA_MESSAGE("pushing pending buffer %p", m_pendingBuffer.get());
                 gst_app_src_push_buffer(GST_APP_SRC(appsrc()), m_pendingBuffer.leakRef());
                 markEndOfAppendData();
                 nextAppendStage = Ongoing;
@@ -1813,6 +1814,8 @@ void AppendPipeline::receiveEndOfAppendData()
 {
     ASSERT(WTF::isMainThread());
 
+    TRACE_MEDIA_MESSAGE("end of append data mark was received");
+
     switch (m_appendStage) {
     case Ongoing:
         TRACE_MEDIA_MESSAGE("DataStarve");
@@ -1994,6 +1997,7 @@ GstFlowReturn AppendPipeline::pushNewBuffer(GstBuffer* buffer)
         result = GST_FLOW_OK;
     } else {
         setAppendStage(AppendPipeline::Ongoing);
+        TRACE_MEDIA_MESSAGE("pushing new buffer %p", buffer);
         result = gst_app_src_push_buffer(GST_APP_SRC(appsrc()), buffer);
         markEndOfAppendData();
     }
@@ -2005,6 +2009,8 @@ void AppendPipeline::markEndOfAppendData()
 {
     GstEvent* event = gst_event_new_custom(GST_EVENT_CUSTOM_DOWNSTREAM, gst_structure_new_empty("end-of-append-data-mark"));
     m_appendIdMarkedInSrc = guint64(gst_event_get_seqnum(event));
+
+    TRACE_MEDIA_MESSAGE("marking end of append with id %" G_GUINT64_FORMAT, m_appendIdMarkedInSrc);
 
     gst_element_send_event(m_appsrc, event);
 
@@ -2176,6 +2182,7 @@ void AppendPipeline::connectToAppSink(GstPad* demuxerSrcPad)
     }
 
     // The previous mark has probably been lost because appsink was disconnected. Mark again.
+    TRACE_MEDIA_MESSAGE("previous append end mark lost, reinsterting");
     markEndOfAppendData();
 
     g_cond_signal(&m_padAddRemoveCondition);

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerMSE.cpp
@@ -1213,8 +1213,8 @@ static GstFlowReturn appendPipelineAppSinkNewSample(GstElement*, AppendPipeline*
 static gboolean appendPipelineAppSinkNewSampleMainThread(NewSampleInfo*);
 static void appendPipelineAppSinkEOS(GstElement*, AppendPipeline*);
 static gboolean appendPipelineAppSinkEOSMainThread(AppendPipeline* ap);
-static gboolean appendPipelineDataStarveTimeout(AppendPipeline* ap);
-static gboolean appendPipelineLastSampleTimeout(AppendPipeline* ap);
+static gboolean appendPipelineDataStarveTimeout(gpointer);
+static gboolean appendPipelineLastSampleTimeout(gpointer);
 
 static void appendPipelineElementMessageCallback(GstBus*, GstMessage* message, AppendPipeline* ap)
 {
@@ -1453,7 +1453,7 @@ gint AppendPipeline::id()
 void AppendPipeline::scheduleDataStarveTimer()
 {
     LOG_MEDIA_MESSAGE("Scheduling data starve timer");
-    m_dataStarvedTimeoutTag = g_timeout_add(s_dataStarvedTimeoutMsec, GSourceFunc(appendPipelineDataStarveTimeout), this);
+    m_dataStarvedTimeoutTag = g_timeout_add(s_dataStarvedTimeoutMsec, appendPipelineDataStarveTimeout, this);
 }
 
 void AppendPipeline::cancelDataStarveTimer()
@@ -1470,7 +1470,7 @@ void AppendPipeline::scheduleLastSampleTimer()
 {
     if (m_lastSampleTimeoutTag)
         cancelLastSampleTimer();
-    m_lastSampleTimeoutTag = g_timeout_add(s_lastSampleTimeoutMsec, GSourceFunc(appendPipelineLastSampleTimeout), this);
+    m_lastSampleTimeoutTag = g_timeout_add(s_lastSampleTimeoutMsec, appendPipelineLastSampleTimeout, this);
 }
 
 void AppendPipeline::cancelLastSampleTimer()
@@ -2299,23 +2299,17 @@ static gboolean appendPipelineAppSinkEOSMainThread(AppendPipeline* ap)
     return G_SOURCE_REMOVE;
 }
 
-static gboolean appendPipelineDataStarveTimeout(AppendPipeline* ap)
+static gboolean appendPipelineDataStarveTimeout(gpointer)
 {
-    LOG_MEDIA_MESSAGE("data starve timer fired");
-    if (ap->appendStage()==AppendPipeline::AppendStage::Invalid)
-        return G_SOURCE_REMOVE;
-
-    ap->setAppendStage(AppendPipeline::DataStarve);
+    ERROR_MEDIA_MESSAGE("data starve timer fired");
+    ASSERT_NOT_REACHED();
     return G_SOURCE_REMOVE;
 }
 
-static gboolean appendPipelineLastSampleTimeout(AppendPipeline* ap)
+static gboolean appendPipelineLastSampleTimeout(gpointer)
 {
-    TRACE_MEDIA_MESSAGE("last sample timer fired");
-    if (ap->appendStage()==AppendPipeline::AppendStage::Invalid)
-        return G_SOURCE_REMOVE;
-
-    ap->setAppendStage(AppendPipeline::LastSample);
+    ERROR_MEDIA_MESSAGE("last sample timer fired");
+    ASSERT_NOT_REACHED();
     return G_SOURCE_REMOVE;
 }
 

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerMSE.cpp
@@ -178,7 +178,7 @@ private:
     // This is the last id received by the probe in the appsink sink pad
     guint64 m_appendIdReceivedInSink;
 
-    gulong m_endOfDataProbeId;
+    gulong m_appsinkDataEnteringProbeId;
     gulong m_appsrcDataLeavingProbeId;
 
     // Some appended data are only headers and don't generate any
@@ -1211,7 +1211,7 @@ static void appendPipelineDemuxerPadRemoved(GstElement*, GstPad*, AppendPipeline
 static gboolean appendPipelineDemuxerConnectToAppSinkMainThread(PadInfo*);
 static gboolean appendPipelineDemuxerDisconnectFromAppSinkMainThread(PadInfo*);
 static void appendPipelineAppSinkCapsChanged(GObject*, GParamSpec*, AppendPipeline*);
-static GstPadProbeReturn appendPipelineAppSinkEvent(GstPad *pad, GstPadProbeInfo *info, AppendPipeline* ap);
+static GstPadProbeReturn appendPipelineAppsinkDataEntering(GstPad*, GstPadProbeInfo*, AppendPipeline*);
 static GstPadProbeReturn appendPipelineAppsrcDataLeaving(GstPad*, GstPadProbeInfo*, AppendPipeline*);
 static GstFlowReturn appendPipelineAppSinkNewSample(GstElement*, AppendPipeline*);
 static gboolean appendPipelineAppSinkNewSampleMainThread(NewSampleInfo*);
@@ -1284,7 +1284,7 @@ AppendPipeline::AppendPipeline(PassRefPtr<MediaSourceClientGStreamerMSE> mediaSo
     GRefPtr<GstPad> appSinkPad = adoptGRef(gst_element_get_static_pad(m_appsink, "sink"));
     g_signal_connect(appSinkPad.get(), "notify::caps", G_CALLBACK(appendPipelineAppSinkCapsChanged), this);
 
-    m_endOfDataProbeId = gst_pad_add_probe(appSinkPad.get(), GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM, reinterpret_cast<GstPadProbeCallback>(appendPipelineAppSinkEvent), this, nullptr);
+    m_appsinkDataEnteringProbeId = gst_pad_add_probe(appSinkPad.get(), GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM, reinterpret_cast<GstPadProbeCallback>(appendPipelineAppsinkDataEntering), this, nullptr);
 
     GRefPtr<GstPad> appsrcPad = adoptGRef(gst_element_get_static_pad(m_appsrc, "src"));
     m_appsrcDataLeavingProbeId = gst_pad_add_probe(appsrcPad.get(), GST_PAD_PROBE_TYPE_BUFFER, reinterpret_cast<GstPadProbeCallback>(appendPipelineAppsrcDataLeaving), this, nullptr);
@@ -1367,7 +1367,7 @@ AppendPipeline::~AppendPipeline()
         g_signal_handlers_disconnect_by_func(m_appsink, (gpointer)appendPipelineAppSinkNewSample, this);
         g_signal_handlers_disconnect_by_func(m_appsink, (gpointer)appendPipelineAppSinkEOS, this);
 
-        gst_pad_remove_probe(appSinkPad.get(), m_endOfDataProbeId);
+        gst_pad_remove_probe(appSinkPad.get(), m_appsinkDataEnteringProbeId);
 
         gst_object_unref(m_appsink);
         m_appsink = NULL;
@@ -2278,7 +2278,7 @@ static GstPadProbeReturn appendPipelineAppsrcDataLeaving(GstPad*, GstPadProbeInf
     return GST_PAD_PROBE_OK;
 }
 
-static GstPadProbeReturn appendPipelineAppSinkEvent(GstPad *, GstPadProbeInfo *info, AppendPipeline* ap)
+static GstPadProbeReturn appendPipelineAppsinkDataEntering(GstPad*, GstPadProbeInfo* info, AppendPipeline* appendPipeline)
 {
     GstEvent* event = GST_PAD_PROBE_INFO_EVENT(info);
     if (GST_EVENT_TYPE(event) != GST_EVENT_CUSTOM_DOWNSTREAM)
@@ -2292,7 +2292,7 @@ static GstPadProbeReturn appendPipelineAppSinkEvent(GstPad *, GstPadProbeInfo *i
 
     TRACE_MEDIA_MESSAGE("id=%" G_GUINT64_FORMAT, id);
 
-    ap->reportEndOfAppendDataMarkReceived(id);
+    appendPipeline->reportEndOfAppendDataMarkReceived(id);
 
     return GST_PAD_PROBE_OK;
 }

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerMSE.cpp
@@ -88,7 +88,7 @@ class AppendPipeline : public ThreadSafeRefCounted<AppendPipeline> {
 public:
     enum AppendStage { Invalid, NotStarted, Ongoing, KeyNegotiation, DataStarve, Sampling, LastSample, Aborting };
 
-    static const unsigned int s_dataStarvedTimeoutMsec = 1000;
+    static const unsigned int s_dataStarvedTimeoutMsec = 2000;
     static const unsigned int s_lastSampleTimeoutMsec = 250;
 
     AppendPipeline(PassRefPtr<MediaSourceClientGStreamerMSE> mediaSourceClient, PassRefPtr<SourceBufferPrivateGStreamer> sourceBufferPrivate, MediaPlayerPrivateGStreamerMSE* playerPrivate);
@@ -1229,7 +1229,7 @@ static GstFlowReturn appendPipelineAppSinkNewSample(GstElement*, AppendPipeline*
 static gboolean appendPipelineAppSinkNewSampleMainThread(NewSampleInfo*);
 static void appendPipelineAppSinkEOS(GstElement*, AppendPipeline*);
 static gboolean appendPipelineAppSinkEOSMainThread(AppendPipeline* ap);
-static gboolean appendPipelineDataStarveTimeout(gpointer);
+static gboolean appendPipelineDataStarveTimeout(AppendPipeline*);
 static gboolean appendPipelineLastSampleTimeout(gpointer);
 
 static void appendPipelineElementMessageCallback(GstBus*, GstMessage* message, AppendPipeline* ap)
@@ -1522,7 +1522,7 @@ gint AppendPipeline::id()
 void AppendPipeline::scheduleDataStarveTimer()
 {
     LOG_MEDIA_MESSAGE("Scheduling data starve timer");
-    m_dataStarvedTimeoutTag = g_timeout_add(s_dataStarvedTimeoutMsec, appendPipelineDataStarveTimeout, this);
+    m_dataStarvedTimeoutTag = g_timeout_add(s_dataStarvedTimeoutMsec, GSourceFunc(appendPipelineDataStarveTimeout), this);
 }
 
 void AppendPipeline::cancelDataStarveTimer()
@@ -2445,10 +2445,14 @@ static gboolean appendPipelineAppSinkEOSMainThread(AppendPipeline* ap)
     return G_SOURCE_REMOVE;
 }
 
-static gboolean appendPipelineDataStarveTimeout(gpointer)
+static gboolean appendPipelineDataStarveTimeout(AppendPipeline* appendPipeline)
 {
-    ERROR_MEDIA_MESSAGE("data starve timer fired");
-    ASSERT_NOT_REACHED();
+    AppendPipeline::AppendStage appendStage = appendPipeline->appendStage();
+    INFO_MEDIA_MESSAGE("data starve timer fired, stage %s", dumpAppendStage(appendStage));
+    if (appendStage == AppendPipeline::AppendStage::Ongoing) {
+        WARN_MEDIA_MESSAGE("setting DataStarve because of timeout");
+        appendPipeline->setAppendStage(AppendPipeline::AppendStage::DataStarve);
+    }
     return G_SOURCE_REMOVE;
 }
 

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerMSE.cpp
@@ -1453,7 +1453,7 @@ void AppendPipeline::handleEndOfAppendDataMarkReceived(const GstStructure* struc
     ASSERT(m_appendIdReceivedInSink);
 
     TRACE_MEDIA_MESSAGE("received end of append id %" G_GUINT64_FORMAT " in the sink", m_appendIdReceivedInSink);
-    if (m_appendStage == Sampling)
+    if (m_appendStage == Sampling || m_appendStage == Ongoing)
         checkEndOfAppendDataMarkReceived();
 }
 

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerMSE.cpp
@@ -1477,7 +1477,7 @@ void AppendPipeline::handleEndOfAppendDataMarkReceived(const GstStructure* struc
     gst_structure_get(structure, "id", G_TYPE_UINT, &m_appendIdReceivedInSink, NULL);
     ASSERT(m_appendIdReceivedInSink);
 
-    TRACE_MEDIA_MESSAGE("received end of append id %d in the sink", m_appendIdReceivedInSink);
+    TRACE_MEDIA_MESSAGE("received end of append id %u in the sink", m_appendIdReceivedInSink);
     if (m_appendStage == Sampling || m_appendStage == Ongoing)
         checkEndOfAppendDataMarkReceived();
 }
@@ -2046,7 +2046,7 @@ void AppendPipeline::handleEndOfAppendDataMarkNeeded()
     m_appendIdMarkedInSrc = gst_event_get_seqnum(event);
     m_appendIdReceivedInSink = 0;
 
-    TRACE_MEDIA_MESSAGE("marking end of append with id %d", m_appendIdMarkedInSrc);
+    TRACE_MEDIA_MESSAGE("marking end of append with id %u", m_appendIdMarkedInSrc);
 
     gst_element_send_event(m_appsrc, event);
 
@@ -2060,7 +2060,7 @@ void AppendPipeline::reportEndOfAppendDataMarkReceived(guint id)
     GstStructure* structure = gst_structure_new("end-of-append-data-mark-received", "id", G_TYPE_UINT, id, NULL);
     GstMessage* message = gst_message_new_application(GST_OBJECT(m_appsink), structure);
     gst_bus_post(m_bus.get(), message);
-    TRACE_MEDIA_MESSAGE("received message with id %d, re-posted to bus", id);
+    TRACE_MEDIA_MESSAGE("received message with id %u, re-posted to bus", id);
 }
 
 void AppendPipeline::reportEndOfAppendDataMarkNeeded()
@@ -2226,7 +2226,7 @@ void AppendPipeline::connectToAppSink(GstPad* demuxerSrcPad)
     }
 
     // The previous mark has probably been lost because appsink was disconnected. Mark again.
-    TRACE_MEDIA_MESSAGE("previous append end mark lost, reinsterting");
+    TRACE_MEDIA_MESSAGE("previous append end mark lost, reinjecting");
     handleEndOfAppendDataMarkNeeded();
 
     g_cond_signal(&m_padAddRemoveCondition);
@@ -2298,7 +2298,7 @@ static GstPadProbeReturn appendPipelineAppsrcDataLeaving(GstPad*, GstPadProbeInf
         GstBuffer* buffer = GST_PAD_PROBE_INFO_BUFFER(info);
         gsize bufferSize = gst_buffer_get_size(buffer);
 
-        TRACE_MEDIA_MESSAGE("buffer of size %d going thru", bufferSize);
+        TRACE_MEDIA_MESSAGE("buffer of size %" G_GSIZE_FORMAT " going thru", bufferSize);
 
         if (bufferSize > 0)
             appendPipeline->reportEndOfAppendDataMarkNeeded();
@@ -2317,7 +2317,7 @@ static GstPadProbeReturn appendPipelineAppsrcDataLeaving(GstPad*, GstPadProbeInf
             return GST_PAD_PROBE_OK;
 
         guint id = gst_event_get_seqnum(event);
-        TRACE_MEDIA_MESSAGE("custom downstream event id=%d", id);
+        TRACE_MEDIA_MESSAGE("custom downstream event id=%u", id);
 
         return GST_PAD_PROBE_OK;
     }
@@ -2340,7 +2340,7 @@ static GstPadProbeReturn appendPipelineAppsinkDataEntering(GstPad*, GstPadProbeI
 
         guint id = gst_event_get_seqnum(event);
 
-        TRACE_MEDIA_MESSAGE("id=%d", id);
+        TRACE_MEDIA_MESSAGE("id=%u", id);
 
         appendPipeline->reportEndOfAppendDataMarkReceived(id);
 
@@ -2350,7 +2350,7 @@ static GstPadProbeReturn appendPipelineAppsinkDataEntering(GstPad*, GstPadProbeI
 #ifdef DEBUG_APPEND_PIPELINE_PADS
     if (GST_PAD_PROBE_INFO_TYPE(info) & GST_PAD_PROBE_TYPE_BUFFER) {
         GstBuffer* buffer = GST_PAD_PROBE_INFO_BUFFER(info);
-        TRACE_MEDIA_MESSAGE("buffer of size %d going thru", gst_buffer_get_size(buffer));
+        TRACE_MEDIA_MESSAGE("buffer of size %" G_GSIZE_FORMAT " going thru", gst_buffer_get_size(buffer));
         return GST_PAD_PROBE_OK;
     }
 #endif
@@ -2365,7 +2365,7 @@ static GstPadProbeReturn appendPipelinePadProbeDebugInformation(GstPad*, GstPadP
     ASSERT(GST_PAD_PROBE_INFO_TYPE(info) != static_cast<GstPadProbeType>(GST_PAD_PROBE_TYPE_BUFFER | GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM));
     if (GST_PAD_PROBE_INFO_TYPE(info) & GST_PAD_PROBE_TYPE_BUFFER) {
         GstBuffer* buffer = GST_PAD_PROBE_INFO_BUFFER(info);
-        TRACE_MEDIA_MESSAGE("%s: buffer of size %d going thru", padProbeInformation->m_description, gst_buffer_get_size(buffer));
+        TRACE_MEDIA_MESSAGE("%s: buffer of size %" G_GSIZE_FORMAT " going thru", padProbeInformation->m_description, gst_buffer_get_size(buffer));
         return GST_PAD_PROBE_OK;
     }
 
@@ -2379,7 +2379,7 @@ static GstPadProbeReturn appendPipelinePadProbeDebugInformation(GstPad*, GstPadP
             return GST_PAD_PROBE_OK;
 
         guint id = gst_event_get_seqnum(event);
-        TRACE_MEDIA_MESSAGE("%s: custom downstream event id=%d", padProbeInformation->m_description, id);
+        TRACE_MEDIA_MESSAGE("%s: custom downstream event id=%u", padProbeInformation->m_description, id);
 
         return GST_PAD_PROBE_OK;
     }


### PR DESCRIPTION
The timeouts were kept and raising an error and an ASSERT to be able to detect any possible regressions in the near future. If this goes were, we can remove the timeouts.

This implementation was based on an initial one by @eocanha and I corrected the pending issues.