### PR TITLE
Added malloc_trim to memory pressure of network processs for glibc impl

### DIFF
--- a/Source/WebKit2/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit2/NetworkProcess/NetworkProcess.cpp
@@ -72,6 +72,10 @@
 #include "NetworkCacheCoders.h"
 #endif
 
+#ifdef __GLIBC__
+#include <malloc.h>
+#endif
+
 using namespace WebCore;
 
 namespace WebKit {
@@ -665,6 +669,9 @@ void NetworkProcess::initializeSandbox(const ChildProcessInitializationParameter
 
 void NetworkProcess::platformLowMemoryHandler(Critical)
 {
+#ifdef __GLIBC__
+    malloc_trim(0);
+#endif
 }
 #endif
 


### PR DESCRIPTION
Now when memory pressure is performing malloc_trim will be called.
The same as web process.
See MemoryPressureHandler::platformReleaseMemory.
It could "save" some memory, for example that is kept after SoupNetworkSession::defaultSession().setSSLPolicy(SoupNetworkSession::SSLUseSystemCAFile);