### PR TITLE
Skip condition wait to avoid deadlock

### DIFF
--- a/Source/WTF/wtf/generic/WorkQueueGeneric.cpp
+++ b/Source/WTF/wtf/generic/WorkQueueGeneric.cpp
@@ -71,7 +71,8 @@ void WorkQueue::platformInvalidate()
         LockHolder locker(m_terminateRunLoopConditionMutex);
         if (m_runLoop) {
             m_runLoop->stop();
-            m_terminateRunLoopCondition.wait(m_terminateRunLoopConditionMutex);
+            if(m_runLoop != &RunLoop::current())
+                m_terminateRunLoopCondition.wait(m_terminateRunLoopConditionMutex);
         }
     }
 


### PR DESCRIPTION
This happens when platformInvalidate() is called from same thread as that of platformInitialize()