### PR TITLE
[GStreamer][MSE] Remove use of timeouts completely on AppendPipeline

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerMSE.cpp
@@ -134,7 +134,7 @@ public:
     void cancelLastSampleTimer();
 
     void reportAppsrcNeedDataReceived();
-    void markAtLeastABufferLeftAppsrc() { m_atLeastABufferLeftAppsrc = true; }
+    void markAtLeastABufferLeftAppsrc();
 
 private:
     void resetPipeline();
@@ -175,6 +175,7 @@ private:
 
     bool m_appsrcNeedDataReceived;
     bool m_atLeastABufferLeftAppsrc;
+    Mutex m_atLeastABufferLeftAppsrcMutex;
 
     gulong m_appsinkDataEnteringProbeId;
     gulong m_appsrcDataLeavingProbeId;
@@ -2033,8 +2034,16 @@ GstFlowReturn AppendPipeline::pushNewBuffer(GstBuffer* buffer)
     return result;
 }
 
+void AppendPipeline::markAtLeastABufferLeftAppsrc()
+{
+    MutexLocker locker(m_atLeastABufferLeftAppsrcMutex);
+    m_atLeastABufferLeftAppsrc = true;
+}
+
 void AppendPipeline::reportAppsrcNeedDataReceived()
 {
+    MutexLocker locker(m_atLeastABufferLeftAppsrcMutex);
+
     if (!m_atLeastABufferLeftAppsrc) {
         TRACE_MEDIA_MESSAGE("discarding signal until at least a buffer leaves appsrc");
         return;

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerMSE.cpp
@@ -177,10 +177,10 @@ private:
     bool m_atLeastABufferLeftAppsrc;
     Mutex m_atLeastABufferLeftAppsrcMutex;
 
-    gulong m_appsinkDataEnteringProbeId;
     gulong m_appsrcDataLeavingProbeId;
 #ifdef DEBUG_APPEND_PIPELINE_PADS
     struct PadProbeInformation m_demuxerDataEnteringPadProbeInformation;
+    struct PadProbeInformation m_appsinkDataEnteringPadProbeInformation;
 #endif
 
     // Some appended data are only headers and don't generate any
@@ -1214,7 +1214,6 @@ static void appendPipelineDemuxerPadRemoved(GstElement*, GstPad*, AppendPipeline
 static gboolean appendPipelineDemuxerConnectToAppSinkMainThread(PadInfo*);
 static gboolean appendPipelineDemuxerDisconnectFromAppSinkMainThread(PadInfo*);
 static void appendPipelineAppSinkCapsChanged(GObject*, GParamSpec*, AppendPipeline*);
-static GstPadProbeReturn appendPipelineAppsinkDataEntering(GstPad*, GstPadProbeInfo*, AppendPipeline*);
 static GstPadProbeReturn appendPipelineAppsrcDataLeaving(GstPad*, GstPadProbeInfo*, AppendPipeline*);
 #ifdef DEBUG_APPEND_PIPELINE_PADS
 static GstPadProbeReturn appendPipelinePadProbeDebugInformation(GstPad*, GstPadProbeInfo*, struct PadProbeInformation*);
@@ -1289,24 +1288,17 @@ AppendPipeline::AppendPipeline(PassRefPtr<MediaSourceClientGStreamerMSE> mediaSo
     GRefPtr<GstPad> appSinkPad = adoptGRef(gst_element_get_static_pad(m_appsink, "sink"));
     g_signal_connect(appSinkPad.get(), "notify::caps", G_CALLBACK(appendPipelineAppSinkCapsChanged), this);
 
-#ifdef DEBUG_APPEND_PIPELINE_PADS
-    m_appsinkDataEnteringProbeId = gst_pad_add_probe(appSinkPad.get(), static_cast<GstPadProbeType>(GST_PAD_PROBE_TYPE_BUFFER | GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM), reinterpret_cast<GstPadProbeCallback>(appendPipelineAppsinkDataEntering), this, nullptr);
-#else
-    m_appsinkDataEnteringProbeId = gst_pad_add_probe(appSinkPad.get(), GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM, reinterpret_cast<GstPadProbeCallback>(appendPipelineAppsinkDataEntering), this, nullptr);
-#endif
-
     GRefPtr<GstPad> appsrcPad = adoptGRef(gst_element_get_static_pad(m_appsrc, "src"));
-#ifdef DEBUG_APPEND_PIPELINE_PADS
-    m_appsrcDataLeavingProbeId = gst_pad_add_probe(appsrcPad.get(), static_cast<GstPadProbeType>(GST_PAD_PROBE_TYPE_BUFFER | GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM), reinterpret_cast<GstPadProbeCallback>(appendPipelineAppsrcDataLeaving), this, nullptr);
-#else
     m_appsrcDataLeavingProbeId = gst_pad_add_probe(appsrcPad.get(), GST_PAD_PROBE_TYPE_BUFFER, reinterpret_cast<GstPadProbeCallback>(appendPipelineAppsrcDataLeaving), this, nullptr);
-#endif
 
 #ifdef DEBUG_APPEND_PIPELINE_PADS
     GRefPtr<GstPad> demuxerPad = adoptGRef(gst_element_get_static_pad(m_qtdemux, "sink"));
     m_demuxerDataEnteringPadProbeInformation.m_appendPipeline = this;
     m_demuxerDataEnteringPadProbeInformation.m_description = "demuxer data entering";
-    m_demuxerDataEnteringPadProbeInformation.m_probeId = gst_pad_add_probe(demuxerPad.get(), static_cast<GstPadProbeType>(GST_PAD_PROBE_TYPE_BUFFER | GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM), reinterpret_cast<GstPadProbeCallback>(appendPipelinePadProbeDebugInformation), &m_demuxerDataEnteringPadProbeInformation, nullptr);
+    m_demuxerDataEnteringPadProbeInformation.m_probeId = gst_pad_add_probe(demuxerPad.get(), GST_PAD_PROBE_TYPE_BUFFER, reinterpret_cast<GstPadProbeCallback>(appendPipelinePadProbeDebugInformation), &m_demuxerDataEnteringPadProbeInformation, nullptr);
+    m_appsinkDataEnteringPadProbeInformation.m_appendPipeline = this;
+    m_appsinkDataEnteringPadProbeInformation.m_description = "appsink data entering";
+    m_appsinkDataEnteringPadProbeInformation.m_probeId = gst_pad_add_probe(appSinkPad.get(), GST_PAD_PROBE_TYPE_BUFFER, reinterpret_cast<GstPadProbeCallback>(appendPipelinePadProbeDebugInformation), &m_appsinkDataEnteringPadProbeInformation, nullptr);
 #endif
 
     // These signals won't be connected outside of the lifetime of "this".
@@ -1390,7 +1382,9 @@ AppendPipeline::~AppendPipeline()
         g_signal_handlers_disconnect_by_func(m_appsink, (gpointer)appendPipelineAppSinkNewSample, this);
         g_signal_handlers_disconnect_by_func(m_appsink, (gpointer)appendPipelineAppSinkEOS, this);
 
-        gst_pad_remove_probe(appSinkPad.get(), m_appsinkDataEnteringProbeId);
+#ifdef DEBUG_APPEND_PIPELINE_PADS
+        gst_pad_remove_probe(appSinkPad.get(), m_appsinkDataEnteringPadProbeInformation.m_probeId);
+#endif
 
         gst_object_unref(m_appsink);
         m_appsink = NULL;
@@ -2277,90 +2271,24 @@ static void appendPipelineAppSinkCapsChanged(GObject*, GParamSpec*, AppendPipeli
 
 static GstPadProbeReturn appendPipelineAppsrcDataLeaving(GstPad*, GstPadProbeInfo* info, AppendPipeline* appendPipeline)
 {
-    if (GST_PAD_PROBE_INFO_TYPE(info) & GST_PAD_PROBE_TYPE_BUFFER) {
-        GstBuffer* buffer = GST_PAD_PROBE_INFO_BUFFER(info);
-        gsize bufferSize = gst_buffer_get_size(buffer);
+    ASSERT(GST_PAD_PROBE_INFO_TYPE(info) & GST_PAD_PROBE_TYPE_BUFFER);
 
-        TRACE_MEDIA_MESSAGE("buffer of size %" G_GSIZE_FORMAT " going thru", bufferSize);
+    GstBuffer* buffer = GST_PAD_PROBE_INFO_BUFFER(info);
+    gsize bufferSize = gst_buffer_get_size(buffer);
 
-        appendPipeline->markAtLeastABufferLeftAppsrc();
+    TRACE_MEDIA_MESSAGE("buffer of size %" G_GSIZE_FORMAT " going thru", bufferSize);
 
-        return GST_PAD_PROBE_OK;
-    }
+    appendPipeline->markAtLeastABufferLeftAppsrc();
 
-#ifdef DEBUG_APPEND_PIPELINE_PADS
-    if (GST_PAD_PROBE_INFO_TYPE(info) & GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM) {
-        GstEvent* event = GST_PAD_PROBE_INFO_EVENT(info);
-        if (GST_EVENT_TYPE(event) != GST_EVENT_CUSTOM_DOWNSTREAM)
-            return GST_PAD_PROBE_OK;
-
-        const GstStructure* structure = gst_event_get_structure(event);
-        ASSERT(gst_structure_has_name(structure, "end-of-append-data-mark"));
-
-        guint id = gst_event_get_seqnum(event);
-        TRACE_MEDIA_MESSAGE("custom downstream event id=%u", id);
-
-        return GST_PAD_PROBE_OK;
-    }
-#endif
-
-    ASSERT_NOT_REACHED();
-    return GST_PAD_PROBE_OK;
-}
-
-static GstPadProbeReturn appendPipelineAppsinkDataEntering(GstPad*, GstPadProbeInfo* info, AppendPipeline*)
-{
-    if (GST_PAD_PROBE_INFO_TYPE(info) & GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM) {
-        GstEvent* event = GST_PAD_PROBE_INFO_EVENT(info);
-        if (GST_EVENT_TYPE(event) != GST_EVENT_CUSTOM_DOWNSTREAM)
-            return GST_PAD_PROBE_OK;
-
-        const GstStructure* structure = gst_event_get_structure(event);
-        ASSERT(gst_structure_has_name(structure, "end-of-append-data-mark"));
-
-        guint id = gst_event_get_seqnum(event);
-
-        TRACE_MEDIA_MESSAGE("id=%u", id);
-
-        return GST_PAD_PROBE_OK;
-    }
-
-#ifdef DEBUG_APPEND_PIPELINE_PADS
-    if (GST_PAD_PROBE_INFO_TYPE(info) & GST_PAD_PROBE_TYPE_BUFFER) {
-        GstBuffer* buffer = GST_PAD_PROBE_INFO_BUFFER(info);
-        TRACE_MEDIA_MESSAGE("buffer of size %" G_GSIZE_FORMAT " going thru", gst_buffer_get_size(buffer));
-        return GST_PAD_PROBE_OK;
-    }
-#endif
-
-    ASSERT_NOT_REACHED();
     return GST_PAD_PROBE_OK;
 }
 
 #ifdef DEBUG_APPEND_PIPELINE_PADS
 static GstPadProbeReturn appendPipelinePadProbeDebugInformation(GstPad*, GstPadProbeInfo* info, struct PadProbeInformation* padProbeInformation)
 {
-    if (GST_PAD_PROBE_INFO_TYPE(info) & GST_PAD_PROBE_TYPE_BUFFER) {
-        GstBuffer* buffer = GST_PAD_PROBE_INFO_BUFFER(info);
-        TRACE_MEDIA_MESSAGE("%s: buffer of size %" G_GSIZE_FORMAT " going thru", padProbeInformation->m_description, gst_buffer_get_size(buffer));
-        return GST_PAD_PROBE_OK;
-    }
-
-    if (GST_PAD_PROBE_INFO_TYPE(info) & GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM) {
-        GstEvent* event = GST_PAD_PROBE_INFO_EVENT(info);
-        if (GST_EVENT_TYPE(event) != GST_EVENT_CUSTOM_DOWNSTREAM)
-            return GST_PAD_PROBE_OK;
-
-        const GstStructure* structure = gst_event_get_structure(event);
-        ASSERT(gst_structure_has_name(structure, "end-of-append-data-mark"));
-
-        guint id = gst_event_get_seqnum(event);
-        TRACE_MEDIA_MESSAGE("%s: custom downstream event id=%u", padProbeInformation->m_description, id);
-
-        return GST_PAD_PROBE_OK;
-    }
-
-    ASSERT_NOT_REACHED();
+    ASSERT(GST_PAD_PROBE_INFO_TYPE(info) & GST_PAD_PROBE_TYPE_BUFFER);
+    GstBuffer* buffer = GST_PAD_PROBE_INFO_BUFFER(info);
+    TRACE_MEDIA_MESSAGE("%s: buffer of size %" G_GSIZE_FORMAT " going thru", padProbeInformation->m_description, gst_buffer_get_size(buffer));
     return GST_PAD_PROBE_OK;
 }
 #endif

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerMSE.cpp
@@ -1987,6 +1987,9 @@ void AppendPipeline::resetPipeline()
 {
     ASSERT(WTF::isMainThread());
     LOG_MEDIA_MESSAGE("resetting pipeline");
+    m_atLeastABufferLeftAppsrcMutex.lock();
+    m_atLeastABufferLeftAppsrc = false;
+    m_atLeastABufferLeftAppsrcMutex.unlock();
     g_mutex_lock(&m_newSampleMutex);
     g_cond_signal(&m_newSampleCondition);
     gst_element_set_state(m_pipeline, GST_STATE_READY);

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerMSE.cpp
@@ -2313,8 +2313,7 @@ static GstPadProbeReturn appendPipelineAppsrcDataLeaving(GstPad*, GstPadProbeInf
             return GST_PAD_PROBE_OK;
 
         const GstStructure* structure = gst_event_get_structure(event);
-        if (!gst_structure_has_name(structure, "end-of-append-data-mark"))
-            return GST_PAD_PROBE_OK;
+        ASSERT(gst_structure_has_name(structure, "end-of-append-data-mark"));
 
         guint id = gst_event_get_seqnum(event);
         TRACE_MEDIA_MESSAGE("custom downstream event id=%u", id);
@@ -2335,8 +2334,7 @@ static GstPadProbeReturn appendPipelineAppsinkDataEntering(GstPad*, GstPadProbeI
             return GST_PAD_PROBE_OK;
 
         const GstStructure* structure = gst_event_get_structure(event);
-        if (!gst_structure_has_name(structure, "end-of-append-data-mark"))
-            return GST_PAD_PROBE_OK;
+        ASSERT(gst_structure_has_name(structure, "end-of-append-data-mark"));
 
         guint id = gst_event_get_seqnum(event);
 
@@ -2362,7 +2360,6 @@ static GstPadProbeReturn appendPipelineAppsinkDataEntering(GstPad*, GstPadProbeI
 #ifdef DEBUG_APPEND_PIPELINE_PADS
 static GstPadProbeReturn appendPipelinePadProbeDebugInformation(GstPad*, GstPadProbeInfo* info, struct PadProbeInformation* padProbeInformation)
 {
-    ASSERT(GST_PAD_PROBE_INFO_TYPE(info) != static_cast<GstPadProbeType>(GST_PAD_PROBE_TYPE_BUFFER | GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM));
     if (GST_PAD_PROBE_INFO_TYPE(info) & GST_PAD_PROBE_TYPE_BUFFER) {
         GstBuffer* buffer = GST_PAD_PROBE_INFO_BUFFER(info);
         TRACE_MEDIA_MESSAGE("%s: buffer of size %" G_GSIZE_FORMAT " going thru", padProbeInformation->m_description, gst_buffer_get_size(buffer));
@@ -2375,8 +2372,7 @@ static GstPadProbeReturn appendPipelinePadProbeDebugInformation(GstPad*, GstPadP
             return GST_PAD_PROBE_OK;
 
         const GstStructure* structure = gst_event_get_structure(event);
-        if (!gst_structure_has_name(structure, "end-of-append-data-mark"))
-            return GST_PAD_PROBE_OK;
+        ASSERT(gst_structure_has_name(structure, "end-of-append-data-mark"));
 
         guint id = gst_event_get_seqnum(event);
         TRACE_MEDIA_MESSAGE("%s: custom downstream event id=%u", padProbeInformation->m_description, id);


### PR DESCRIPTION
After some investigation I got the idea that using the need-data signal on appsrc could be what we needed to remove the data starve timeout in the cases the demuxer stalls. I realized too that with that signal was telling us in every case when the demuxer had finished processing so we could really get rid of the custom events as well and rely only on that signal.