### PR TITLE
Fixing a seek to unbuffered range (MSE)

### DIFF
--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -877,8 +877,8 @@ void SourceBuffer::evictCodedFrames(size_t newDataSize)
     // currenTime whichever we hit first.
     auto buffered = m_buffered->ranges();
     size_t currentTimeRange = buffered.find(currentTime);
-    if (currentTimeRange == notFound || currentTimeRange == buffered.length() - 1) {
         LOG(MediaSource, "SourceBuffer::evictCodedFrames(%p) - evicted %zu bytes but FAILED to free enough", this, initialBufferedSize - extraMemoryCost());
+    if (currentTimeRange == buffered.length() - 1) {
         return;
     }
 


### PR DESCRIPTION
This patch is fixing a seek to unbuffered range just before the buffered one.
For example, if range [120.0, 300.0) was buffered, seek to 115.0 would fail
without the fix, since evictCodedFrames will return without actually evicting
anything, and appendBufferInternal will print
"buffer full, failing with QUOTA_EXCEEDED_ERR error".