### PR TITLE
Fix a WebKit compile error

### DIFF
--- a/Tools/BuildSlaveSupport/gtk/daemontools-buildbot.conf
+++ b/Tools/BuildSlaveSupport/gtk/daemontools-buildbot.conf
@@ -38,8 +38,8 @@ ccache_path="/usr/lib/ccache"
 
 # Environment variables. Prefix them with "env_".
 #
-env_CFLAGS="-pipe"
-env_CXXFLAGS="-pipe"
+env_CFLAGS=""
+env_CXXFLAGS=""
 env_LDFLAGS="-no-install -no-fast-install"
 env_WEBKIT_TESTFONTS="/home/${buildbot_user}/testfonts"
 


### PR DESCRIPTION
Sometimes WebKit fails to compile on Jenkins.

Removing "-pipe" option can help with this problem.
