### PR TITLE
[wpe-platform] Adding LG WPE patch for Wayland/Weston

### DIFF
--- a/Source/ThirdParty/WPE-platform/src/wayland-egl/renderer-backend.cpp
+++ b/Source/ThirdParty/WPE-platform/src/wayland-egl/renderer-backend.cpp
@@ -97,13 +97,14 @@ EGLTarget::EGLTarget(struct wpe_renderer_backend_egl_target* target, int hostFd)
     : target(target)
 {
     ipcClient.initialize(*this, hostFd);
+    Wayland::EventDispatcher::singleton().setIPC( ipcClient );
 }
 
 void EGLTarget::initialize(Backend& backend, uint32_t width, uint32_t height)
 {
     m_backend = &backend;
-
     m_surface = wl_compositor_create_surface(m_backend->display.interfaces().compositor);
+
     if (!m_surface) {
         fprintf(stderr, "EGLTarget: unable to create wayland surface\n");
         return;
@@ -114,10 +115,10 @@ void EGLTarget::initialize(Backend& backend, uint32_t width, uint32_t height)
         if (m_shellSurface) {
             wl_shell_surface_add_listener(m_shellSurface,
                                           &shell_surface_listener, NULL);
-            wl_shell_surface_set_toplevel(m_shellSurface);
+            // wl_shell_surface_set_toplevel(m_shellSurface);
+            wl_shell_surface_set_fullscreen(m_shellSurface, WL_SHELL_SURFACE_FULLSCREEN_METHOD_DEFAULT, 0, NULL);
         }
     }
-
     struct wl_region *region;
     region = wl_compositor_create_region(m_backend->display.interfaces().compositor);
     wl_region_add(region, 0, 0,

--- a/Source/ThirdParty/WPE-platform/src/wayland/display.h
+++ b/Source/ThirdParty/WPE-platform/src/wayland/display.h
@@ -33,6 +33,7 @@
 #include <wpe/input.h>
 #include <xkbcommon/xkbcommon-compose.h>
 #include <xkbcommon/xkbcommon.h>
+#include "ipc.h"
 
 struct wpe_view_backend;
 
@@ -53,6 +54,28 @@ struct wl_shell;
 typedef struct _GSource GSource;
 
 namespace Wayland {
+
+class EventDispatcher
+{
+public:
+    static EventDispatcher& singleton();
+    void sendEvent( wpe_input_axis_event& event );
+    void sendEvent( wpe_input_pointer_event& event );
+    void sendEvent( wpe_input_touch_event& event );
+    void sendEvent( wpe_input_keyboard_event& event );
+    void setIPC( IPC::Client& ipcClient );
+    enum MsgType
+    {
+	AXIS = 0x30,
+	POINTER,
+	TOUCH,
+	KEYBOARD
+    };
+private:
+    EventDispatcher() {};
+    ~EventDispatcher() {};
+    IPC::Client * m_ipc;
+};
 
 class Display {
 public:


### PR DESCRIPTION
PR created on behalf of LGI. Patch is created by the LGI team to solve:
- Input device (IR/Keyboard/Mouse) doesn't work for WPE. But works for Weston.
- Video window is incorrect. Size of the video window is a contant value and position is random.
- WPE browser cannot be set to full screen due the issue #5.c.
