### PR TITLE
WorkQueueGeneric's platformInvalidate() can deadlock when called on RunLoop's thread

### DIFF
--- a/Source/WTF/wtf/WorkQueue.h
+++ b/Source/WTF/wtf/WorkQueue.h
@@ -116,8 +116,6 @@ private:
     Lock m_initializeRunLoopConditionMutex;
     Condition m_initializeRunLoopCondition;
     RunLoop* m_runLoop;
-    Lock m_terminateRunLoopConditionMutex;
-    Condition m_terminateRunLoopCondition;
 #endif
 };
 

--- a/Source/WTF/wtf/generic/WorkQueueGeneric.cpp
+++ b/Source/WTF/wtf/generic/WorkQueueGeneric.cpp
@@ -56,25 +56,14 @@ void WorkQueue::platformInitialize(const char* name, Type, QOS)
             m_initializeRunLoopCondition.notifyOne();
         }
         m_runLoop->run();
-        {
-            LockHolder locker(m_terminateRunLoopConditionMutex);
-            m_runLoop = nullptr;
-            m_terminateRunLoopCondition.notifyOne();
-        }
     });
     m_initializeRunLoopCondition.wait(m_initializeRunLoopConditionMutex);
 }
 
 void WorkQueue::platformInvalidate()
 {
-    {
-        LockHolder locker(m_terminateRunLoopConditionMutex);
-        if (m_runLoop) {
-            m_runLoop->stop();
-            m_terminateRunLoopCondition.wait(m_terminateRunLoopConditionMutex);
-        }
-    }
-
+    if (m_runLoop)
+        m_runLoop->stop();
     if (m_workQueueThread) {
         detachThread(m_workQueueThread);
         m_workQueueThread = 0;


### PR DESCRIPTION
Cherry-Picked from Master