### PR TITLE
[UpdateAtlas] Do not useGeneralAreaAllocator to allocate space.

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/coordinated/UpdateAtlas.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/UpdateAtlas.cpp
@@ -90,23 +90,16 @@ void UpdateAtlas::didSwapBuffers()
 bool UpdateAtlas::paintOnAvailableBuffer(const IntSize& size, uint32_t& atlasID, IntPoint& offset, CoordinatedSurface::Client* client)
 {
     m_inactivityInSeconds = 0;
-    buildLayoutIfNeeded();
-    IntRect rect = m_areaAllocator->allocate(size);
-
-    // No available buffer was found.
-    if (rect.isEmpty())
-        return false;
 
     if (!m_surface)
         return false;
 
     atlasID = m_ID;
 
-    // FIXME: Use tri-state buffers, to allow faster updates.
-    offset = rect.location();
+    offset = IntPoint(0, 0);
 
     UpdateAtlasSurfaceClient surfaceClient(client, size, supportsAlpha());
-    m_surface->paintToSurface(rect, &surfaceClient);
+    m_surface->paintToSurface(IntRect(offset, size), &surfaceClient);
 
     return true;
 }


### PR DESCRIPTION
We are not using the UpdateAtlas as a buffer to paint several areas, but just
to paint a single one, so it doesn't make sense to use an AreaAllocator
to allocate an area inside the current atlas to paint to.

Also, with the current implementation, the GeneralAreaAlocator would give
errors when allocating areas smaller than half of the minimum size.