### PR TITLE
Fixing crash in CompositingRunLoop::updateCompleted

### DIFF
--- a/Source/WebKit2/Shared/CoordinatedGraphics/threadedcompositor/CompositingRunLoop.cpp
+++ b/Source/WebKit2/Shared/CoordinatedGraphics/threadedcompositor/CompositingRunLoop.cpp
@@ -147,7 +147,7 @@ bool CompositingRunLoop::isActive()
 void CompositingRunLoop::scheduleUpdate()
 {
     if (m_updateState.compareExchangeStrong(UpdateState::Completed, UpdateState::InProgress)) {
-        m_updateTimer.startOneShot(0);
+        startTimer(0);
         return;
     }
 
@@ -157,7 +157,7 @@ void CompositingRunLoop::scheduleUpdate()
 
 void CompositingRunLoop::stopUpdates()
 {
-    m_updateTimer.stop();
+    stopTimer();
     m_updateState.store(UpdateState::Completed);
 }
 
@@ -167,16 +167,26 @@ void CompositingRunLoop::updateCompleted()
         return;
 
     if (m_updateState.compareExchangeStrong(UpdateState::PendingAfterCompletion, UpdateState::InProgress)) {
-        m_updateTimer.startOneShot(0);
+        startTimer(0);
         return;
     }
-
-    ASSERT_NOT_REACHED();
 }
 
 void CompositingRunLoop::updateTimerFired()
 {
     m_updateFunction();
+}
+
+void CompositingRunLoop::startTimer(double interval)
+{
+    MutexLocker lock(m_timerMutex);
+    m_updateTimer.startOneShot(interval);
+}
+
+void CompositingRunLoop::stopTimer()
+{
+    MutexLocker lock(m_timerMutex);
+    m_updateTimer.stop();
 }
 
 } // namespace WebKit

--- a/Source/WebKit2/Shared/CoordinatedGraphics/threadedcompositor/CompositingRunLoop.h
+++ b/Source/WebKit2/Shared/CoordinatedGraphics/threadedcompositor/CompositingRunLoop.h
@@ -65,7 +65,10 @@ private:
     };
 
     void updateTimerFired();
+    void startTimer(double interval);
+    void stopTimer();
 
+    Mutex m_timerMutex;
     RunLoop::Timer<CompositingRunLoop> m_updateTimer;
     std::function<void ()> m_updateFunction;
     Atomic<UpdateState> m_updateState;


### PR DESCRIPTION
CompositingRunLoop::updateCompleted and CompositingRunLoop::scheduleUpdate
run on different threads (main thread and compositing thread)
So need to protect the timer with mutex and assertion is not appropriate