### PR TITLE
Fixed sounds within navigation on youtube.com/tv

### DIFF
--- a/Source/WebCore/platform/audio/gstreamer/AudioFileReaderGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioFileReaderGStreamer.cpp
@@ -325,6 +325,12 @@ void AudioFileReader::decodeAudioForBusCreation()
     }
 
     m_decodebin = gst_element_factory_make("decodebin", "decodebin");
+#if PLATFORM(BROADCOM)
+    static GstStaticCaps default_raw_caps = GST_STATIC_CAPS("audio/x-brcm-native; video/x-brcm-native");
+    g_object_set(m_decodebin.get(), "caps", gst_static_caps_get (&default_raw_caps), nullptr);
+    auto cb = [](AudioFileReader* reader) {gst_element_set_state(reader->m_pipeline.get(), GST_STATE_PLAYING);};
+    g_signal_connect_swapped(m_decodebin.get(), "no-more-pads", G_CALLBACK(static_cast<void(*)(AudioFileReader*)>(cb)), this);
+#endif
     g_signal_connect_swapped(m_decodebin.get(), "pad-added", G_CALLBACK(decodebinPadAddedCallback), this);
 
     gst_bin_add_many(GST_BIN(m_pipeline.get()), source, m_decodebin.get(), NULL);


### PR DESCRIPTION
The problem there due to decodebin expects to see audio/x-raw caps to stop
looking for new decoders.
But broadcom plugins return audio/x-brcm-native instead.
This leads an error:
No suitable plugins found

Also there is another problem with piple line when
no-more-pads event is not emitted for deinterleave element.
Which will never start playing which fixed by ignoring the element
and starting playback if this event is emitted by decodebin instead.