### PR TITLE
Fix dynamic video positioning

### DIFF
--- a/Source/WebCore/rendering/RenderVideo.cpp
+++ b/Source/WebCore/rendering/RenderVideo.cpp
@@ -242,6 +242,10 @@ void RenderVideo::updatePlayer()
 
     IntRect videoBounds = videoBox();
     mediaPlayer->setSize(IntSize(videoBounds.width(), videoBounds.height()));
+#if USE(HOLE_PUNCH_GSTREAMER) || USE(HOLE_PUNCH_EXTERNAL)
+    IntRect windowRect = document().view()->contentsToScreen(absoluteBoundingBoxRect(true));
+    mediaPlayer->setPosition(IntPoint(windowRect.x(), windowRect.y()));
+#endif
     mediaPlayer->setVisible(true);
     mediaPlayer->setShouldMaintainAspectRatio(style().objectFit() != ObjectFitFill);
 }


### PR DESCRIPTION
The new position isn't applied correctly when video is repositioned dynamically using USE(HOLE_PUNCH_GSTREAMER) [possibly also with USE(HOLE_PUNCH_EXTERNAL) - not tested].
I have created a simple test file to show the problem. Please see attached zip.
Using the testpage, the initial position is wrong (too much to the left). When pressing "Key Down" on the keyboard it should set the video fullscreen, but the result is too much down. Pressing the key again sets the position back to the original.
[testpage.zip](https://github.com/Metrological/WebKitForWayland/files/223896/testpage.zip)
