### PR TITLE
Debug build fixes

### DIFF
--- a/Source/JavaScriptCore/heap/HeapInlines.h
+++ b/Source/JavaScriptCore/heap/HeapInlines.h
@@ -258,7 +258,7 @@ inline void* Heap::allocateAuxiliary(JSCell* intendedOwner, size_t bytes)
 #endif
 #if ENABLE(JS_MEMORY_TRACKING)
     if (Options::showAllocationBacktraces())
-        HeapStatistics::showAllocBacktrace(this, bytes, *outPtr);
+        HeapStatistics::showAllocBacktrace(this, bytes, result);
 #endif
     return result;
 }
@@ -270,6 +270,10 @@ inline void* Heap::tryAllocateAuxiliary(JSCell* intendedOwner, size_t bytes)
     dataLogF("JSC GC allocating %lu bytes of auxiliary for %p: %p.\n", bytes, intendedOwner, result);
 #else
     UNUSED_PARAM(intendedOwner);
+#endif
+#if ENABLE(JS_MEMORY_TRACKING)
+    if (Options::showAllocationBacktraces())
+        HeapStatistics::showAllocBacktrace(this, bytes, result);
 #endif
     return result;
 }
@@ -284,7 +288,7 @@ inline void* Heap::tryAllocateAuxiliary(GCDeferralContext* deferralContext, JSCe
 #endif
 #if ENABLE(JS_MEMORY_TRACKING)
     if (Options::showAllocationBacktraces())
-        HeapStatistics::showAllocBacktrace(this, newSize, *ptr);
+        HeapStatistics::showAllocBacktrace(this, bytes, result);
 #endif
     return result;
 }

--- a/Source/ThirdParty/WPE-platform/src/bcm-nexus/renderer-backend.cpp
+++ b/Source/ThirdParty/WPE-platform/src/bcm-nexus/renderer-backend.cpp
@@ -31,6 +31,7 @@
 #include "ipc-bcmnexus.h"
 #include <EGL/egl.h>
 #include <cstring>
+#include <stdio.h>
 #include <refsw/nexus_config.h>
 #include <refsw/nexus_platform.h>
 #include <refsw/nexus_display.h>

--- a/Source/ThirdParty/WPE-platform/src/bcm-nexus/view-backend.cpp
+++ b/Source/ThirdParty/WPE-platform/src/bcm-nexus/view-backend.cpp
@@ -34,6 +34,7 @@
 #include <array>
 #include <cassert>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <tuple>
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -107,7 +107,7 @@ AppendPipeline::AppendPipeline(Ref<MediaSourceClientGStreamerMSE> mediaSourceCli
 
     // FIXME: give a name to the pipeline, maybe related with the track it's managing.
     // The track name is still unknown at this time, though.
-    m_pipeline = adoptGRef(gst_pipeline_new(nullptr));
+    m_pipeline = gst_pipeline_new(nullptr);
 
     m_bus = adoptGRef(gst_pipeline_get_bus(GST_PIPELINE(m_pipeline.get())));
     gst_bus_add_signal_watch_full(m_bus.get(), G_PRIORITY_HIGH + 30);

--- a/Source/WebCore/platform/graphics/gstreamer/mse/PlaybackPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/PlaybackPipeline.cpp
@@ -133,7 +133,7 @@ MediaSourcePrivate::AddStatus PlaybackPipeline::addSourceBuffer(RefPtr<SourceBuf
     g_object_set(G_OBJECT(stream->appsrc), "block", FALSE, "min-percent", 20, nullptr);
 
     GST_OBJECT_LOCK(m_webKitMediaSrc.get());
-    priv->streams.prepend(stream);
+    priv->streams.append(stream);
     GST_OBJECT_UNLOCK(m_webKitMediaSrc.get());
 
     gst_bin_add(GST_BIN(m_webKitMediaSrc.get()), stream->appsrc);
@@ -149,17 +149,9 @@ void PlaybackPipeline::removeSourceBuffer(RefPtr<SourceBufferPrivateGStreamer> s
     GST_DEBUG_OBJECT(m_webKitMediaSrc.get(), "Element removed from MediaSource");
     GST_OBJECT_LOCK(m_webKitMediaSrc.get());
     WebKitMediaSrcPrivate* priv = m_webKitMediaSrc->priv;
-    Stream* stream = nullptr;
-    Deque<Stream*>::iterator streamPosition = priv->streams.begin();
-
-    for (; streamPosition != priv->streams.end(); ++streamPosition) {
-        if ((*streamPosition)->sourceBuffer == sourceBufferPrivate.get()) {
-            stream = *streamPosition;
-            break;
-        }
-    }
+    Stream* stream = getStreamBySourceBufferPrivate(m_webKitMediaSrc.get(), sourceBufferPrivate.get());
     if (stream)
-        priv->streams.remove(streamPosition);
+        priv->streams.removeFirst(stream);
     GST_OBJECT_UNLOCK(m_webKitMediaSrc.get());
 
     if (stream)

--- a/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
@@ -268,7 +268,7 @@ void webKitMediaSrcFinalize(GObject* object)
     WebKitMediaSrc* source = WEBKIT_MEDIA_SRC(object);
     WebKitMediaSrcPrivate* priv = source->priv;
 
-    Deque<Stream*> oldStreams;
+    Vector<Stream*> oldStreams;
     source->priv->streams.swap(oldStreams);
 
     for (Stream* stream : oldStreams)

--- a/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamerPrivate.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamerPrivate.h
@@ -97,7 +97,7 @@ struct _WebKitMediaSrcPrivate {
     Lock streamLock;
     Condition streamCondition;
 
-    Deque<Stream*> streams;
+    Vector<Stream*> streams;
     GUniquePtr<gchar> location;
     int numberOfAudioStreams;
     int numberOfVideoStreams;

--- a/Source/WebCore/platform/wpe/RenderThemeWPE.cpp
+++ b/Source/WebCore/platform/wpe/RenderThemeWPE.cpp
@@ -52,7 +52,7 @@ String RenderThemeWPE::extraDefaultStyleSheet()
 #if ENABLE(VIDEO)
 String RenderThemeWPE::mediaControlsStyleSheet()
 {
-    return ASCIILiteral(mediaControlsBaseUserAgentStyleSheet);
+    return String(mediaControlsBaseUserAgentStyleSheet, sizeof(mediaControlsBaseUserAgentStyleSheet));
 }
 
 String RenderThemeWPE::mediaControlsScript()


### PR DESCRIPTION
This contains fixes both for compiling and running the debug build.

Two patches from @eocanha have been rebased from master to avoid assertions failures at runtime.

One patch fix JSC build in debug mode for the JS_MEMORY_TRACKING code that was not updated to latest JSC changes.

Two build fixes are specific to the bcm-nexus backend.

The RenderThemeWPE patch fixes an assertion failure (and buffer over-read), it has also been reported and integrated upstream for the EFL port which was probably the initial source of this function.

More patches are needed for a debug build, but some are already in newer WebKit, I would prefer to wait for a new WPE rebase to check what is still needed.