### PR TITLE
Fixed deathRate value when GC caused heap to grow

### DIFF
--- a/Source/JavaScriptCore/heap/EdenGCActivityCallback.cpp
+++ b/Source/JavaScriptCore/heap/EdenGCActivityCallback.cpp
@@ -58,7 +58,7 @@ double EdenGCActivityCallback::deathRate()
         // GC caused the heap to grow(!)
         // This could happen if the we visited more extra memory than was reported allocated.
         // We don't return a negative death rate, since that would schedule the next GC in the past.
-        return 0;
+        return 1.0;
     }
     return static_cast<double>(sizeBefore - sizeAfter) / static_cast<double>(sizeBefore);
 }

--- a/Source/JavaScriptCore/heap/FullGCActivityCallback.cpp
+++ b/Source/JavaScriptCore/heap/FullGCActivityCallback.cpp
@@ -74,7 +74,7 @@ double FullGCActivityCallback::deathRate()
         // GC caused the heap to grow(!)
         // This could happen if the we visited more extra memory than was reported allocated.
         // We don't return a negative death rate, since that would schedule the next GC in the past.
-        return 0;
+        return 1.0;
     }
     return static_cast<double>(sizeBefore - sizeAfter) / static_cast<double>(sizeBefore);
 }


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=164472
Problem there is about when deathRate is 0, GC timers stop to work.
To recalculate sizeBeforeLastFullCollection and sizeAfterLastFullCollection
need to force GC. And need to wait for memory pressure or memory exceeds max heap size etc to force it.