### PR TITLE
During asynchronous state change, play state might be not updated. (#…

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -707,8 +707,12 @@ bool MediaPlayerPrivateGStreamer::paused() const
     if (m_playbackRatePause)
         return false;
 
-    GstState state;
-    gst_element_get_state(m_pipeline.get(), &state, nullptr, 0);
+    GstState state, pending;
+    GstStateChangeReturn result = gst_element_get_state(m_pipeline.get(), &state, &pending, 0);
+
+    if (result == GST_STATE_CHANGE_ASYNC)
+        state = pending;
+
     return state <= GST_STATE_PAUSED;
 }
 


### PR DESCRIPTION
…183)

This commit tries to fix a situation when WebKit doesn't see the state change immediately because it's still not completed. If you quickly press play-pause-play-pause on YouTube, you can get into the situation where pipeline is playing but UI is showing pause state. That might happen if gst_element_get_state() returns ASYNC, but "current" will be the old state which is changing.
The issue is reproducible pressing the space key with ~1 second intervals for a couple of times.