### PR TITLE
WPE-platform: rework the wayland event loop to fix hangs in Wayland::Display

### DIFF
--- a/Source/cmake/FindWayland.cmake
+++ b/Source/cmake/FindWayland.cmake
@@ -29,7 +29,7 @@
 # ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 find_package(PkgConfig)
-pkg_check_modules(WAYLAND wayland-client wayland-server)
+pkg_check_modules(WAYLAND wayland-client>=1.2 wayland-server)
 
 include(FindPackageHandleStandardArgs)
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(WAYLAND DEFAULT_MSG WAYLAND_LIBRARIES)


### PR DESCRIPTION
Hangs occured because of races with multi-threaded wayland usage, for
example with wayland-egl usage in the renderer.