### PR TITLE
drawSystemFocusRing support added using drawFocusIfNeeded API

### DIFF
--- a/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
@@ -2130,6 +2130,16 @@ void CanvasRenderingContext2D::webkitPutImageDataHD(ImageData* data, float dx, f
     putImageData(data, ImageBuffer::BackingStoreCoordinateSystem, dx, dy, dirtyX, dirtyY, dirtyWidth, dirtyHeight, ec);
 }
 
+void CanvasRenderingContext2D::drawSystemFocusRing(Element* element)
+{
+    drawFocusIfNeededInternal(m_path, element);
+}
+
+void CanvasRenderingContext2D::drawSystemFocusRing(DOMPath* path, Element* element)
+{
+    drawFocusIfNeededInternal(path->path(), element);
+}
+
 void CanvasRenderingContext2D::drawFocusIfNeeded(Element* element)
 {
     drawFocusIfNeededInternal(m_path, element);
@@ -2139,6 +2149,7 @@ void CanvasRenderingContext2D::drawFocusIfNeeded(DOMPath* path, Element* element
 {
     drawFocusIfNeededInternal(path->path(), element);
 }
+
 
 void CanvasRenderingContext2D::drawFocusIfNeededInternal(const Path& path, Element* element)
 {

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2D.idl
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2D.idl
@@ -189,6 +189,9 @@ interface CanvasRenderingContext2D : CanvasRenderingContext {
     void drawFocusIfNeeded(Element element);
     void drawFocusIfNeeded(DOMPath path, Element element);
 
+    void drawSystemFocusRing(Element element);
+    void drawSystemFocusRing(DOMPath path, Element element);
+
     readonly attribute float webkitBackingStorePixelRatio;
 
     attribute boolean imageSmoothingEnabled;


### PR DESCRIPTION
According to HTML A11y consensus the API drawSystemFocusRing is renamed to drawFocusIfNeeded 
https://lists.w3.org/Archives/Public/public-html/2014Jan/0085.html
The html5test.com is calling drawSystemFocusRing API for the verification of Focus Ring functionality.
To make this test case compliance as well as backward compatibility enabled drawSystemFocusRing support (creating a wrapper on the drawFocusIfNeeded API)