### PR TITLE
Added maxDelayForGCTimers option in seconds to limit GC timers.

### DIFF
--- a/Source/JavaScriptCore/heap/GCActivityCallback.cpp
+++ b/Source/JavaScriptCore/heap/GCActivityCallback.cpp
@@ -134,7 +134,8 @@ void GCActivityCallback::scheduleTimer(double newDelay)
     }
 
     auto delayDuration = std::chrono::duration<double>(m_delay);
-    auto safeDelayDuration = std::chrono::microseconds::max();
+    std::chrono::microseconds safeDelayDuration =
+        Options::maxDelayForGCTimers() ? std::chrono::seconds(Options::maxDelayForGCTimers()) : std::chrono::microseconds::max();
     if (delayDuration < safeDelayDuration)
         safeDelayDuration = std::chrono::duration_cast<std::chrono::microseconds>(delayDuration);
     gint64 currentTime = g_get_monotonic_time();

--- a/Source/JavaScriptCore/runtime/Options.h
+++ b/Source/JavaScriptCore/runtime/Options.h
@@ -306,6 +306,7 @@ typedef const char* optionString;
     v(double, percentCPUPerMBForFullTimer, 0.0003125, Normal, nullptr) \
     v(double, percentCPUPerMBForEdenTimer, 0.0025, Normal, nullptr) \
     v(double, collectionTimerMaxPercentCPU, 0.05, Normal, nullptr) \
+    v(unsigned, maxDelayForGCTimers, 0, Normal, "max delay in seconds for GC timers, if 0 means no delay") \
     \
     v(bool, forceWeakRandomSeed, false, Normal, nullptr) \
     v(unsigned, forcedWeakRandomSeed, 0, Normal, nullptr) \


### PR DESCRIPTION
Used for full and eden timers.
If 0 means no limit as it was before.
Useful when timers were set to inf and GC is not triggered anymore.
Limiting the timers makes sure that GC will be forced and new delay will be calculated.
Otherwise will need to wait for memory pressure or exceeding max heap size to trigger GC.