### PR TITLE
Fixed black screen before opening the page with linked stylesheets

### DIFF
--- a/Source/WebKit2/WebProcess/WebPage/wpe/DrawingAreaWPE.cpp
+++ b/Source/WebKit2/WebProcess/WebPage/wpe/DrawingAreaWPE.cpp
@@ -69,6 +69,9 @@ bool DrawingAreaWPE::forceRepaintAsync(uint64_t callbackID)
 void DrawingAreaWPE::setLayerTreeStateIsFrozen(bool frozen)
 {
     m_layerTreeStateIsFrozen = frozen;
+
+    if (m_layerTreeHost)
+        m_layerTreeHost->setLayerFlushSchedulingEnabled(!frozen);
 }
 
 void DrawingAreaWPE::setPaintingEnabled(bool)


### PR DESCRIPTION
If a page contains a link to stylesheets like:
<link rel="stylesheet" type="text/css" href="styles.css"/>
there could be a black screen (a blink) before the page is shown.
It is caused due to painting is triggered before css file is loaded.

The flow:
1. Click to a link/open web page with rel="stylesheets"
2. Somewhere ThreadedCoordinatedLayerTreeHost::scheduleLayerFlush() is called
   to set a timer to flush layers.
3. WebCore::HTMLLinkElement::process is called where addPendingSheet() increases number of pending sheets.
4. ThreadedCoordinatedLayerTreeHost::performScheduledLayerFlush() timer is shot
5. StyleTreeResolver::styleForElement() where it checks m_document.haveStylesheetsLoaded()
   and returns placeholder RenderStyle (which is hidden)
6. CompositingCoordinator::flushPendingLayerChanges commits scene's state.
7. CoordinatedGraphicsScene::paintToGraphicsContext paints to gl context.
8. Black screen (due to default placeholder hidden style for html element)) is shown.