### PR TITLE
[Comcast-master][GStreamer][MSE] Fix video size tests for build with USE_HOLE_PUNCH_G…

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerMSE.cpp
@@ -275,6 +275,17 @@ void MediaPlayerPrivateGStreamerMSE::load(const String& url, MediaSourcePrivateC
     load(mediasourceUri);
 }
 
+FloatSize MediaPlayerPrivateGStreamerMSE::naturalSize() const
+{
+    if (!hasVideo())
+        return FloatSize();
+
+    if (!m_videoSize.isEmpty())
+        return m_videoSize;
+
+    return MediaPlayerPrivateGStreamerBase::naturalSize();
+}
+
 void MediaPlayerPrivateGStreamerMSE::pause()
 {
     m_paused = true;

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerMSE.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerMSE.h
@@ -51,6 +51,8 @@ public:
     void load(const String &url) override;
     void load(const String& url, MediaSourcePrivateClient*) override;
 
+    FloatSize naturalSize() const override;
+
     void setDownloadBuffering() override { };
 
     bool isLiveStream() const override { return false; }


### PR DESCRIPTION
…STREAMER

Following tests should succeed:

 7. InitialMediaVideoWidth
 8. InitialMediaVideoHeight
 31. VideoDimension

http://yt-dash-mse-test.commondatastorage.googleapis.com/unit-tests/2016.html?enablewebm=off&tests=7,8,31