### PR TITLE
Fix proxy type naming and change some logic

### DIFF
--- a/Source/WebCore/platform/network/soup/SoupNetworkSession.cpp
+++ b/Source/WebCore/platform/network/soup/SoupNetworkSession.cpp
@@ -261,7 +261,7 @@ void SoupNetworkSession::setProxies(const Vector<WebCore::Proxy>& proxies)
     GPtrArray* array = g_ptr_array_sized_new(proxies.size());
     for (size_t i = 0; i < proxies.size(); ++i)
     {
-        Proxy* p = g_new(Proxy, 1);
+        GWildcardProxyResolverProxy* p = g_new(GWildcardProxyResolverProxy, 1);
         p->pattern = g_strdup(proxies[i].pattern.utf8().data());
         p->proxy = g_strdup(proxies[i].proxy.utf8().data());
         g_ptr_array_add(array, p);

--- a/Source/WebCore/platform/network/soup/gwildcardproxyresolver.c
+++ b/Source/WebCore/platform/network/soup/gwildcardproxyresolver.c
@@ -38,7 +38,7 @@ struct _GWildcardProxyResolverPrivate
 
 static void free_proxies(gpointer data)
 {
-    Proxy *p = (Proxy*)(data);
+    GWildcardProxyResolverProxy *p = (GWildcardProxyResolverProxy*)(data);
     g_free(p->pattern);
     g_free(p->proxy);
     g_free(p);
@@ -197,7 +197,7 @@ static gchar** g_wildcard_proxy_resolver_lookup(GProxyResolver *proxy_resolver,
         GRegex *regex_wildcard = (GRegex*)g_ptr_array_index(resolver->priv->regex_wildcard, i);
         if (g_regex_match(regex_wildcard, uri, (GRegexMatchFlags)0, NULL))
         {
-            Proxy *p = (Proxy*)g_ptr_array_index(resolver->priv->proxies, i);
+            GWildcardProxyResolverProxy *p = (GWildcardProxyResolverProxy*)g_ptr_array_index(resolver->priv->proxies, i);
             if (!p->proxy || !strlen(p->proxy) || !strncmp(p->proxy, "direct", 6))
                 proxy = "direct://";
             else
@@ -318,7 +318,7 @@ void g_wildcard_proxy_resolver_set_proxies(GWildcardProxyResolver  *resolver,
     for (guint i = 0; i < length; ++i)
     {
         GError *error = NULL;
-        Proxy *p = (Proxy*)g_ptr_array_index(proxies, i);
+        GWildcardProxyResolverProxy *p = (GWildcardProxyResolverProxy*)g_ptr_array_index(proxies, i);
         gchar *regex_wildcard = glob_to_regex(p->pattern);
         g_ptr_array_add(resolver->priv->regex_wildcard,
                         g_regex_new(regex_wildcard,

--- a/Source/WebCore/platform/network/soup/gwildcardproxyresolver.h
+++ b/Source/WebCore/platform/network/soup/gwildcardproxyresolver.h
@@ -45,7 +45,7 @@ typedef struct
 {
     gchar *pattern;
     gchar *proxy;
-} Proxy;
+} GWildcardProxyResolverProxy;
 
 struct _GWildcardProxyResolver
 {

--- a/Source/WebKit2/Shared/API/c/wpe/WebKit.h
+++ b/Source/WebKit2/Shared/API/c/wpe/WebKit.h
@@ -85,6 +85,7 @@
 #include <WebKit/WKContext.h>
 #include <WebKit/WKCredential.h>
 #include <WebKit/WKCredentialTypes.h>
+#include <WebKit/WKCookieManager.h>
 #include <WebKit/WKFrame.h>
 #include <WebKit/WKFrameInfoRef.h>
 #include <WebKit/WKFramePolicyListener.h>
@@ -97,6 +98,7 @@
 #include <WebKit/WKPageGroup.h>
 #include <WebKit/WKPage.h>
 #include <WebKit/WKPreferencesRef.h>
+#include <WebKit/WKProxy.h>
 #include <WebKit/WKSessionRef.h>
 #include <WebKit/WKSessionStateRef.h>
 #include <WebKit/WKUserContentControllerRef.h>

--- a/Source/WebKit2/UIProcess/API/C/WKCookieManager.cpp
+++ b/Source/WebKit2/UIProcess/API/C/WKCookieManager.cpp
@@ -78,9 +78,9 @@ void WKCookieManagerGetHTTPCookieAcceptPolicy(WKCookieManagerRef cookieManager, 
 void WKCookieManagerSetCookies(WKCookieManagerRef cookieManager, WKArrayRef cookies)
 {
     size_t size = cookies ? WKArrayGetSize(cookies) : 0;
-    if (!size)
-        return;
+
     Vector<String> passCookies(size);
+
     for (size_t i = 0; i < size; ++i)
     {
         WKTypeRef cookie = WKArrayGetItemAtIndex(cookies, i);

--- a/Source/WebKit2/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit2/UIProcess/API/C/WKPage.cpp
@@ -390,8 +390,6 @@ void WKPageSetCustomUserAgent(WKPageRef pageRef, WKStringRef userAgentRef)
 void WKPageSetProxies(WKPageRef pageRef, WKArrayRef proxies)
 {
     size_t size = proxies ? WKArrayGetSize(proxies) : 0;
-    if (!size)
-        return;
 
     Vector<WebCore::Proxy> passProxies(size);
 


### PR DESCRIPTION
Cause of name collision and a method from which the type is instantiated is in WebCore namespace,
the wrong proxy type (from WebCore) is chosen (haven't noticed when renamed types before ading for PR)

Including necessary headers to generate forwarding headers for them.

Allowing to set empty proxy and cookies list.