### PR TITLE
Wayland-egl backend (previously named STM)

### DIFF
--- a/Source/ThirdParty/WPE-platform/CMakeLists.txt
+++ b/Source/ThirdParty/WPE-platform/CMakeLists.txt
@@ -5,7 +5,7 @@ option(USE_WPE_BACKEND_BCM_NEXUS "Whether to enable support for the BCM_NEXUS WP
 option(USE_WPE_BACKEND_BCM_NEXUS_WAYLAND "Whether to enable support for the BCM_NEXUS Wayland WPE backend" OFF)
 option(USE_WPE_BACKEND_BCM_RPI "Whether to enable support for the BCM_RPi WPE backend" OFF)
 option(USE_WPE_BACKEND_INTEL_CE "Whether to enable support for the Intel CE WPE backend" OFF)
-option(USE_WPE_BACKEND_STM "Whether to enable support for the STM WPE backend" OFF)
+option(USE_WPE_BACKEND_WAYLAND_EGL "Whether to enable support for the wayland-egl WPE backend" OFF)
 option(USE_WPE_BACKEND_WESTEROS "Whether to enable support for the Westeros WPE backend" OFF)
 
 # TODO
@@ -95,8 +95,8 @@ if (USE_WPE_BACKEND_INTEL_CE)
     include(src/intelce/CMakeLists.txt)
 endif ()
 
-if (USE_WPE_BACKEND_STM)
-    include(src/stm/CMakeLists.txt)
+if (USE_WPE_BACKEND_WAYLAND_EGL)
+    include(src/wayland-egl/CMakeLists.txt)
 endif ()
 
 if (USE_WPE_BACKEND_WESTEROS)

--- a/Source/ThirdParty/WPE-platform/src/bcm-nexus-wayland/view-backend.cpp
+++ b/Source/ThirdParty/WPE-platform/src/bcm-nexus-wayland/view-backend.cpp
@@ -68,7 +68,7 @@ public:
     };
 
 private:
-    Display& m_display;
+    Wayland::Display& m_display;
     struct wpe_view_backend* m_backend;
 
     struct wl_surface* m_surface;
@@ -147,7 +147,7 @@ static const struct wl_nsc_listener g_nscListener = {
 };
 
 ViewBackend::ViewBackend(struct wpe_view_backend* backend)
-    : m_display(Display::singleton())
+    : m_display(Wayland::Display::singleton())
     , m_backend(backend)
 {
     m_ipcHost.initialize(*this);

--- a/Source/ThirdParty/WPE-platform/src/loader-impl.cpp
+++ b/Source/ThirdParty/WPE-platform/src/loader-impl.cpp
@@ -46,8 +46,8 @@
 #include "intelce/interfaces.h"
 #endif
 
-#ifdef BACKEND_STM
-#include "stm/interfaces.h"
+#ifdef BACKEND_WAYLAND_EGL
+#include "wayland-egl/interfaces.h"
 #endif
 
 #ifdef BACKEND_WESTEROS
@@ -116,16 +116,16 @@ struct wpe_loader_interface _wpe_loader_interface = {
             return &intelce_view_backend_interface;
 #endif
 
-#ifdef BACKEND_STM
+#ifdef BACKEND_WAYLAND_EGL
         if (!std::strcmp(object_name, "_wpe_renderer_backend_egl_interface"))
-            return &stm_renderer_backend_egl_interface;
+            return &wayland_egl_renderer_backend_egl_interface;
         if (!std::strcmp(object_name, "_wpe_renderer_backend_egl_target_interface"))
-            return &stm_renderer_backend_egl_target_interface;
+            return &wayland_egl_renderer_backend_egl_target_interface;
         if (!std::strcmp(object_name, "_wpe_renderer_backend_egl_offscreen_target_interface"))
-            return &stm_renderer_backend_egl_offscreen_target_interface;
+            return &wayland_egl_renderer_backend_egl_offscreen_target_interface;
 
         if (!std::strcmp(object_name, "_wpe_view_backend_interface"))
-            return &stm_view_backend_interface;
+            return &wayland_egl_view_backend_interface;
 #endif
 
 #ifdef BACKEND_WESTEROS

--- a/Source/ThirdParty/WPE-platform/src/stm/CMakeLists.txt
+++ b/Source/ThirdParty/WPE-platform/src/stm/CMakeLists.txt
@@ -1,6 +1,0 @@
-add_definitions(-DBACKEND_STM=1)
-
-list(APPEND WPE_PLATFORM_SOURCES
-    src/stm/renderer-backend.cpp
-    src/stm/view-backend.cpp
-)

--- a/Source/ThirdParty/WPE-platform/src/wayland-egl/CMakeLists.txt
+++ b/Source/ThirdParty/WPE-platform/src/wayland-egl/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_definitions(-DBACKEND_WAYLAND_EGL=1)
+
+list(APPEND WPE_PLATFORM_SOURCES
+    src/wayland-egl/renderer-backend.cpp
+    src/wayland-egl/view-backend.cpp
+)

--- a/Source/ThirdParty/WPE-platform/src/wayland-egl/CMakeLists.txt
+++ b/Source/ThirdParty/WPE-platform/src/wayland-egl/CMakeLists.txt
@@ -1,6 +1,22 @@
+find_package(Wayland REQUIRED)
+find_package(WaylandEGL REQUIRED)
+
 add_definitions(-DBACKEND_WAYLAND_EGL=1)
+
+list(APPEND WPE_PLATFORM_INCLUDE_DIRECTORIES
+    "${WPE_PLATFORM_SOURCE_DIR}/src/wayland"
+    ${WAYLAND_INCLUDE_DIRS}
+    ${WAYLAND_EGL_INCLUDE_DIRS}
+)
+
+list(APPEND WPE_PLATFORM_LIBRARIES
+    ${WAYLAND_LIBRARIES}
+    ${WAYLAND_EGL_LIBRARIES}
+)
 
 list(APPEND WPE_PLATFORM_SOURCES
     src/wayland-egl/renderer-backend.cpp
     src/wayland-egl/view-backend.cpp
+    src/wayland/protocols/xdg-shell-protocol.c
+    src/wayland/display.cpp
 )

--- a/Source/ThirdParty/WPE-platform/src/wayland-egl/interfaces.h
+++ b/Source/ThirdParty/WPE-platform/src/wayland-egl/interfaces.h
@@ -25,8 +25,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef stm_interfaces_h
-#define stm_interfaces_h
+#ifndef wayland_egl_interfaces_h
+#define wayland_egl_interfaces_h
 
 #include <wpe/renderer-backend-egl.h>
 #include <wpe/view-backend.h>
@@ -35,14 +35,14 @@
 extern "C" {
 #endif
 
-extern struct wpe_renderer_backend_egl_interface stm_renderer_backend_egl_interface;
-extern struct wpe_renderer_backend_egl_target_interface stm_renderer_backend_egl_target_interface;
-extern struct wpe_renderer_backend_egl_offscreen_target_interface stm_renderer_backend_egl_offscreen_target_interface;
+extern struct wpe_renderer_backend_egl_interface wayland_egl_renderer_backend_egl_interface;
+extern struct wpe_renderer_backend_egl_target_interface wayland_egl_renderer_backend_egl_target_interface;
+extern struct wpe_renderer_backend_egl_offscreen_target_interface wayland_egl_renderer_backend_egl_offscreen_target_interface;
 
-extern struct wpe_view_backend_interface stm_view_backend_interface;
+extern struct wpe_view_backend_interface wayland_egl_view_backend_interface;
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif // stm_interfaces_h
+#endif // wayland_egl_interfaces_h

--- a/Source/ThirdParty/WPE-platform/src/wayland-egl/ipc-waylandegl.h
+++ b/Source/ThirdParty/WPE-platform/src/wayland-egl/ipc-waylandegl.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2015, 2016 Igalia S.L.
+ * Copyright (C) 2015, 2016 Metrological
+ * Copyright (C) 2016 SoftAtHome
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef wpe_platform_ipc_wayland_egl_h
+#define wpe_platform_ipc_wayland_egl_h
+
+#include <memory>
+#include <stdint.h>
+
+namespace IPC {
+
+namespace WaylandEGL {
+
+struct BufferCommit {
+    uint8_t padding[24];
+
+    static const uint64_t code = 1;
+    static void construct(Message& message)
+    {
+        message.messageCode = code;
+    }
+    static BufferCommit& cast(Message& message)
+    {
+        return *reinterpret_cast<BufferCommit*>(std::addressof(message.messageData));
+    }
+};
+static_assert(sizeof(BufferCommit) == Message::dataSize, "BufferCommit is of correct size");
+
+struct FrameComplete {
+    int8_t padding[24];
+
+    static const uint64_t code = 2;
+    static void construct(Message& message)
+    {
+        message.messageCode = code;
+    }
+    static FrameComplete& cast(Message& message)
+    {
+        return *reinterpret_cast<FrameComplete*>(std::addressof(message.messageData));
+    }
+};
+static_assert(sizeof(FrameComplete) == Message::dataSize, "FrameComplete is of correct size");
+
+} // namespace WaylandEGL
+
+} // namespace IPC
+
+#endif // wpe_platform_ipc_wayland_egl_h

--- a/Source/ThirdParty/WPE-platform/src/wayland-egl/renderer-backend.cpp
+++ b/Source/ThirdParty/WPE-platform/src/wayland-egl/renderer-backend.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2015, 2016 Igalia S.L.
  * Copyright (C) 2015, 2016 Metrological
+ * Copyright (C) 2016 SoftAtHome
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,21 +28,157 @@
 
 #include <wpe/renderer-backend-egl.h>
 
+#include "display.h"
+#include "ipc.h"
+#include "ipc-waylandegl.h"
+#include <wayland-client-protocol.h>
+#include <wayland-egl.h>
+
+namespace WaylandEGL {
+
+struct Backend {
+    Backend();
+    ~Backend();
+
+    Wayland::Display& display;
+};
+
+Backend::Backend()
+    : display(Wayland::Display::singleton())
+{
+}
+
+Backend::~Backend()
+{
+}
+
+struct EGLTarget : public IPC::Client::Handler {
+    EGLTarget(struct wpe_renderer_backend_egl_target*, int);
+    virtual ~EGLTarget();
+
+    void initialize(Backend& backend, uint32_t width, uint32_t height);
+    // IPC::Client::Handler
+    void handleMessage(char* data, size_t size) override;
+
+    struct wpe_renderer_backend_egl_target* target;
+    IPC::Client ipcClient;
+
+    struct wl_surface* m_surface { nullptr };
+    struct wl_shell_surface *m_shellSurface { nullptr };
+    struct wl_egl_window* m_window { nullptr };
+    Backend* m_backend { nullptr };
+};
+
+static void
+handle_ping(void *data, struct wl_shell_surface *shell_surface,
+                                                       uint32_t serial)
+{
+       wl_shell_surface_pong(shell_surface, serial);
+}
+
+static void
+handle_configure(void *data, struct wl_shell_surface *shell_surface,
+                uint32_t edges, int32_t width, int32_t height)
+{
+}
+
+static void
+handle_popup_done(void *data, struct wl_shell_surface *shell_surface)
+{
+}
+
+static const struct wl_shell_surface_listener shell_surface_listener = {
+       handle_ping,
+       handle_configure,
+       handle_popup_done
+};
+
+EGLTarget::EGLTarget(struct wpe_renderer_backend_egl_target* target, int hostFd)
+    : target(target)
+{
+    ipcClient.initialize(*this, hostFd);
+}
+
+void EGLTarget::initialize(Backend& backend, uint32_t width, uint32_t height)
+{
+    m_backend = &backend;
+
+    m_surface = wl_compositor_create_surface(m_backend->display.interfaces().compositor);
+
+    if (m_backend->display.interfaces().shell) {
+        m_shellSurface = wl_shell_get_shell_surface(m_backend->display.interfaces().shell, m_surface);
+        if (m_shellSurface) {
+            wl_shell_surface_add_listener(m_shellSurface,
+                                          &shell_surface_listener, NULL);
+            wl_shell_surface_set_toplevel(m_shellSurface);
+        }
+    }
+
+    struct wl_region *region;
+    region = wl_compositor_create_region(m_backend->display.interfaces().compositor);
+    wl_region_add(region, 0, 0,
+                   width,
+                   height);
+    wl_surface_set_opaque_region(m_surface, region);
+
+    if (m_surface) {
+        m_window = wl_egl_window_create(m_surface, width, height);
+    }
+}
+
+EGLTarget::~EGLTarget()
+{
+    ipcClient.deinitialize();
+
+    if (m_window)
+        wl_egl_window_destroy(m_window);
+    m_window = nullptr;
+    if (m_shellSurface)
+        wl_shell_surface_destroy(m_shellSurface);
+    m_shellSurface = nullptr;
+    if (m_surface)
+        wl_surface_destroy(m_surface);
+    m_surface = nullptr;
+}
+
+void EGLTarget::handleMessage(char* data, size_t size)
+{
+    if (size != IPC::Message::size)
+        return;
+
+    auto& message = IPC::Message::cast(data);
+    switch (message.messageCode) {
+    case IPC::WaylandEGL::FrameComplete::code:
+    {
+        wpe_renderer_backend_egl_target_dispatch_frame_complete(target);
+        break;
+    }
+    default:
+        fprintf(stderr, "EGLTarget: unhandled message\n");
+    };
+}
+
+} // namespace WaylandEGL
+
 extern "C" {
 
 struct wpe_renderer_backend_egl_interface wayland_egl_renderer_backend_egl_interface = {
     // create
     []() -> void*
     {
-        return nullptr;
+        return new WaylandEGL::Backend;
     },
     // destroy
     [](void* data)
     {
+        auto* backend = static_cast<WaylandEGL::Backend*>(data);
+        delete backend;
     },
     // get_native_display
     [](void* data) -> EGLNativeDisplayType
     {
+        auto& backend = *static_cast<WaylandEGL::Backend*>(data);
+        return backend.display.display();
     },
 };
 
@@ -49,19 +186,26 @@ struct wpe_renderer_backend_egl_target_interface wayland_egl_renderer_backend_eg
     // create
     [](struct wpe_renderer_backend_egl_target* target, int host_fd) -> void*
     {
-        return nullptr;
+        return new WaylandEGL::EGLTarget(target, host_fd);
     },
     // destroy
     [](void* data)
     {
+        auto* target = static_cast<WaylandEGL::EGLTarget*>(data);
+        delete target;
     },
     // initialize
     [](void* data, void* backend_data, uint32_t width, uint32_t height)
     {
+        auto& target = *static_cast<WaylandEGL::EGLTarget*>(data);
+        auto& backend = *static_cast<WaylandEGL::Backend*>(backend_data);
+        target.initialize(backend, width, height);
     },
     // get_native_window
     [](void* data) -> EGLNativeWindowType
     {
+        auto& target = *static_cast<WaylandEGL::EGLTarget*>(data);
+        return target.m_window;
     },
     // resize
     [](void* data, uint32_t width, uint32_t height)
@@ -74,6 +218,15 @@ struct wpe_renderer_backend_egl_target_interface wayland_egl_renderer_backend_eg
     // frame_rendered
     [](void* data)
     {
+        auto& target = *static_cast<WaylandEGL::EGLTarget*>(data);
+
+        wl_display *display = target.m_backend->display.display();
+        if(display)
+            wl_display_flush(display);
+
+        IPC::Message message;
+        IPC::WaylandEGL::BufferCommit::construct(message);
+        target.ipcClient.sendMessage(IPC::Message::data(message), IPC::Message::size);
     },
 };
 

--- a/Source/ThirdParty/WPE-platform/src/wayland-egl/renderer-backend.cpp
+++ b/Source/ThirdParty/WPE-platform/src/wayland-egl/renderer-backend.cpp
@@ -25,13 +25,29 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <wpe/view-backend.h>
+#include <wpe/renderer-backend-egl.h>
 
 extern "C" {
 
-struct wpe_view_backend_interface stm_view_backend_interface = {
+struct wpe_renderer_backend_egl_interface wayland_egl_renderer_backend_egl_interface = {
     // create
-    [](void*, struct wpe_view_backend* backend) -> void*
+    []() -> void*
+    {
+        return nullptr;
+    },
+    // destroy
+    [](void* data)
+    {
+    },
+    // get_native_display
+    [](void* data) -> EGLNativeDisplayType
+    {
+    },
+};
+
+struct wpe_renderer_backend_egl_target_interface wayland_egl_renderer_backend_egl_target_interface = {
+    // create
+    [](struct wpe_renderer_backend_egl_target* target, int host_fd) -> void*
     {
         return nullptr;
     },
@@ -40,13 +56,45 @@ struct wpe_view_backend_interface stm_view_backend_interface = {
     {
     },
     // initialize
+    [](void* data, void* backend_data, uint32_t width, uint32_t height)
+    {
+    },
+    // get_native_window
+    [](void* data) -> EGLNativeWindowType
+    {
+    },
+    // resize
+    [](void* data, uint32_t width, uint32_t height)
+    {
+    },
+    // frame_will_render
     [](void* data)
     {
     },
-    // get_renderer_host_fd
-    [](void* data) -> int
+    // frame_rendered
+    [](void* data)
     {
-        return -1;
+    },
+};
+
+struct wpe_renderer_backend_egl_offscreen_target_interface wayland_egl_renderer_backend_egl_offscreen_target_interface = {
+    // create
+    []() -> void*
+    {
+        return nullptr;
+    },
+    // destroy
+    [](void* data)
+    {
+    },
+    // initialize
+    [](void* data, void* backend_data)
+    {
+    },
+    // get_native_window
+    [](void* data) -> EGLNativeWindowType
+    {
+        return nullptr;
     },
 };
 

--- a/Source/ThirdParty/WPE-platform/src/wayland-egl/view-backend.cpp
+++ b/Source/ThirdParty/WPE-platform/src/wayland-egl/view-backend.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2015, 2016 Igalia S.L.
  * Copyright (C) 2015, 2016 Metrological
+ * Copyright (C) 2016 SoftAtHome
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,17 +28,79 @@
 
 #include <wpe/view-backend.h>
 
+#include "ipc.h"
+#include "ipc-waylandegl.h"
+
+namespace WaylandEGL {
+
+struct ViewBackend;
+
+struct ViewBackend : public IPC::Host::Handler {
+    ViewBackend(struct wpe_view_backend*);
+    virtual ~ViewBackend();
+
+    // IPC::Host::Handler
+    void handleFd(int) override { };
+    void handleMessage(char*, size_t) override;
+
+    void ackBufferCommit();
+
+    struct wpe_view_backend* backend;
+    IPC::Host ipcHost;
+};
+
+ViewBackend::ViewBackend(struct wpe_view_backend* backend)
+    : backend(backend)
+{
+    ipcHost.initialize(*this);
+}
+
+ViewBackend::~ViewBackend()
+{
+    ipcHost.deinitialize();
+}
+
+void ViewBackend::handleMessage(char* data, size_t size)
+{
+    if (size != IPC::Message::size)
+        return;
+
+    auto& message = IPC::Message::cast(data);
+    switch (message.messageCode) {
+    case IPC::WaylandEGL::BufferCommit::code:
+    {
+        ackBufferCommit();
+        break;
+    }
+    default:
+        fprintf(stderr, "ViewBackend: unhandled message\n");
+    }
+}
+
+void ViewBackend::ackBufferCommit()
+{
+    IPC::Message message;
+    IPC::WaylandEGL::FrameComplete::construct(message);
+    ipcHost.sendMessage(IPC::Message::data(message), IPC::Message::size);
+
+    wpe_view_backend_dispatch_frame_displayed(backend);
+}
+
+} // namespace WaylandEGL
+
 extern "C" {
 
 struct wpe_view_backend_interface wayland_egl_view_backend_interface = {
     // create
     [](void*, struct wpe_view_backend* backend) -> void*
     {
-        return nullptr;
+        return new WaylandEGL::ViewBackend(backend);
     },
     // destroy
     [](void* data)
     {
+        auto* backend = static_cast<WaylandEGL::ViewBackend*>(data);
+        delete backend;
     },
     // initialize
     [](void* data)
@@ -46,7 +109,8 @@ struct wpe_view_backend_interface wayland_egl_view_backend_interface = {
     // get_renderer_host_fd
     [](void* data) -> int
     {
-        return -1;
+        auto& backend = *static_cast<WaylandEGL::ViewBackend*>(data);
+        return backend.ipcHost.releaseClientFD();
     },
 };
 

--- a/Source/ThirdParty/WPE-platform/src/wayland-egl/view-backend.cpp
+++ b/Source/ThirdParty/WPE-platform/src/wayland-egl/view-backend.cpp
@@ -25,29 +25,13 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <wpe/renderer-backend-egl.h>
+#include <wpe/view-backend.h>
 
 extern "C" {
 
-struct wpe_renderer_backend_egl_interface stm_renderer_backend_egl_interface = {
+struct wpe_view_backend_interface wayland_egl_view_backend_interface = {
     // create
-    []() -> void*
-    {
-        return nullptr;
-    },
-    // destroy
-    [](void* data)
-    {
-    },
-    // get_native_display
-    [](void* data) -> EGLNativeDisplayType
-    {
-    },
-};
-
-struct wpe_renderer_backend_egl_target_interface stm_renderer_backend_egl_target_interface = {
-    // create
-    [](struct wpe_renderer_backend_egl_target* target, int host_fd) -> void*
+    [](void*, struct wpe_view_backend* backend) -> void*
     {
         return nullptr;
     },
@@ -56,45 +40,13 @@ struct wpe_renderer_backend_egl_target_interface stm_renderer_backend_egl_target
     {
     },
     // initialize
-    [](void* data, void* backend_data, uint32_t width, uint32_t height)
-    {
-    },
-    // get_native_window
-    [](void* data) -> EGLNativeWindowType
-    {
-    },
-    // resize
-    [](void* data, uint32_t width, uint32_t height)
-    {
-    },
-    // frame_will_render
     [](void* data)
     {
     },
-    // frame_rendered
-    [](void* data)
+    // get_renderer_host_fd
+    [](void* data) -> int
     {
-    },
-};
-
-struct wpe_renderer_backend_egl_offscreen_target_interface stm_renderer_backend_egl_offscreen_target_interface = {
-    // create
-    []() -> void*
-    {
-        return nullptr;
-    },
-    // destroy
-    [](void* data)
-    {
-    },
-    // initialize
-    [](void* data, void* backend_data)
-    {
-    },
-    // get_native_window
-    [](void* data) -> EGLNativeWindowType
-    {
-        return nullptr;
+        return -1;
     },
 };
 

--- a/Source/ThirdParty/WPE-platform/src/wayland/display.cpp
+++ b/Source/ThirdParty/WPE-platform/src/wayland/display.cpp
@@ -26,7 +26,9 @@
 
 #include "display.h"
 
+#ifdef BACKEND_BCM_NEXUS_WAYLAND
 #include "nsc-client-protocol.h"
+#endif
 #include "xdg-shell-client-protocol.h"
 #include <cassert>
 #include <cstring>
@@ -100,8 +102,10 @@ const struct wl_registry_listener g_registryListener = {
         if (!std::strcmp(interface, "wl_compositor"))
             interfaces.compositor = static_cast<struct wl_compositor*>(wl_registry_bind(registry, name, &wl_compositor_interface, 1));
 
+#ifdef BACKEND_BCM_NEXUS_WAYLAND
         if (!std::strcmp(interface, "wl_nsc"))
             interfaces.nsc = static_cast<struct wl_nsc*>(wl_registry_bind(registry, name, &wl_nsc_interface, version));
+#endif
 
         if (!std::strcmp(interface, "wl_seat"))
             interfaces.seat = static_cast<struct wl_seat*>(wl_registry_bind(registry, name, &wl_seat_interface, 4));
@@ -524,11 +528,20 @@ Display::~Display()
         wl_compositor_destroy(m_interfaces.compositor);
     if (m_interfaces.seat)
         wl_seat_destroy(m_interfaces.seat);
+#ifdef BACKEND_BCM_NEXUS_WAYLAND
     if (m_interfaces.nsc)
         wl_nsc_destroy(m_interfaces.nsc);
+#endif
     if (m_interfaces.xdg)
         xdg_shell_destroy(m_interfaces.xdg);
-    m_interfaces = { nullptr, nullptr, nullptr, nullptr };
+    m_interfaces = {
+        nullptr,
+#ifdef BACKEND_BCM_NEXUS_WAYLAND
+        nullptr,
+#endif
+        nullptr,
+        nullptr,
+    };
 
     if (m_registry)
         wl_registry_destroy(m_registry);

--- a/Source/ThirdParty/WPE-platform/src/wayland/display.cpp
+++ b/Source/ThirdParty/WPE-platform/src/wayland/display.cpp
@@ -40,7 +40,7 @@
 #include <wpe/input.h>
 #include <wpe/view-backend.h>
 
-namespace BCMNexusWL {
+namespace Wayland {
 
 class EventSource {
 public:
@@ -579,4 +579,4 @@ void Display::unregisterInputClient(struct wl_surface* surface)
     m_seatData.inputClients.erase(it);
 }
 
-} // namespace BCMNexusWL
+} // namespace Wayland

--- a/Source/ThirdParty/WPE-platform/src/wayland/display.cpp
+++ b/Source/ThirdParty/WPE-platform/src/wayland/display.cpp
@@ -30,6 +30,7 @@
 #include "nsc-client-protocol.h"
 #endif
 #include "xdg-shell-client-protocol.h"
+#include "wayland-client-protocol.h"
 #include <cassert>
 #include <cstring>
 #include <glib.h>
@@ -112,6 +113,9 @@ const struct wl_registry_listener g_registryListener = {
 
         if (!std::strcmp(interface, "xdg_shell"))
             interfaces.xdg = static_cast<struct xdg_shell*>(wl_registry_bind(registry, name, &xdg_shell_interface, 1)); 
+
+        if (!std::strcmp(interface, "wl_shell"))
+            interfaces.shell = static_cast<struct wl_shell*>(wl_registry_bind(registry, name, &wl_shell_interface, 1));
     },
     // global_remove
     [](void*, struct wl_registry*, uint32_t) { },
@@ -534,11 +538,14 @@ Display::~Display()
 #endif
     if (m_interfaces.xdg)
         xdg_shell_destroy(m_interfaces.xdg);
+    if (m_interfaces.shell)
+        wl_shell_destroy(m_interfaces.shell);
     m_interfaces = {
         nullptr,
 #ifdef BACKEND_BCM_NEXUS_WAYLAND
         nullptr,
 #endif
+        nullptr,
         nullptr,
         nullptr,
     };

--- a/Source/ThirdParty/WPE-platform/src/wayland/display.h
+++ b/Source/ThirdParty/WPE-platform/src/wayland/display.h
@@ -49,7 +49,7 @@ struct xdg_shell;
 
 typedef struct _GSource GSource;
 
-namespace BCMNexusWL {
+namespace Wayland {
 
 class Display {
 public:
@@ -132,6 +132,6 @@ private:
     GSource* m_eventSource;
 };
 
-} // namespace BCMNexusWL
+} // namespace Wayland
 
 #endif // wpe_view_backend_wayland_display_h

--- a/Source/ThirdParty/WPE-platform/src/wayland/display.h
+++ b/Source/ThirdParty/WPE-platform/src/wayland/display.h
@@ -48,6 +48,7 @@ struct wl_seat;
 struct wl_surface;
 struct wl_touch;
 struct xdg_shell;
+struct wl_shell;
 
 typedef struct _GSource GSource;
 
@@ -68,6 +69,7 @@ public:
 #endif
         struct wl_seat* seat;
         struct xdg_shell* xdg;
+        struct wl_shell* shell;
     };
     const Interfaces& interfaces() const { return m_interfaces; }
 

--- a/Source/ThirdParty/WPE-platform/src/wayland/display.h
+++ b/Source/ThirdParty/WPE-platform/src/wayland/display.h
@@ -39,7 +39,9 @@ struct wpe_view_backend;
 struct wl_compositor;
 struct wl_display;
 struct wl_keyboard;
+#ifdef BACKEND_BCM_NEXUS_WAYLAND
 struct wl_nsc;
+#endif
 struct wl_pointer;
 struct wl_registry;
 struct wl_seat;
@@ -61,7 +63,9 @@ public:
 
     struct Interfaces {
         struct wl_compositor* compositor;
+#ifdef BACKEND_BCM_NEXUS_WAYLAND
         struct wl_nsc* nsc;
+#endif
         struct wl_seat* seat;
         struct xdg_shell* xdg;
     };

--- a/Source/cmake/OptionsWPE.cmake
+++ b/Source/cmake/OptionsWPE.cmake
@@ -90,11 +90,6 @@ if (USE_WPE_BACKEND_BCM_RPI)
     find_package(BCMHost REQUIRED)
 endif ()
 
-if (USE_WPE_BACKEND_STM)
-    find_package(Wayland REQUIRED)
-    find_package(WaylandEGL REQUIRED)
-endif(USE_WPE_BACKEND_STM)
-
 if (USE_WPE_BACKEND_WESTEROS)
     find_package(Wayland REQUIRED)
     find_package(WaylandEGL REQUIRED)


### PR DESCRIPTION
This backend creates wayland-egl window from the renderer process.
The view part only acks buffer to send frame complete events.

This is based on the STM implementation in WPE-old, and reuses the
Wayland::Display class initially implemented for BCMNexusWL.
    
Input support is not implemented yet.

This closes #65.