### PR TITLE
Revert "Enable important log when built in Release mode."

### DIFF
--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -523,7 +523,7 @@ void SourceBuffer::appendBufferInternal(unsigned char* data, unsigned size, Exce
 #if USE(GSTREAMER)
     // 5. If the buffer full flag equals true, then throw a QUOTA_EXCEEDED_ERR exception and abort these step.
     if (m_bufferFull) {
-        RELEASE_LOG_ERROR("SourceBuffer::appendBufferInternal(%p) -  buffer full, failing with QUOTA_EXCEEDED_ERR error", this);
+        LOG(MediaSource, "SourceBuffer::appendBufferInternal(%p) -  buffer full, failing with QUOTA_EXCEEDED_ERR error", this);
         ec = QUOTA_EXCEEDED_ERR;
         return;
     }


### PR DESCRIPTION
Reverts Metrological/WebKitForWayland#207
This approach doesn't look like a recommended way to log something unconditionally.