### PR TITLE
Fixed race condition in CoordinatedLayerTreeHost::scheduleLayerFlush

### DIFF
--- a/Source/WebKit2/Shared/CoordinatedGraphics/CoordinatedGraphicsScene.cpp
+++ b/Source/WebKit2/Shared/CoordinatedGraphics/CoordinatedGraphicsScene.cpp
@@ -629,6 +629,9 @@ void CoordinatedGraphicsScene::commitSceneState(const CoordinatedGraphicsState& 
 
     commitPendingBackingStoreOperations();
     removeReleasedImageBackingsIfNeeded();
+
+    // The pending tiles state is on its way for the screen, tell the web process to render the next one.
+    renderNextFrame();
 }
 
 void CoordinatedGraphicsScene::renderNextFrame()


### PR DESCRIPTION
1. When scene is committed (CoordinatedLayerTreeHost::commitSceneState)
   CoordinatedLayerTreeHost.m_isWaitingForRenderer is set
2. Which prevents scheduling the timer to flush the layer in CoordinatedLayerTreeHost::scheduleLayerFlush
3. CoordinatedLayerTreeHost::renderNextFrame() must be called to flush layer
4. ThreadedCompositor::frameComplete() must be called to call CoordinatedLayerTreeHost::renderNextFrame()
   but sometimes frameComplete is not called and UI is not refreshing anymore even if anything else is working correctly.
   CoordinatedLayerTreeHost::scheduleLayerFlush() is usually called but failed to flush layers.