### PR TITLE
Fixing playback with gstreamer

### DIFF
--- a/Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunchBase.cpp
+++ b/Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunchBase.cpp
@@ -42,7 +42,8 @@ using namespace std;
 namespace WebCore {
 
 MediaPlayerPrivateHolePunchBase::MediaPlayerPrivateHolePunchBase(MediaPlayer* player)
-    :m_player(player)
+    : m_player(player)
+    , m_networkState(MediaPlayer::Empty)
 {
 #if USE(COORDINATED_GRAPHICS_THREADED)
     m_platformLayerProxy = adoptRef(new TextureMapperPlatformLayerProxy());

--- a/Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunchBase.h
+++ b/Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunchBase.h
@@ -70,8 +70,10 @@ public:
     virtual void swapBuffersIfNeeded() override { };
 #endif
 
-private:
+protected:
     MediaPlayer* m_player;
+    MediaPlayer::NetworkState m_networkState;
+private:
     IntSize m_size;
 #if USE(COORDINATED_GRAPHICS_THREADED)
     RefPtr<TextureMapperPlatformLayerProxy> m_platformLayerProxy;

--- a/Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunchDummy.cpp
+++ b/Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunchDummy.cpp
@@ -89,6 +89,12 @@ static HashSet<String, ASCIICaseInsensitiveHash>& mimeTypeCache()
     return cache;
 }
 
+void MediaPlayerPrivateHolePunchDummy::notifyLoadFailed()
+{
+    m_networkState = MediaPlayer::FormatError;
+    m_player->networkStateChanged();
+}
+
 void MediaPlayerPrivateHolePunchDummy::getSupportedTypes(HashSet<String, ASCIICaseInsensitiveHash>& types)
 {
     types = mimeTypeCache();

--- a/Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunchDummy.h
+++ b/Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunchDummy.h
@@ -41,12 +41,12 @@ public:
     bool hasVideo() const override { return false; };
     bool hasAudio() const override { return false; };
 
-    void load(const String&) override { };
+    void load(const String&) override { notifyLoadFailed(); };
 #if ENABLE(MEDIA_SOURCE)
-    void load(const String&, MediaSourcePrivateClient*) override { };
+    void load(const String&, MediaSourcePrivateClient*) override { notifyLoadFailed(); };
 #endif
 #if ENABLE(MEDIA_STREAM)
-    void load(MediaStreamPrivate&) override { };
+    void load(MediaStreamPrivate&) override { notifyLoadFailed(); };
 #endif
     void commitLoad() { };
     void cancelLoad() override { };
@@ -59,6 +59,7 @@ public:
     bool didLoadingProgress() const override { return false; };
 
 private:
+    void notifyLoadFailed();
     static void getSupportedTypes(HashSet<String, ASCIICaseInsensitiveHash>&);
     static MediaPlayer::SupportsType supportsType(const MediaEngineSupportParameters&);
 };


### PR DESCRIPTION
When contenttype is empty/not available, MediaPlayer::loadWithNextMediaEngine
is using nextMediaEngine method to select the media engine.
nextMediaEngine basically returns the first media engine from the media engines vector.
Currently, if WebRTC or hole punch gstreamer is enabled,
it will be selected and the playback will fail.
The patch fixes this by reordering media engines in the vector.