### PR TITLE
getting and setting entire cookie jar

### DIFF
--- a/Source/WebCore/platform/network/PlatformCookieJar.h
+++ b/Source/WebCore/platform/network/PlatformCookieJar.h
@@ -51,6 +51,8 @@ WEBCORE_EXPORT void getHostnamesWithCookies(const NetworkStorageSession&, HashSe
 WEBCORE_EXPORT void deleteCookiesForHostnames(const NetworkStorageSession&, const Vector<String>& cookieHostNames);
 WEBCORE_EXPORT void deleteAllCookies(const NetworkStorageSession&);
 WEBCORE_EXPORT void deleteAllCookiesModifiedSince(const NetworkStorageSession&, std::chrono::system_clock::time_point);
+WEBCORE_EXPORT void setCookies(const NetworkStorageSession&, const Vector<String>&);
+WEBCORE_EXPORT bool getCookies(const NetworkStorageSession&, Vector<String>&);
 
 }
 

--- a/Source/WebKit2/UIProcess/API/C/WKCookieManager.cpp
+++ b/Source/WebKit2/UIProcess/API/C/WKCookieManager.cpp
@@ -28,6 +28,7 @@
 
 #include "WKAPICast.h"
 #include "WebCookieManagerProxy.h"
+#include "WKArray.h"
 
 using namespace WebKit;
 
@@ -72,6 +73,25 @@ void WKCookieManagerSetHTTPCookieAcceptPolicy(WKCookieManagerRef cookieManager, 
 void WKCookieManagerGetHTTPCookieAcceptPolicy(WKCookieManagerRef cookieManager, void* context, WKCookieManagerGetHTTPCookieAcceptPolicyFunction callback)
 {
     toImpl(cookieManager)->getHTTPCookieAcceptPolicy(toGenericCallbackFunction<WKHTTPCookieAcceptPolicy, HTTPCookieAcceptPolicy>(context, callback));
+}
+
+void WKCookieManagerSetCookies(WKCookieManagerRef cookieManager, WKArrayRef cookies)
+{
+    size_t size = cookies ? WKArrayGetSize(cookies) : 0;
+    if (!size)
+        return;
+    Vector<String> passCookies(size);
+    for (size_t i = 0; i < size; ++i)
+    {
+        WKTypeRef cookie = WKArrayGetItemAtIndex(cookies, i);
+        passCookies[i] = toWTFString(static_cast<WKStringRef>(cookie));
+    }
+    toImpl(cookieManager)->setCookies(passCookies);
+}
+
+void WKCookieManagerGetCookies(WKCookieManagerRef cookieManager, void* context, WKCookieManagerGetCookiesFunction callback)
+{
+    toImpl(cookieManager)->getCookies(toGenericCallbackFunction(context, callback));
 }
 
 void WKCookieManagerStartObservingCookieChanges(WKCookieManagerRef cookieManager)

--- a/Source/WebKit2/UIProcess/API/C/WKCookieManager.h
+++ b/Source/WebKit2/UIProcess/API/C/WKCookieManager.h
@@ -72,6 +72,11 @@ WK_EXPORT void WKCookieManagerSetHTTPCookieAcceptPolicy(WKCookieManagerRef cooki
 typedef void (*WKCookieManagerGetHTTPCookieAcceptPolicyFunction)(WKHTTPCookieAcceptPolicy, WKErrorRef, void*);
 WK_EXPORT void WKCookieManagerGetHTTPCookieAcceptPolicy(WKCookieManagerRef cookieManager, void* context, WKCookieManagerGetHTTPCookieAcceptPolicyFunction callback);
 
+WK_EXPORT void WKCookieManagerSetCookies(WKCookieManagerRef cookieManager, WKArrayRef cookieList);
+
+typedef void (*WKCookieManagerGetCookiesFunction)(WKArrayRef, WKErrorRef, void*);
+WK_EXPORT void WKCookieManagerGetCookies(WKCookieManagerRef cookieManager, void* context, WKCookieManagerGetCookiesFunction callback);
+
 WK_EXPORT void WKCookieManagerStartObservingCookieChanges(WKCookieManagerRef cookieManager);
 WK_EXPORT void WKCookieManagerStopObservingCookieChanges(WKCookieManagerRef cookieManager);
 

--- a/Source/WebKit2/UIProcess/WebCookieManagerProxy.h
+++ b/Source/WebKit2/UIProcess/WebCookieManagerProxy.h
@@ -73,6 +73,10 @@ public:
     void setHTTPCookieAcceptPolicy(HTTPCookieAcceptPolicy);
     void getHTTPCookieAcceptPolicy(std::function<void (HTTPCookieAcceptPolicy, CallbackBase::Error)>);
 
+    void setCookies(const Vector<String>& cookies);
+    void getCookies(std::function<void (API::Array*, CallbackBase::Error)>);
+    void didGetCookies(Vector<String> cookies,  uint64_t callbackID);
+
     void startObservingCookieChanges();
     void stopObservingCookieChanges();
 

--- a/Source/WebKit2/UIProcess/WebCookieManagerProxy.messages.in
+++ b/Source/WebKit2/UIProcess/WebCookieManagerProxy.messages.in
@@ -24,5 +24,7 @@ messages -> WebCookieManagerProxy {
     DidGetHostnamesWithCookies(Vector<String> hostnames, uint64_t callbackID);
     DidGetHTTPCookieAcceptPolicy(uint32_t policy, uint64_t callbackID);
     
+    DidGetCookies(Vector<String> cookies, uint64_t callbackID)
+
     CookiesDidChange()
 }

--- a/Source/WebKit2/WebProcess/Cookies/WebCookieManager.cpp
+++ b/Source/WebKit2/WebProcess/Cookies/WebCookieManager.cpp
@@ -120,4 +120,16 @@ void WebCookieManager::getHTTPCookieAcceptPolicy(uint64_t callbackID)
     m_process->send(Messages::WebCookieManagerProxy::DidGetHTTPCookieAcceptPolicy(platformGetHTTPCookieAcceptPolicy(), callbackID), 0);
 }
 
+void WebCookieManager::setCookies(const Vector<String>& cookies)
+{
+    WebCore::setCookies(NetworkStorageSession::defaultStorageSession(), cookies);
+}
+
+void WebCookieManager::getCookies(uint64_t callbackID)
+{
+    Vector<String> cookies;
+    WebCore::getCookies(NetworkStorageSession::defaultStorageSession(), cookies);
+    m_process->send(Messages::WebCookieManagerProxy::DidGetCookies(cookies, callbackID), 0);
+}
+
 } // namespace WebKit

--- a/Source/WebKit2/WebProcess/Cookies/WebCookieManager.h
+++ b/Source/WebKit2/WebProcess/Cookies/WebCookieManager.h
@@ -33,6 +33,7 @@
 #include <stdint.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/Vector.h>
 
 #if USE(SOUP)
 #include "SoupCookiePersistentStorageType.h"
@@ -71,6 +72,9 @@ private:
     void platformSetHTTPCookieAcceptPolicy(HTTPCookieAcceptPolicy);
     void getHTTPCookieAcceptPolicy(uint64_t callbackID);
     HTTPCookieAcceptPolicy platformGetHTTPCookieAcceptPolicy();
+
+    void setCookies(const Vector<String>& cookies);
+    void getCookies(uint64_t callbackID);
 
     void startObservingCookieChanges();
     void stopObservingCookieChanges();

--- a/Source/WebKit2/WebProcess/Cookies/WebCookieManager.messages.in
+++ b/Source/WebKit2/WebProcess/Cookies/WebCookieManager.messages.in
@@ -33,6 +33,9 @@
     void SetHTTPCookieAcceptPolicy(uint32_t policy)
     void GetHTTPCookieAcceptPolicy(uint64_t callbackID)
     
+    void SetCookies(Vector<String> cookies)
+    void GetCookies(uint64_t callbackID)
+
     void StartObservingCookieChanges()
     void StopObservingCookieChanges()
 


### PR DESCRIPTION
Currently there's no way to set entire cookie jar (from server)
and get it to save somewhere outside. Without change notification.
Added.