### PR TITLE
Handle media and TV keys for libxkbcommon input

### DIFF
--- a/Source/ThirdParty/WPE-platform/src/input/TvKeyboardCodes.h
+++ b/Source/ThirdParty/WPE-platform/src/input/TvKeyboardCodes.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2016 SoftAtHome. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef TvKeyboardCodes_h
+#define TvKeyboardCodes_h
+
+// From DASE, also used in CE-HTML
+// http://atsc.org/wp-content/uploads/2015/03/a_100_2.pdf
+#define VK_DASE_CANCEL 3
+
+// From HAVi, used in DASE and OCAP
+#define VK_HAVI_COLORED_KEY_0 403
+#define VK_HAVI_COLORED_KEY_1 404
+#define VK_HAVI_COLORED_KEY_2 405
+#define VK_HAVI_COLORED_KEY_3 406
+#define VK_HAVI_POWER 409
+#define VK_HAVI_PLAY 415
+#define VK_HAVI_RECORD 416
+#define VK_HAVI_DISPLAY_SWAP 444
+#define VK_HAVI_SUBTITLE 460
+
+// OCAP
+// http://www.cablelabs.com/wp-content/uploads/specdocs/OC-SP-OCAP1.3.1-130530.pdf
+#define VK_OCAP_ON_DEMAND 623
+
+#endif // TvKeyboardCodes_h

--- a/Source/ThirdParty/WPE-platform/src/input/XKB/input-libxkbcommon.cpp
+++ b/Source/ThirdParty/WPE-platform/src/input/XKB/input-libxkbcommon.cpp
@@ -135,6 +135,53 @@ struct wpe_input_key_mapper_interface libxkbcommon_input_key_mapper_interface = 
             case XKB_KEY_3270_BackTab:
             case XKB_KEY_Tab:
                 return "U+0009";
+
+            // Device Keys
+            case XKB_KEY_XF86Sleep:
+                return "Standby";
+
+            // Multimedia Keys
+            case XKB_KEY_XF86AudioForward:
+                return "MediaFastForward";
+            case XKB_KEY_XF86AudioPause:
+                return "MediaPause";
+            case XKB_KEY_XF86AudioRewind:
+                return "MediaRewind";
+            case XKB_KEY_XF86AudioStop:
+                return "MediaStop";
+            case XKB_KEY_XF86AudioPrev:
+                return "MediaTrackPrevious";
+            case XKB_KEY_XF86AudioNext:
+                return "MediaTrackNext";
+
+            // Audio Keys
+            case XKB_KEY_XF86AudioLowerVolume:
+                return "AudioVolumeDown";
+            case XKB_KEY_XF86AudioRaiseVolume:
+                return "AudioVolumeUp";
+            case XKB_KEY_XF86AudioMute:
+                return "AudioVolumeMute";
+
+            // Application Keys
+            case XKB_KEY_XF86AudioMedia:
+                return "LaunchMediaPlayer";
+
+            // Browser Keys
+            case XKB_KEY_XF86Back:
+                return "BrowserBack";
+            case XKB_KEY_XF86Favorites:
+                return "BrowserFavorites";
+            case XKB_KEY_XF86Forward:
+                return "BrowserForward";
+            case XKB_KEY_XF86HomePage:
+                return "BrowserHome";
+            case XKB_KEY_XF86Refresh:
+                return "BrowserRefresh";
+            case XKB_KEY_XF86Search:
+                return "BrowserSearch";
+            case XKB_KEY_XF86Stop:
+                return "BrowserStop";
+
             default:
                 return nullptr;
         }
@@ -213,6 +260,7 @@ struct wpe_input_key_mapper_interface libxkbcommon_input_key_mapper_interface = 
                 // VK_MENU (12) ALT key
 
             case XKB_KEY_Pause:
+            case XKB_KEY_XF86AudioPause:
                 return VK_PAUSE; // (13) PAUSE key
             case XKB_KEY_Caps_Lock:
                 return VK_CAPITAL; // (14) CAPS LOCK key
@@ -377,7 +425,8 @@ struct wpe_input_key_mapper_interface libxkbcommon_input_key_mapper_interface = 
                 return VK_LWIN; // (5B) Left Windows key (Microsoft Natural keyboard)
             case XKB_KEY_Meta_R:
                 return VK_RWIN; // (5C) Right Windows key (Natural keyboard)
-                // VK_SLEEP (5F) Computer Sleep key
+            case XKB_KEY_XF86Sleep:
+                return VK_SLEEP; // (5F) Computer Sleep key
                 // VK_SEPARATOR (6C) Separator key
                 // VK_SUBTRACT (6D) Subtract key
                 // VK_DECIMAL (6E) Decimal key
@@ -403,22 +452,36 @@ struct wpe_input_key_mapper_interface libxkbcommon_input_key_mapper_interface = 
             case XKB_KEY_Alt_R:
                 return VK_RMENU; // (A5) Right MENU key
 
-                // VK_BROWSER_BACK (A6) Windows 2000/XP: Browser Back key
-                // VK_BROWSER_FORWARD (A7) Windows 2000/XP: Browser Forward key
-                // VK_BROWSER_REFRESH (A8) Windows 2000/XP: Browser Refresh key
-                // VK_BROWSER_STOP (A9) Windows 2000/XP: Browser Stop key
-                // VK_BROWSER_SEARCH (AA) Windows 2000/XP: Browser Search key
-                // VK_BROWSER_FAVORITES (AB) Windows 2000/XP: Browser Favorites key
-                // VK_BROWSER_HOME (AC) Windows 2000/XP: Browser Start and Home key
-                // VK_VOLUME_MUTE (AD) Windows 2000/XP: Volume Mute key
-                // VK_VOLUME_DOWN (AE) Windows 2000/XP: Volume Down key
-                // VK_VOLUME_UP (AF) Windows 2000/XP: Volume Up key
-                // VK_MEDIA_NEXT_TRACK (B0) Windows 2000/XP: Next Track key
-                // VK_MEDIA_PREV_TRACK (B1) Windows 2000/XP: Previous Track key
-                // VK_MEDIA_STOP (B2) Windows 2000/XP: Stop Media key
+            case XKB_KEY_XF86Back:
+                return VK_BROWSER_BACK; // VK_BROWSER_BACK (A6) Windows 2000/XP: Browser Back key
+            case XKB_KEY_XF86Forward:
+                return VK_BROWSER_FORWARD; // (A7) Windows 2000/XP: Browser Forward key
+            case XKB_KEY_XF86Refresh:
+                return VK_BROWSER_REFRESH; // (A8) Windows 2000/XP: Browser Refresh key
+            case XKB_KEY_XF86Stop:
+                return VK_BROWSER_STOP; // (A9) Windows 2000/XP: Browser Stop key
+            case XKB_KEY_XF86Search:
+                return VK_BROWSER_SEARCH; // (AA) Windows 2000/XP: Browser Search key
+            case XKB_KEY_XF86Favorites:
+                return VK_BROWSER_FAVORITES; // (AB) Windows 2000/XP: Browser Favorites key
+            case XKB_KEY_XF86HomePage:
+                return VK_BROWSER_HOME; // (AC) Windows 2000/XP: Browser Start and Home key
+            case XKB_KEY_XF86AudioMute:
+                return VK_VOLUME_MUTE; // (AD) Windows 2000/XP: Volume Mute key
+            case XKB_KEY_XF86AudioLowerVolume:
+                return VK_VOLUME_DOWN; // (AE) Windows 2000/XP: Volume Down key
+            case XKB_KEY_XF86AudioRaiseVolume:
+                return VK_VOLUME_UP; // (AF) Windows 2000/XP: Volume Up key
+            case XKB_KEY_XF86AudioNext:
+                return VK_MEDIA_NEXT_TRACK; // (B0) Windows 2000/XP: Next Track key
+            case XKB_KEY_XF86AudioPrev:
+                return VK_MEDIA_PREV_TRACK; // (B1) Windows 2000/XP: Previous Track key
+            case XKB_KEY_XF86AudioStop:
+                return VK_MEDIA_STOP; // (B2) Windows 2000/XP: Stop Media key
                 // VK_MEDIA_PLAY_PAUSE (B3) Windows 2000/XP: Play/Pause Media key
                 // VK_LAUNCH_MAIL (B4) Windows 2000/XP: Start Mail key
-                // VK_LAUNCH_MEDIA_SELECT (B5) Windows 2000/XP: Select Media key
+            case XKB_KEY_XF86AudioMedia:
+                return VK_MEDIA_LAUNCH_MEDIA_SELECT; // (B5) Windows 2000/XP: Select Media key
                 // VK_LAUNCH_APP1 (B6) Windows 2000/XP: Start Application 1 key
                 // VK_LAUNCH_APP2 (B7) Windows 2000/XP: Start Application 2 key
 
@@ -468,6 +531,10 @@ struct wpe_input_key_mapper_interface libxkbcommon_input_key_mapper_interface = 
                 return VK_OEM_7; // case '\'': case '"': return 0xDE;
                 // VK_OEM_8 (DF) Used for miscellaneous characters; it can vary by keyboard.
                 // VK_OEM_102 (E2) Windows 2000/XP: Either the angle bracket key or the backslash key on the RT 102-key keyboard
+            case XKB_KEY_XF86AudioRewind:
+                return 0xE3; // (E3) Android/GoogleTV: Rewind media key (Windows: VK_ICO_HELP Help key on 1984 Olivetti M24 deluxe keyboard)
+            case XKB_KEY_XF86AudioForward:
+                return 0xE4; // (E4) Android/GoogleTV: Fast forward media key  (Windows: VK_ICO_00 '00' key on 1984 Olivetti M24 deluxe keyboard)
                 // VK_PROCESSKEY (E5) Windows 95/98/Me, Windows NT 4.0, Windows 2000/XP: IME PROCESS key
                 // VK_PACKET (E7) Windows 2000/XP: Used to pass Unicode characters as if they were keystrokes. The VK_PACKET key is the low word of a 32-bit Virtual Key value used for non-keyboard input methods. For more information, see Remark in KEYBDINPUT,SendInput, WM_KEYDOWN, and WM_KEYUP
                 // VK_ATTN (F6) Attn key

--- a/Source/ThirdParty/WPE-platform/src/input/XKB/input-libxkbcommon.cpp
+++ b/Source/ThirdParty/WPE-platform/src/input/XKB/input-libxkbcommon.cpp
@@ -30,6 +30,7 @@
 #ifdef KEY_INPUT_HANDLING_XKB
 
 #include "WindowsKeyboardCodes.h"
+#include "TvKeyboardCodes.h"
 #include <xkbcommon/xkbcommon-keysyms.h>
 
 extern "C" {
@@ -136,7 +137,13 @@ struct wpe_input_key_mapper_interface libxkbcommon_input_key_mapper_interface = 
             case XKB_KEY_Tab:
                 return "U+0009";
 
+            // UI Keys
+            case XKB_KEY_Cancel:
+                return "Cancel";
+
             // Device Keys
+            case XKB_KEY_XF86PowerOff:
+                return "Power"; // the spec also mentions "PowerOff"
             case XKB_KEY_XF86Sleep:
                 return "Standby";
 
@@ -145,6 +152,10 @@ struct wpe_input_key_mapper_interface libxkbcommon_input_key_mapper_interface = 
                 return "MediaFastForward";
             case XKB_KEY_XF86AudioPause:
                 return "MediaPause";
+            case XKB_KEY_XF86AudioPlay:
+                return "MediaPlay";
+            case XKB_KEY_XF86AudioRecord:
+                return "MediaRecord";
             case XKB_KEY_XF86AudioRewind:
                 return "MediaRewind";
             case XKB_KEY_XF86AudioStop:
@@ -181,6 +192,22 @@ struct wpe_input_key_mapper_interface libxkbcommon_input_key_mapper_interface = 
                 return "BrowserSearch";
             case XKB_KEY_XF86Stop:
                 return "BrowserStop";
+
+            // Media Controller Keys
+            case XKB_KEY_XF86Red:
+                return "ColorF0Red";
+            case XKB_KEY_XF86Green:
+                return "ColorF1Green";
+            case XKB_KEY_XF86Yellow:
+                return "ColorF2Yellow";
+            case XKB_KEY_XF86Blue:
+                return "ColorF3Blue";
+            case XKB_KEY_XF86Display:
+                return "DisplaySwap";
+            case XKB_KEY_XF86Video:
+                return "OnDemand";
+            case XKB_KEY_XF86Subtitle:
+                return "Subtitle";
 
             default:
                 return nullptr;
@@ -573,6 +600,31 @@ struct wpe_input_key_mapper_interface libxkbcommon_input_key_mapper_interface = 
                 return VK_F1 + (event->keyCode - XKB_KEY_F1);
             case XKB_KEY_VoidSymbol:
                 return VK_PROCESSKEY;
+
+            // TV keycodes from HAVi / DASE / OCAP / CE-HTML standards
+            case XKB_KEY_Cancel:
+                return VK_DASE_CANCEL;
+            case XKB_KEY_XF86Red:
+                return VK_HAVI_COLORED_KEY_0;
+            case XKB_KEY_XF86Green:
+                return VK_HAVI_COLORED_KEY_1;
+            case XKB_KEY_XF86Yellow:
+                return VK_HAVI_COLORED_KEY_2;
+            case XKB_KEY_XF86Blue:
+                return VK_HAVI_COLORED_KEY_3;
+            case XKB_KEY_XF86PowerOff:
+                return VK_HAVI_POWER;
+            case XKB_KEY_XF86AudioPlay:
+                return VK_HAVI_PLAY;
+            case XKB_KEY_XF86AudioRecord:
+                return VK_HAVI_RECORD;
+            case XKB_KEY_XF86Display:
+                return VK_HAVI_DISPLAY_SWAP;
+            case XKB_KEY_XF86Subtitle:
+                return VK_HAVI_SUBTITLE;
+            case XKB_KEY_XF86Video:
+                return VK_OCAP_ON_DEMAND;
+
             default:
                 return 0;
         }


### PR DESCRIPTION
These commits handle more media and TV for libxkbcommon input in WPE-platform.
It follows the W3C KeyboardEvent spec, and other TV standards when no keycode definition exists in the W3C spec.