### PR TITLE
adding WKCookie type to set cookies as is

### DIFF
--- a/Source/WebCore/platform/network/PlatformCookieJar.h
+++ b/Source/WebCore/platform/network/PlatformCookieJar.h
@@ -51,8 +51,8 @@ WEBCORE_EXPORT void getHostnamesWithCookies(const NetworkStorageSession&, HashSe
 WEBCORE_EXPORT void deleteCookiesForHostnames(const NetworkStorageSession&, const Vector<String>& cookieHostNames);
 WEBCORE_EXPORT void deleteAllCookies(const NetworkStorageSession&);
 WEBCORE_EXPORT void deleteAllCookiesModifiedSince(const NetworkStorageSession&, std::chrono::system_clock::time_point);
-WEBCORE_EXPORT void setCookies(const NetworkStorageSession&, const Vector<String>&);
-WEBCORE_EXPORT bool getCookies(const NetworkStorageSession&, Vector<String>&);
+WEBCORE_EXPORT void setCookies(const NetworkStorageSession&, const Vector<Cookie>&);
+WEBCORE_EXPORT bool getCookies(const NetworkStorageSession&, Vector<Cookie>&);
 
 }
 

--- a/Source/WebKit2/CMakeLists.txt
+++ b/Source/WebKit2/CMakeLists.txt
@@ -419,6 +419,7 @@ set(WebKit2_SOURCES
     UIProcess/API/C/WKBatteryStatus.cpp
     UIProcess/API/C/WKContext.cpp
     UIProcess/API/C/WKContextConfigurationRef.cpp
+    UIProcess/API/C/WKCookie.cpp
     UIProcess/API/C/WKCookieManager.cpp
     UIProcess/API/C/WKCredential.cpp
     UIProcess/API/C/WKDownload.cpp

--- a/Source/WebKit2/Shared/API/APIObject.h
+++ b/Source/WebKit2/Shared/API/APIObject.h
@@ -155,6 +155,7 @@ public:
         Vibration,
         ViewportAttributes,
         VisitedLinkStore,
+        WebCookie,
         WebsiteDataRecord,
         WebsiteDataStore,
         WindowFeatures,

--- a/Source/WebKit2/Shared/API/c/WKBase.h
+++ b/Source/WebKit2/Shared/API/c/WKBase.h
@@ -99,6 +99,7 @@ typedef const struct OpaqueWKResourceCacheManager* WKResourceCacheManagerRef;
 typedef const struct OpaqueWKColorPickerResultListener* WKColorPickerResultListenerRef;
 typedef const struct OpaqueWKContext* WKContextRef;
 typedef const struct OpaqueWKContextConfiguration* WKContextConfigurationRef;
+typedef const struct OpaqueWKCookie* WKCookieRef;
 typedef const struct OpaqueWKCookieManager* WKCookieManagerRef;
 typedef const struct OpaqueWKCredential* WKCredentialRef;
 typedef const struct OpaqueWKDownload* WKDownloadRef;

--- a/Source/WebKit2/Shared/API/c/wpe/WebKit.h
+++ b/Source/WebKit2/Shared/API/c/wpe/WebKit.h
@@ -85,6 +85,7 @@
 #include <WebKit/WKContext.h>
 #include <WebKit/WKCredential.h>
 #include <WebKit/WKCredentialTypes.h>
+#include <WebKit/WKCookie.h>
 #include <WebKit/WKCookieManager.h>
 #include <WebKit/WKFrame.h>
 #include <WebKit/WKFrameInfoRef.h>

--- a/Source/WebKit2/UIProcess/API/APIWebCookie.h
+++ b/Source/WebKit2/UIProcess/API/APIWebCookie.h
@@ -1,0 +1,55 @@
+/*
+* Copyright (c) 2016, Comcast
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+*  * Redistributions of source code must retain the above copyright notice,
+*    this list of conditions and the following disclaimer.
+*  * Redistributions in binary form must reproduce the above copyright notice,
+*    this list of conditions and the following disclaimer in the documentation
+*    and/or other materials provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR OR; PROFITS BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+* ANY OF THEORY LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef APIWebCookie_h
+#define APIWebCookie_h
+
+#include "APIObject.h"
+#include <WebCore/Cookie.h>
+
+namespace WebKit {
+
+class WebCookie final : public API::ObjectImpl<API::Object::Type::WebCookie> {
+public:
+    static Ref<WebCookie> create(const WebCore::Cookie& cookie)
+    {
+        return adoptRef(*new WebCookie(cookie));
+    }
+
+    const WebCore::Cookie& cookie() const { return m_cookie; }
+
+private:
+
+    WebCookie(const WebCore::Cookie& cookie)
+        : m_cookie(cookie)
+    {
+    }
+
+    WebCore::Cookie m_cookie;
+};
+
+}
+
+#endif

--- a/Source/WebKit2/UIProcess/API/C/WKAPICast.h
+++ b/Source/WebKit2/UIProcess/API/C/WKAPICast.h
@@ -84,6 +84,7 @@ class WebBackForwardListItem;
 class WebBatteryManagerProxy;
 class WebBatteryStatus;
 class WebColorPickerResultListenerProxy;
+class WebCookie;
 class WebCookieManagerProxy;
 class WebCredential;
 class WebFormSubmissionListenerProxy;
@@ -123,6 +124,7 @@ WK_ADD_API_MAPPING(WKBundleHitTestResultMediaType, BundleHitTestResultMediaType)
 WK_ADD_API_MAPPING(WKColorPickerResultListenerRef, WebColorPickerResultListenerProxy)
 WK_ADD_API_MAPPING(WKContextRef, WebProcessPool)
 WK_ADD_API_MAPPING(WKContextConfigurationRef, API::ProcessPoolConfiguration)
+WK_ADD_API_MAPPING(WKCookieRef, WebCookie)
 WK_ADD_API_MAPPING(WKCookieManagerRef, WebCookieManagerProxy)
 WK_ADD_API_MAPPING(WKCredentialRef, WebCredential)
 WK_ADD_API_MAPPING(WKDownloadRef, DownloadProxy)

--- a/Source/WebKit2/UIProcess/API/C/WKCookie.cpp
+++ b/Source/WebKit2/UIProcess/API/C/WKCookie.cpp
@@ -1,0 +1,101 @@
+/*
+* Copyright (c) 2016, Comcast
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+*  * Redistributions of source code must retain the above copyright notice,
+*    this list of conditions and the following disclaimer.
+*  * Redistributions in binary form must reproduce the above copyright notice,
+*    this list of conditions and the following disclaimer in the documentation
+*    and/or other materials provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR OR; PROFITS BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+* ANY OF THEORY LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "config.h"
+#include "APIWebCookie.h"
+#include "WKCookie.h"
+#include "WKAPICast.h"
+#include "WKString.h"
+
+using namespace WebKit;
+
+WKTypeID WKCookieGetTypeID()
+{
+    return toAPI(WebCookie::APIType);
+}
+
+WKCookieRef WKCookieCreate(WKStringRef name,
+                           WKStringRef value,
+                           WKStringRef domain,
+                           WKStringRef path,
+                           double expires,
+                           bool httpOnly,
+                           bool secure,
+                           bool session)
+{
+    return toAPI(&WebCookie::create(WebCore::Cookie(
+                                        toWTFString(name),
+                                        toWTFString(value),
+                                        toWTFString(domain),
+                                        toWTFString(path),
+                                        expires,
+                                        httpOnly,
+                                        secure,
+                                        session)).leakRef());
+}
+
+WKStringRef WKCookieGetName(WKCookieRef cookie)
+{
+    return WKStringCreateWithUTF8CString(
+        toImpl(cookie)->cookie().name.utf8().data());
+}
+
+WKStringRef WKCookieGetValue(WKCookieRef cookie)
+{
+    return WKStringCreateWithUTF8CString(
+        toImpl(cookie)->cookie().value.utf8().data());
+}
+
+WKStringRef WKCookieGetDomain(WKCookieRef cookie)
+{
+    return WKStringCreateWithUTF8CString(
+        toImpl(cookie)->cookie().domain.utf8().data());
+}
+
+WKStringRef WKCookieGetPath(WKCookieRef cookie)
+{
+    return WKStringCreateWithUTF8CString(
+        toImpl(cookie)->cookie().path.utf8().data());
+}
+
+double WKCookieGetExpires(WKCookieRef cookie)
+{
+    return toImpl(cookie)->cookie().expires;
+}
+
+bool WKCookieGetHttpOnly(WKCookieRef cookie)
+{
+    return toImpl(cookie)->cookie().httpOnly;
+}
+
+bool WKCookieGetSecure(WKCookieRef cookie)
+{
+    return toImpl(cookie)->cookie().secure;
+}
+
+bool WKCookieGetSession(WKCookieRef cookie)
+{
+    return toImpl(cookie)->cookie().session;
+}

--- a/Source/WebKit2/UIProcess/API/C/WKCookie.h
+++ b/Source/WebKit2/UIProcess/API/C/WKCookie.h
@@ -1,0 +1,59 @@
+/*
+* Copyright (c) 2016, Comcast
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+*  * Redistributions of source code must retain the above copyright notice,
+*    this list of conditions and the following disclaimer.
+*  * Redistributions in binary form must reproduce the above copyright notice,
+*    this list of conditions and the following disclaimer in the documentation
+*    and/or other materials provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR OR; PROFITS BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+* ANY OF THEORY LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef WKCookie_h
+#define WKCookie_h
+
+#include <WebKit/WKBase.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+WK_EXPORT WKTypeID WKCookieGetTypeID();
+
+WK_EXPORT WKCookieRef WKCookieCreate(WKStringRef name,
+                                     WKStringRef value,
+                                     WKStringRef domain,
+                                     WKStringRef path,
+                                     double expires,
+                                     bool httpOnly,
+                                     bool secure,
+                                     bool session);
+
+WK_EXPORT WKStringRef WKCookieGetName(WKCookieRef cookie);
+WK_EXPORT WKStringRef WKCookieGetValue(WKCookieRef cookie);
+WK_EXPORT WKStringRef WKCookieGetDomain(WKCookieRef cookie);
+WK_EXPORT WKStringRef WKCookieGetPath(WKCookieRef cookie);
+WK_EXPORT double WKCookieGetExpires(WKCookieRef cookie);
+WK_EXPORT bool WKCookieGetHttpOnly(WKCookieRef cookie);
+WK_EXPORT bool WKCookieGetSecure(WKCookieRef cookie);
+WK_EXPORT bool WKCookieGetSession(WKCookieRef cookie);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/Source/WebKit2/UIProcess/API/C/WKCookieManager.cpp
+++ b/Source/WebKit2/UIProcess/API/C/WKCookieManager.cpp
@@ -29,6 +29,8 @@
 #include "WKAPICast.h"
 #include "WebCookieManagerProxy.h"
 #include "WKArray.h"
+#include "APIWebCookie.h"
+#include "WKCookie.h"
 
 using namespace WebKit;
 
@@ -79,13 +81,11 @@ void WKCookieManagerSetCookies(WKCookieManagerRef cookieManager, WKArrayRef cook
 {
     size_t size = cookies ? WKArrayGetSize(cookies) : 0;
 
-    Vector<String> passCookies(size);
+    Vector<WebCore::Cookie> passCookies(size);
 
     for (size_t i = 0; i < size; ++i)
-    {
-        WKTypeRef cookie = WKArrayGetItemAtIndex(cookies, i);
-        passCookies[i] = toWTFString(static_cast<WKStringRef>(cookie));
-    }
+        passCookies[i] = toImpl(static_cast<WKCookieRef>(WKArrayGetItemAtIndex(cookies, i)))->cookie();
+
     toImpl(cookieManager)->setCookies(passCookies);
 }
 

--- a/Source/WebKit2/UIProcess/WebCookieManagerProxy.cpp
+++ b/Source/WebKit2/UIProcess/WebCookieManagerProxy.cpp
@@ -27,6 +27,7 @@
 #include "WebCookieManagerProxy.h"
 
 #include "APIArray.h"
+#include "APIWebCookie.h"
 #include "APISecurityOrigin.h"
 #include "WebCookieManagerMessages.h"
 #include "WebCookieManagerProxyMessages.h"
@@ -186,7 +187,7 @@ void WebCookieManagerProxy::didGetHTTPCookieAcceptPolicy(uint32_t policy, uint64
     callback->performCallbackWithReturnValue(policy);
 }
 
-void WebCookieManagerProxy::setCookies(const Vector<String>& cookies)
+void WebCookieManagerProxy::setCookies(const Vector<WebCore::Cookie>& cookies)
 {
     processPool()->sendToNetworkingProcessRelaunchingIfNecessary(Messages::WebCookieManager::SetCookies(cookies));
 }
@@ -200,7 +201,7 @@ void WebCookieManagerProxy::getCookies(std::function<void (API::Array*, Callback
     processPool()->sendToNetworkingProcessRelaunchingIfNecessary(Messages::WebCookieManager::GetCookies(callbackID));
 }
 
-void WebCookieManagerProxy::didGetCookies(Vector<String> cookies, uint64_t callbackID)
+void WebCookieManagerProxy::didGetCookies(Vector<WebCore::Cookie> cookies, uint64_t callbackID)
 {
     RefPtr<ArrayCallback> callback = m_arrayCallbacks.take(callbackID);
     if (!callback)
@@ -213,7 +214,7 @@ void WebCookieManagerProxy::didGetCookies(Vector<String> cookies, uint64_t callb
 
     for (size_t i = 0; i < cookiesSize; ++i)
     {
-        passCookies[i] = API::String::create(WTFMove(cookies[i]));
+        passCookies[i] = WebCookie::create(cookies[i]);
     }
     callback->performCallbackWithReturnValue(API::Array::create(WTFMove(passCookies)).ptr());
 }

--- a/Source/WebKit2/UIProcess/WebCookieManagerProxy.h
+++ b/Source/WebKit2/UIProcess/WebCookieManagerProxy.h
@@ -73,9 +73,9 @@ public:
     void setHTTPCookieAcceptPolicy(HTTPCookieAcceptPolicy);
     void getHTTPCookieAcceptPolicy(std::function<void (HTTPCookieAcceptPolicy, CallbackBase::Error)>);
 
-    void setCookies(const Vector<String>& cookies);
+    void setCookies(const Vector<WebCore::Cookie>& cookies);
     void getCookies(std::function<void (API::Array*, CallbackBase::Error)>);
-    void didGetCookies(Vector<String> cookies,  uint64_t callbackID);
+    void didGetCookies(Vector<WebCore::Cookie> cookies,  uint64_t callbackID);
 
     void startObservingCookieChanges();
     void stopObservingCookieChanges();

--- a/Source/WebKit2/UIProcess/WebCookieManagerProxy.messages.in
+++ b/Source/WebKit2/UIProcess/WebCookieManagerProxy.messages.in
@@ -23,8 +23,8 @@
 messages -> WebCookieManagerProxy {
     DidGetHostnamesWithCookies(Vector<String> hostnames, uint64_t callbackID);
     DidGetHTTPCookieAcceptPolicy(uint32_t policy, uint64_t callbackID);
-    
-    DidGetCookies(Vector<String> cookies, uint64_t callbackID)
+
+    DidGetCookies(Vector<WebCore::Cookie> cookies, uint64_t callbackID)
 
     CookiesDidChange()
 }

--- a/Source/WebKit2/WebProcess/Cookies/WebCookieManager.cpp
+++ b/Source/WebKit2/WebProcess/Cookies/WebCookieManager.cpp
@@ -120,14 +120,14 @@ void WebCookieManager::getHTTPCookieAcceptPolicy(uint64_t callbackID)
     m_process->send(Messages::WebCookieManagerProxy::DidGetHTTPCookieAcceptPolicy(platformGetHTTPCookieAcceptPolicy(), callbackID), 0);
 }
 
-void WebCookieManager::setCookies(const Vector<String>& cookies)
+void WebCookieManager::setCookies(const Vector<WebCore::Cookie>& cookies)
 {
     WebCore::setCookies(NetworkStorageSession::defaultStorageSession(), cookies);
 }
 
 void WebCookieManager::getCookies(uint64_t callbackID)
 {
-    Vector<String> cookies;
+    Vector<WebCore::Cookie> cookies;
     WebCore::getCookies(NetworkStorageSession::defaultStorageSession(), cookies);
     m_process->send(Messages::WebCookieManagerProxy::DidGetCookies(cookies, callbackID), 0);
 }

--- a/Source/WebKit2/WebProcess/Cookies/WebCookieManager.h
+++ b/Source/WebKit2/WebProcess/Cookies/WebCookieManager.h
@@ -73,7 +73,7 @@ private:
     void getHTTPCookieAcceptPolicy(uint64_t callbackID);
     HTTPCookieAcceptPolicy platformGetHTTPCookieAcceptPolicy();
 
-    void setCookies(const Vector<String>& cookies);
+    void setCookies(const Vector<WebCore::Cookie>& cookies);
     void getCookies(uint64_t callbackID);
 
     void startObservingCookieChanges();

--- a/Source/WebKit2/WebProcess/Cookies/WebCookieManager.messages.in
+++ b/Source/WebKit2/WebProcess/Cookies/WebCookieManager.messages.in
@@ -32,8 +32,8 @@
 
     void SetHTTPCookieAcceptPolicy(uint32_t policy)
     void GetHTTPCookieAcceptPolicy(uint64_t callbackID)
-    
-    void SetCookies(Vector<String> cookies)
+
+    void SetCookies(Vector<WebCore::Cookie> cookies)
     void GetCookies(uint64_t callbackID)
 
     void StartObservingCookieChanges()


### PR DESCRIPTION
setting all the cookies as a list of strings and parsing with soup_cookie_parse
doesn't always work as soup_cookie_parse adds a dot to the beginning of the domain so
saving cookies from the outside with getCookies and setting them back with
setCookies domain is modified changing the application of the cookie.

Passing as a WKCookie/WebCore::Cookie domain can be set as is.