### PR TITLE
Fixing playback with gstreamer

### DIFF
--- a/Source/WebCore/platform/GStreamer.cmake
+++ b/Source/WebCore/platform/GStreamer.cmake
@@ -162,7 +162,7 @@ endif ()
 if (USE_HOLE_PUNCH_EXTERNAL)
     list(APPEND WebCore_SOURCES
         platform/graphics/holepunch/MediaPlayerPrivateHolePunchBase.cpp
-        platform/graphics/holepunch/MediaPlayerPrivateHolePunchDummy.cpp
+        platform/graphics/holepunch/MediaPlayerPrivateHolePunch.cpp
     )
 
     list(APPEND WebCore_INCLUDE_DIRECTORIES

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -91,7 +91,7 @@
 #endif
 
 #if USE(HOLE_PUNCH_EXTERNAL)
-#include "MediaPlayerPrivateHolePunchDummy.h"
+#include "MediaPlayerPrivateHolePunch.h"
 #endif
 
 #if ENABLE(MEDIA_STREAM) && USE(QT5WEBRTC)
@@ -230,10 +230,6 @@ static void buildMediaEnginesVector()
     MediaPlayerPrivateQt5WebRTC::registerMediaEngine(addMediaEngine);
 #endif
 
-#if USE(HOLE_PUNCH_EXTERNAL)
-    MediaPlayerPrivateHolePunchDummy::registerMediaEngine(addMediaEngine);
-#endif
-
 #if ENABLE(MEDIA_STREAM) && USE(GSTREAMER) && USE(OPENWEBRTC)
     MediaPlayerPrivateGStreamerOwr::registerMediaEngine(addMediaEngine);
 #endif
@@ -244,6 +240,10 @@ static void buildMediaEnginesVector()
 
 #if ENABLE(VIDEO) && USE(GSTREAMER) && ENABLE(MEDIA_SOURCE) && ENABLE(VIDEO_TRACK)
     MediaPlayerPrivateGStreamerMSE::registerMediaEngine(addMediaEngine);
+#endif
+
+#if USE(HOLE_PUNCH_EXTERNAL)
+    MediaPlayerPrivateHolePunch::registerMediaEngine(addMediaEngine);
 #endif
 
     haveMediaEnginesVector = true;

--- a/Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunch.cpp
+++ b/Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunch.cpp
@@ -25,7 +25,7 @@
  */
 
 #include "config.h"
-#include "MediaPlayerPrivateHolePunchDummy.h"
+#include "MediaPlayerPrivateHolePunch.h"
 
 #include "MediaPlayer.h"
 #include "NotImplemented.h"
@@ -89,12 +89,12 @@ static HashSet<String, ASCIICaseInsensitiveHash>& mimeTypeCache()
     return cache;
 }
 
-void MediaPlayerPrivateHolePunchDummy::getSupportedTypes(HashSet<String, ASCIICaseInsensitiveHash>& types)
+void MediaPlayerPrivateHolePunch::getSupportedTypes(HashSet<String, ASCIICaseInsensitiveHash>& types)
 {
     types = mimeTypeCache();
 }
 
-MediaPlayer::SupportsType MediaPlayerPrivateHolePunchDummy::supportsType(const MediaEngineSupportParameters& parameters)
+MediaPlayer::SupportsType MediaPlayerPrivateHolePunch::supportsType(const MediaEngineSupportParameters& parameters)
 {
     if (parameters.type.isNull() || parameters.type.isEmpty())
         return MediaPlayer::IsNotSupported;
@@ -102,19 +102,19 @@ MediaPlayer::SupportsType MediaPlayerPrivateHolePunchDummy::supportsType(const M
     return mimeTypeCache().contains(parameters.type) ? MediaPlayer::IsSupported : MediaPlayer::IsNotSupported;
 }
 
-void MediaPlayerPrivateHolePunchDummy::registerMediaEngine(MediaEngineRegistrar registrar)
+void MediaPlayerPrivateHolePunch::registerMediaEngine(MediaEngineRegistrar registrar)
 {
-    registrar([](MediaPlayer* player) { return std::make_unique<MediaPlayerPrivateHolePunchDummy>(player); },
+    registrar([](MediaPlayer* player) { return std::make_unique<MediaPlayerPrivateHolePunch>(player); },
             getSupportedTypes, supportsType, 0, 0, 0,
               [](const String&, const String&) { return false; });
 }
 
-MediaPlayerPrivateHolePunchDummy::MediaPlayerPrivateHolePunchDummy(MediaPlayer* player)
+MediaPlayerPrivateHolePunch::MediaPlayerPrivateHolePunch(MediaPlayer* player)
     : MediaPlayerPrivateHolePunchBase(player)
 {
 }
 
-MediaPlayerPrivateHolePunchDummy::~MediaPlayerPrivateHolePunchDummy()
+MediaPlayerPrivateHolePunch::~MediaPlayerPrivateHolePunch()
 {
 }
 

--- a/Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunch.h
+++ b/Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunch.h
@@ -24,17 +24,17 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef MediaPlayerPrivateHolePunchDummy_h
-#define MediaPlayerPrivateHolePunchDummy_h
+#ifndef MediaPlayerPrivateHolePunch_h
+#define MediaPlayerPrivateHolePunch_h
 
 #include "MediaPlayerPrivateHolePunchBase.h"
 
 namespace WebCore {
 
-class MediaPlayerPrivateHolePunchDummy : public MediaPlayerPrivateHolePunchBase {
+class MediaPlayerPrivateHolePunch : public MediaPlayerPrivateHolePunchBase {
 public:
-    explicit MediaPlayerPrivateHolePunchDummy(MediaPlayer*);
-    ~MediaPlayerPrivateHolePunchDummy();
+    explicit MediaPlayerPrivateHolePunch(MediaPlayer*);
+    ~MediaPlayerPrivateHolePunch();
 
     static void registerMediaEngine(MediaEngineRegistrar);
 

--- a/Source/WebCore/platform/mediastream/qt5webrtc/MediaPlayerPrivateQt5WebRTC.cpp
+++ b/Source/WebCore/platform/mediastream/qt5webrtc/MediaPlayerPrivateQt5WebRTC.cpp
@@ -43,6 +43,13 @@ private:
 
 namespace WebCore {
 
+void MediaPlayerPrivateQt5WebRTC::notifyLoadFailed()
+{
+    m_networkState = MediaPlayer::FormatError;
+    m_readyState = MediaPlayer::HaveNothing;
+    m_player->networkStateChanged();
+}
+
 void MediaPlayerPrivateQt5WebRTC::getSupportedTypes(HashSet<String, ASCIICaseInsensitiveHash>& types)
 {
     static NeverDestroyed<HashSet<String, ASCIICaseInsensitiveHash>> cache;
@@ -65,6 +72,8 @@ void MediaPlayerPrivateQt5WebRTC::registerMediaEngine(MediaEngineRegistrar regis
 
 MediaPlayerPrivateQt5WebRTC::MediaPlayerPrivateQt5WebRTC(MediaPlayer* player)
     : m_player(player)
+    , m_networkState(MediaPlayer::Empty)
+    , m_readyState(MediaPlayer::HaveEnoughData)
     , m_size(320, 240)
 {
 #if USE(COORDINATED_GRAPHICS_THREADED)

--- a/Source/WebCore/platform/mediastream/qt5webrtc/MediaPlayerPrivateQt5WebRTC.h
+++ b/Source/WebCore/platform/mediastream/qt5webrtc/MediaPlayerPrivateQt5WebRTC.h
@@ -29,9 +29,9 @@ public:
     bool hasVideo() const override { return true; }
     bool hasAudio() const override { return true; }
 
-    void load(const String&) override { }
+    void load(const String&) override { notifyLoadFailed(); }
 #if ENABLE(MEDIA_SOURCE)
-    void load(const String&, MediaSourcePrivateClient*) override { }
+    void load(const String&, MediaSourcePrivateClient*) override { notifyLoadFailed(); }
 #endif
 #if ENABLE(MEDIA_STREAM)
     void load(MediaStreamPrivate&) override;
@@ -54,8 +54,8 @@ public:
     void setPosition(const IntPoint&) override;
     void paint(GraphicsContext&, const FloatRect&) override { }
 
-    MediaPlayer::NetworkState networkState() const override {return MediaPlayer::Empty; }
-    MediaPlayer::ReadyState readyState() const { return MediaPlayer::HaveEnoughData; }
+    MediaPlayer::NetworkState networkState() const override {return m_networkState; }
+    MediaPlayer::ReadyState readyState() const { return m_readyState; }
 
     FloatSize naturalSize() const override;
 
@@ -80,6 +80,7 @@ public:
     void punchHole(int width, int height) override;
 
   private:
+    void notifyLoadFailed();
     static void getSupportedTypes(HashSet<String, ASCIICaseInsensitiveHash>&);
     static MediaPlayer::SupportsType supportsType(const MediaEngineSupportParameters&);
     void updateVideoRectangle();
@@ -96,6 +97,8 @@ public:
     std::unique_ptr<WRTCInt::RTCVideoRenderer> m_rtcRenderer;
 
     MediaPlayer* m_player;
+    MediaPlayer::NetworkState m_networkState;
+    MediaPlayer::ReadyState m_readyState;
     IntSize m_size;
     IntPoint m_position;
     MediaStreamPrivate* m_stream {nullptr};


### PR DESCRIPTION
When contenttype is empty/not available, MediaPlayer::loadWithNextMediaEngine
is using nextMediaEngine method to select the media engine.
nextMediaEngine basically returns the first media engine from the media engines vector.
Currently, if WebRTC or hole punch gstreamer is enabled,
it will be selected and the playback will fail.
The patch fixes this by setting network to failed state for inappropriate engines.