### PR TITLE
Session based Cookies code changes

### DIFF
--- a/Source/WebCore/platform/network/CookieStorage.h
+++ b/Source/WebCore/platform/network/CookieStorage.h
@@ -23,17 +23,16 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef CookieStorage_h
-#define CookieStorage_h
+#pragma once
+
+#include <functional>
 
 namespace WebCore {
 
-// These are always observing the shared cookie storage, even when in private browsing mode.
+class NetworkStorageSession;
 
-typedef void(*CookieChangeCallbackPtr)();
-WEBCORE_EXPORT void startObservingCookieChanges(CookieChangeCallbackPtr);
-WEBCORE_EXPORT void stopObservingCookieChanges();
+WEBCORE_EXPORT void startObservingCookieChanges(const NetworkStorageSession&, std::function<void ()>&&);
+WEBCORE_EXPORT void stopObservingCookieChanges(const NetworkStorageSession&);
 
 }
 
-#endif

--- a/Source/WebCore/platform/network/NetworkStorageSession.h
+++ b/Source/WebCore/platform/network/NetworkStorageSession.h
@@ -74,6 +74,8 @@ public:
     SoupNetworkSession* soupNetworkSession() const { return m_session.get(); };
     SoupNetworkSession& getOrCreateSoupNetworkSession() const;
     SoupCookieJar* cookieStorage() const;
+    void setCookieStorage(SoupCookieJar*);
+    void setCookieObserverHandler(Function<void ()>&&);
     void getCredentialFromPersistentStorage(const ProtectionSpace&, Function<void (Credential&&)> completionHandler);
     void saveCredentialToPersistentStorage(const ProtectionSpace&, const Credential&);
 #else
@@ -90,8 +92,11 @@ private:
 #if PLATFORM(COCOA) || USE(CFURLCONNECTION)
     RetainPtr<CFURLStorageSessionRef> m_platformSession;
 #elif USE(SOUP)
+    static void cookiesDidChange(NetworkStorageSession*);
+
     mutable std::unique_ptr<SoupNetworkSession> m_session;
-    mutable GRefPtr<SoupCookieJar> m_cookieStorage;
+    GRefPtr<SoupCookieJar> m_cookieStorage;
+    Function<void ()> m_cookieObserverHandler;
 #if USE(LIBSECRET)
     Function<void (Credential&&)> m_persisentStorageCompletionHandler;
     GRefPtr<GCancellable> m_persisentStorageCancellable;

--- a/Source/WebCore/platform/network/cf/CookieStorageCFNet.cpp
+++ b/Source/WebCore/platform/network/cf/CookieStorageCFNet.cpp
@@ -27,7 +27,9 @@
 #include "CookieStorage.h"
 
 #include "NetworkStorageSession.h"
+#include <wtf/HashMap.h>
 #include <wtf/MainThread.h>
+#include <wtf/NeverDestroyed.h>
 
 #if PLATFORM(COCOA)
 #include "WebCoreSystemInterface.h"
@@ -41,12 +43,17 @@ namespace WebCore {
 
 #if PLATFORM(WIN)
 
-static CookieChangeCallbackPtr cookieChangeCallback;
-
-static void notifyCookiesChanged(CFHTTPCookieStorageRef, void *)
+static HashMap<CFHTTPCookieStorageRef, std::function<void ()>>& cookieChangeCallbackMap()
 {
-    callOnMainThread([] {
-        cookieChangeCallback();
+    static NeverDestroyed<HashMap<CFHTTPCookieStorageRef, std::function<void ()>>> map;
+    return map;
+}
+
+static void notifyCookiesChanged(CFHTTPCookieStorageRef cookieStorage, void *)
+{
+    callOnMainThread([cookieStorage] {
+        if (auto callback = cookieChangeCallbackMap().get(cookieStorage))
+            callback();
     });
 }
 
@@ -61,34 +68,34 @@ static inline CFRunLoopRef cookieStorageObserverRunLoop()
     return loaderRunLoop();
 }
 
-void startObservingCookieChanges(CookieChangeCallbackPtr callback)
+void startObservingCookieChanges(const NetworkStorageSession& storageSession, std::function<void ()>&& callback)
 {
     ASSERT(isMainThread());
-
-    ASSERT(!cookieChangeCallback);
-    cookieChangeCallback = callback;
 
     CFRunLoopRef runLoop = cookieStorageObserverRunLoop();
     ASSERT(runLoop);
 
-    RetainPtr<CFHTTPCookieStorageRef> cookieStorage = NetworkStorageSession::defaultStorageSession().cookieStorage();
+    RetainPtr<CFHTTPCookieStorageRef> cookieStorage = storageSession.cookieStorage();
     ASSERT(cookieStorage);
+
+    ASSERT(cookieChangeCallbackMap().contains(cookieStorage.get()));
+    cookieChangeCallbackMap().add(cookieStorage.get(), WTFMove(callback));
 
     CFHTTPCookieStorageScheduleWithRunLoop(cookieStorage.get(), runLoop, kCFRunLoopCommonModes);
     CFHTTPCookieStorageAddObserver(cookieStorage.get(), runLoop, kCFRunLoopDefaultMode, notifyCookiesChanged, 0);
 }
 
-void stopObservingCookieChanges()
+void stopObservingCookieChanges(const NetworkStorageSession& storageSession)
 {
     ASSERT(isMainThread());
-
-    cookieChangeCallback = 0;
 
     CFRunLoopRef runLoop = cookieStorageObserverRunLoop();
     ASSERT(runLoop);
 
-    RetainPtr<CFHTTPCookieStorageRef> cookieStorage = NetworkStorageSession::defaultStorageSession().cookieStorage();
+    RetainPtr<CFHTTPCookieStorageRef> cookieStorage = storageSession.cookieStorage();
     ASSERT(cookieStorage);
+
+    cookieChangeCallbackMap().remove(cookieStorage.get());
 
     CFHTTPCookieStorageRemoveObserver(cookieStorage.get(), runLoop, kCFRunLoopDefaultMode, notifyCookiesChanged, 0);
     CFHTTPCookieStorageUnscheduleFromRunLoop(cookieStorage.get(), runLoop, kCFRunLoopCommonModes);

--- a/Source/WebCore/platform/network/soup/CookieStorageSoup.cpp
+++ b/Source/WebCore/platform/network/soup/CookieStorageSoup.cpp
@@ -21,39 +21,16 @@
 
 #if USE(SOUP)
 
-#include "NetworkStorageSession.h"
-#include <libsoup/soup.h>
-#include <wtf/HashMap.h>
-#include <wtf/NeverDestroyed.h>
-
 namespace WebCore {
 
-static HashMap<SoupCookieJar*, std::function<void ()>>& cookieChangeCallbackMap()
+void startObservingCookieChanges(const NetworkStorageSession&, std::function<void ()>&&)
 {
-    static NeverDestroyed<HashMap<SoupCookieJar*, std::function<void ()>>> map;
-    return map;
+    ASSERT_NOT_REACHED();
 }
 
-static void soupCookiesChanged(SoupCookieJar* jar)
+void stopObservingCookieChanges(const NetworkStorageSession&)
 {
-    if (auto callback = cookieChangeCallbackMap().get(jar))
-        callback();
-}
-
-void startObservingCookieChanges(const NetworkStorageSession& storageSession, std::function<void ()>&& callback)
-{
-    auto* jar = storageSession.cookieStorage();
-    ASSERT(!cookieChangeCallbackMap().contains(jar));
-    cookieChangeCallbackMap().add(jar, WTFMove(callback));
-    g_signal_connect(jar, "changed", G_CALLBACK(soupCookiesChanged), nullptr);
-}
-
-void stopObservingCookieChanges(const NetworkStorageSession& storageSession)
-{
-    auto* jar = storageSession.cookieStorage();
-    ASSERT(cookieChangeCallbackMap().contains(jar));
-    cookieChangeCallbackMap().remove(jar);
-    g_signal_handlers_disconnect_by_func(jar, reinterpret_cast<void*>(soupCookiesChanged), nullptr);
+    ASSERT_NOT_REACHED();
 }
 
 }

--- a/Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp
+++ b/Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp
@@ -51,10 +51,13 @@ NetworkStorageSession::NetworkStorageSession(SessionID sessionID, std::unique_pt
     : m_sessionID(sessionID)
     , m_session(WTFMove(session))
 {
+    setCookieStorage(m_session ? m_session->cookieJar() : nullptr);
 }
 
 NetworkStorageSession::~NetworkStorageSession()
 {
+    g_signal_handlers_disconnect_matched(m_cookieStorage.get(), G_SIGNAL_MATCH_DATA, 0, 0, nullptr, nullptr, this);
+
 #if USE(LIBSECRET)
     g_cancellable_cancel(m_persisentStorageCancellable.get());
 #endif
@@ -89,23 +92,42 @@ void NetworkStorageSession::switchToNewTestingSession()
 SoupNetworkSession& NetworkStorageSession::getOrCreateSoupNetworkSession() const
 {
     if (!m_session)
-        m_session = std::make_unique<SoupNetworkSession>(cookieStorage());
+        m_session = std::make_unique<SoupNetworkSession>(m_cookieStorage.get());
     return *m_session;
+}
+
+void NetworkStorageSession::cookiesDidChange(NetworkStorageSession* session)
+{
+    if (session->m_cookieObserverHandler)
+        session->m_cookieObserverHandler();
 }
 
 SoupCookieJar* NetworkStorageSession::cookieStorage() const
 {
-    if (m_session) {
-        m_cookieStorage = nullptr;
-        ASSERT(m_session->cookieJar());
-        return m_session->cookieJar();
-    }
+    RELEASE_ASSERT(!m_session || m_session->cookieJar() == m_cookieStorage.get());
+    return m_cookieStorage.get();
+}
 
-    if (!m_cookieStorage) {
+void NetworkStorageSession::setCookieStorage(SoupCookieJar* jar)
+{
+    if (m_cookieStorage)
+        g_signal_handlers_disconnect_matched(m_cookieStorage.get(), G_SIGNAL_MATCH_DATA, 0, 0, nullptr, nullptr, this);
+
+    // We always have a valid cookieStorage.
+    if (jar)
+        m_cookieStorage = jar;
+    else {
         m_cookieStorage = adoptGRef(soup_cookie_jar_new());
         soup_cookie_jar_set_accept_policy(m_cookieStorage.get(), SOUP_COOKIE_JAR_ACCEPT_NO_THIRD_PARTY);
     }
-    return m_cookieStorage.get();
+    g_signal_connect_swapped(m_cookieStorage.get(), "changed", G_CALLBACK(cookiesDidChange), this);
+    if (m_session && m_session->cookieJar() != m_cookieStorage.get())
+        m_session->setCookieJar(m_cookieStorage.get());
+}
+
+void NetworkStorageSession::setCookieObserverHandler(Function<void ()>&& handler)
+{
+    m_cookieObserverHandler = WTFMove(handler);
 }
 
 #if USE(LIBSECRET)

--- a/Source/WebKit2/CMakeLists.txt
+++ b/Source/WebKit2/CMakeLists.txt
@@ -405,6 +405,7 @@ set(WebKit2_SOURCES
 
     UIProcess/API/APIExperimentalFeature.cpp
     UIProcess/API/APIFrameInfo.cpp
+    UIProcess/API/APIHTTPCookieStorage.cpp
     UIProcess/API/APIHitTestResult.cpp
     UIProcess/API/APINavigation.cpp
     UIProcess/API/APINavigationData.cpp
@@ -440,6 +441,7 @@ set(WebKit2_SOURCES
     UIProcess/API/C/WKGeolocationPermissionRequest.cpp
     UIProcess/API/C/WKGeolocationPosition.cpp
     UIProcess/API/C/WKGrammarDetail.cpp
+    UIProcess/API/C/WKHTTPCookieStorageRef.cpp
     UIProcess/API/C/WKHitTestResult.cpp
     UIProcess/API/C/WKIconDatabase.cpp
     UIProcess/API/C/WKInspector.cpp

--- a/Source/WebKit2/NetworkProcess/soup/NetworkSessionSoup.cpp
+++ b/Source/WebKit2/NetworkProcess/soup/NetworkSessionSoup.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "NetworkSessionSoup.h"
 
+#include "NetworkProcess.h"
+#include "WebCookieManager.h"
 #include <WebCore/NetworkStorageSession.h>
 #include <WebCore/SoupNetworkSession.h>
 
@@ -36,10 +38,15 @@ namespace WebKit {
 NetworkSessionSoup::NetworkSessionSoup(SessionID sessionID)
     : NetworkSession(sessionID)
 {
+    networkStorageSession().setCookieObserverHandler([this] {
+        NetworkProcess::singleton().supplement<WebCookieManager>()->notifyCookiesDidChange(m_sessionID);
+    });
 }
 
 NetworkSessionSoup::~NetworkSessionSoup()
 {
+    if (auto* storageSession = NetworkStorageSession::storageSession(m_sessionID))
+        storageSession->setCookieObserverHandler(nullptr);
 }
 
 SoupSession* NetworkSessionSoup::soupSession() const

--- a/Source/WebKit2/PlatformWPE.cmake
+++ b/Source/WebKit2/PlatformWPE.cmake
@@ -455,6 +455,7 @@ set(WPE_INSTALLED_WEBKIT_HEADERS
     ${WEBKIT2_DIR}/UIProcess/API/C/WKFrame.h
     ${WEBKIT2_DIR}/UIProcess/API/C/WKFrameInfoRef.h
     ${WEBKIT2_DIR}/UIProcess/API/C/WKFramePolicyListener.h
+    ${WEBKIT2_DIR}/UIProcess/API/C/WKHTTPCookieStorageRef.h
     ${WEBKIT2_DIR}/UIProcess/API/C/WKHitTestResult.h
     ${WEBKIT2_DIR}/UIProcess/API/C/WKNativeEvent.h
     ${WEBKIT2_DIR}/UIProcess/API/C/WKNavigationActionRef.h

--- a/Source/WebKit2/Shared/API/APIObject.h
+++ b/Source/WebKit2/Shared/API/APIObject.h
@@ -117,6 +117,7 @@ public:
         HitTestResult,
         GeolocationPosition,
         GrammarDetail,
+        HTTPCookieStorage,
         IconDatabase,
         Inspector,
         KeyValueStorageManager,

--- a/Source/WebKit2/Shared/API/c/WKBase.h
+++ b/Source/WebKit2/Shared/API/c/WKBase.h
@@ -111,6 +111,7 @@ typedef const struct OpaqueWKGeolocationManager* WKGeolocationManagerRef;
 typedef const struct OpaqueWKGeolocationPermissionRequest* WKGeolocationPermissionRequestRef;
 typedef const struct OpaqueWKGeolocationPosition* WKGeolocationPositionRef;
 typedef const struct OpaqueWKGrammarDetail* WKGrammarDetailRef;
+typedef const struct OpaqueWKHTTPCookieStorage* WKHTTPCookieStorageRef;
 typedef const struct OpaqueWKHitTestResult* WKHitTestResultRef;
 typedef const struct OpaqueWKIconDatabase* WKIconDatabaseRef;
 typedef const struct OpaqueWKInspector* WKInspectorRef;

--- a/Source/WebKit2/UIProcess/API/APIHTTPCookieStorage.cpp
+++ b/Source/WebKit2/UIProcess/API/APIHTTPCookieStorage.cpp
@@ -50,14 +50,14 @@ void HTTPCookieStorage::deleteAllCookies()
 
 void HTTPCookieStorage::startObservingCookieChanges()
 {
-    m_webPage.process().processPool().supplement<WebKit::WebCookieManagerProxy>()->startObservingCookieChanges(m_webPage.sessionID(), [this] {
+    m_webPage.process().processPool().supplement<WebKit::WebCookieManagerProxy>()->setCookieObserverCallback(m_webPage.sessionID(), [this] {
         m_webPage.cookiesDidChange();
     });
 }
 
 void HTTPCookieStorage::stopObservingCookieChanges()
 {
-    m_webPage.process().processPool().supplement<WebKit::WebCookieManagerProxy>()->stopObservingCookieChanges(m_webPage.sessionID());
+    m_webPage.process().processPool().supplement<WebKit::WebCookieManagerProxy>()->setCookieObserverCallback(m_webPage.sessionID(), nullptr);
 }
 
 void HTTPCookieStorage::setCookies(const Vector<WebCore::Cookie>& cookies)

--- a/Source/WebKit2/UIProcess/API/APIHTTPCookieStorage.cpp
+++ b/Source/WebKit2/UIProcess/API/APIHTTPCookieStorage.cpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2017 Metrological Group B.V.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "APIHTTPCookieStorage.h"
+
+#include "WebCookieManagerProxy.h"
+#include "WebCoreArgumentCoders.h"
+#include "WebPageProxy.h"
+#include "WebProcessPool.h"
+#include <WebCore/Cookie.h>
+
+namespace API {
+
+HTTPCookieStorage::HTTPCookieStorage(WebKit::WebPageProxy& webPage)
+    : m_webPage(webPage)
+{
+}
+
+HTTPCookieStorage::~HTTPCookieStorage()
+{
+}
+
+void HTTPCookieStorage::deleteAllCookies()
+{
+    m_webPage.process().processPool().supplement<WebKit::WebCookieManagerProxy>()->deleteAllCookies(m_webPage.sessionID());
+}
+
+void HTTPCookieStorage::startObservingCookieChanges()
+{
+    m_webPage.process().processPool().supplement<WebKit::WebCookieManagerProxy>()->startObservingCookieChanges(m_webPage.sessionID(), [this] {
+        m_webPage.cookiesDidChange();
+    });
+}
+
+void HTTPCookieStorage::stopObservingCookieChanges()
+{
+    m_webPage.process().processPool().supplement<WebKit::WebCookieManagerProxy>()->stopObservingCookieChanges(m_webPage.sessionID());
+}
+
+void HTTPCookieStorage::setCookies(const Vector<WebCore::Cookie>& cookies)
+{
+    m_webPage.process().processPool().supplement<WebKit::WebCookieManagerProxy>()->setCookies(m_webPage.sessionID(), cookies);
+}
+
+void HTTPCookieStorage::getCookies(std::function<void (API::Array*, WebKit::CallbackBase::Error)> callbackFunction)
+{
+    m_webPage.process().processPool().supplement<WebKit::WebCookieManagerProxy>()->getCookies(m_webPage.sessionID(), WTFMove(callbackFunction));
+}
+
+} // namespace API

--- a/Source/WebKit2/UIProcess/API/APIHTTPCookieStorage.h
+++ b/Source/WebKit2/UIProcess/API/APIHTTPCookieStorage.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2017 Metrological Group B.V.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "APIObject.h"
+#include "GenericCallback.h"
+#include <functional>
+#include <wtf/Vector.h>
+
+namespace WebCore {
+struct Cookie;
+}
+
+namespace WebKit {
+class WebPageProxy;
+};
+
+namespace API {
+
+class HTTPCookieStorage final : public ObjectImpl<Object::Type::HTTPCookieStorage> {
+public:
+    static Ref<HTTPCookieStorage> create(WebKit::WebPageProxy& webPage)
+    {
+        return adoptRef(*new HTTPCookieStorage(webPage));
+    }
+
+    virtual ~HTTPCookieStorage();
+
+    void deleteAllCookies();
+    void startObservingCookieChanges();
+    void stopObservingCookieChanges();
+    void setCookies(const Vector<WebCore::Cookie>&);
+    void getCookies(std::function<void (API::Array*, WebKit::CallbackBase::Error)>);
+
+private:
+    HTTPCookieStorage(WebKit::WebPageProxy&);
+
+    WebKit::WebPageProxy& m_webPage;
+};
+
+} // namespace API

--- a/Source/WebKit2/UIProcess/API/APILoaderClient.h
+++ b/Source/WebKit2/UIProcess/API/APILoaderClient.h
@@ -102,6 +102,8 @@ public:
     virtual void navigationGestureWillEnd(WebKit::WebPageProxy&, bool willNavigate, WebKit::WebBackForwardListItem&) { }
     virtual void navigationGestureDidEnd(WebKit::WebPageProxy&, bool willNavigate, WebKit::WebBackForwardListItem&) { }
 
+    virtual void cookiesDidChange(WebKit::WebPageProxy&) { }
+
 #if ENABLE(NETSCAPE_PLUGIN_API)
     virtual WebKit::PluginModuleLoadPolicy pluginLoadPolicy(WebKit::WebPageProxy&, WebKit::PluginModuleLoadPolicy currentPluginLoadPolicy, API::Dictionary*, WTF::String& /* unavailabilityDescription */) { return currentPluginLoadPolicy; }
     virtual void didFailToInitializePlugin(WebKit::WebPageProxy&, API::Dictionary*) { }

--- a/Source/WebKit2/UIProcess/API/C/WKAPICast.h
+++ b/Source/WebKit2/UIProcess/API/C/WKAPICast.h
@@ -54,6 +54,7 @@ namespace API {
 class ExperimentalFeature;
 class FrameHandle;
 class FrameInfo;
+class HTTPCookieStorage;
 class HitTestResult;
 class Navigation;
 class NavigationAction;
@@ -135,6 +136,7 @@ WK_ADD_API_MAPPING(WKGeolocationManagerRef, WebGeolocationManagerProxy)
 WK_ADD_API_MAPPING(WKGeolocationPermissionRequestRef, GeolocationPermissionRequestProxy)
 WK_ADD_API_MAPPING(WKGeolocationPositionRef, WebGeolocationPosition)
 WK_ADD_API_MAPPING(WKGrammarDetailRef, WebGrammarDetail)
+WK_ADD_API_MAPPING(WKHTTPCookieStorageRef, API::HTTPCookieStorage)
 WK_ADD_API_MAPPING(WKHitTestResultRef, API::HitTestResult)
 WK_ADD_API_MAPPING(WKIconDatabaseRef, WebIconDatabase)
 WK_ADD_API_MAPPING(WKInspectorRef, WebInspectorProxy)

--- a/Source/WebKit2/UIProcess/API/C/WKCookieManager.cpp
+++ b/Source/WebKit2/UIProcess/API/C/WKCookieManager.cpp
@@ -46,17 +46,17 @@ void WKCookieManagerSetClient(WKCookieManagerRef cookieManagerRef, const WKCooki
 
 void WKCookieManagerGetHostnamesWithCookies(WKCookieManagerRef cookieManagerRef, void* context, WKCookieManagerGetCookieHostnamesFunction callback)
 {
-    toImpl(cookieManagerRef)->getHostnamesWithCookies(toGenericCallbackFunction(context, callback));
+    toImpl(cookieManagerRef)->getHostnamesWithCookies(WebCore::SessionID::defaultSessionID(), toGenericCallbackFunction(context, callback));
 }
 
 void WKCookieManagerDeleteCookiesForHostname(WKCookieManagerRef cookieManagerRef, WKStringRef hostname)
 {
-    toImpl(cookieManagerRef)->deleteCookiesForHostname(toImpl(hostname)->string());
+    toImpl(cookieManagerRef)->deleteCookiesForHostname(WebCore::SessionID::defaultSessionID(), toImpl(hostname)->string());
 }
 
 void WKCookieManagerDeleteAllCookies(WKCookieManagerRef cookieManagerRef)
 {
-    toImpl(cookieManagerRef)->deleteAllCookies();
+    toImpl(cookieManagerRef)->deleteAllCookies(WebCore::SessionID::defaultSessionID());
 }
 
 void WKCookieManagerDeleteAllCookiesModifiedAfterDate(WKCookieManagerRef cookieManagerRef, double date)
@@ -64,7 +64,7 @@ void WKCookieManagerDeleteAllCookiesModifiedAfterDate(WKCookieManagerRef cookieM
     using namespace std::chrono;
 
     auto time = system_clock::time_point(duration_cast<system_clock::duration>(duration<double>(date)));
-    toImpl(cookieManagerRef)->deleteAllCookiesModifiedSince(time);
+    toImpl(cookieManagerRef)->deleteAllCookiesModifiedSince(WebCore::SessionID::defaultSessionID(), time);
 }
 
 void WKCookieManagerSetHTTPCookieAcceptPolicy(WKCookieManagerRef cookieManager, WKHTTPCookieAcceptPolicy policy)
@@ -86,20 +86,20 @@ void WKCookieManagerSetCookies(WKCookieManagerRef cookieManager, WKArrayRef cook
     for (size_t i = 0; i < size; ++i)
         passCookies[i] = toImpl(static_cast<WKCookieRef>(WKArrayGetItemAtIndex(cookies, i)))->cookie();
 
-    toImpl(cookieManager)->setCookies(passCookies);
+    toImpl(cookieManager)->setCookies(WebCore::SessionID::defaultSessionID(), passCookies);
 }
 
 void WKCookieManagerGetCookies(WKCookieManagerRef cookieManager, void* context, WKCookieManagerGetCookiesFunction callback)
 {
-    toImpl(cookieManager)->getCookies(toGenericCallbackFunction(context, callback));
+    toImpl(cookieManager)->getCookies(WebCore::SessionID::defaultSessionID(), toGenericCallbackFunction(context, callback));
 }
 
 void WKCookieManagerStartObservingCookieChanges(WKCookieManagerRef cookieManager)
 {
-    toImpl(cookieManager)->startObservingCookieChanges();
+    toImpl(cookieManager)->startObservingCookieChanges(WebCore::SessionID::defaultSessionID());
 }
 
 void WKCookieManagerStopObservingCookieChanges(WKCookieManagerRef cookieManager)
 {
-    toImpl(cookieManager)->stopObservingCookieChanges();
+    toImpl(cookieManager)->stopObservingCookieChanges(WebCore::SessionID::defaultSessionID());
 }

--- a/Source/WebKit2/UIProcess/API/C/WKHTTPCookieStorageRef.cpp
+++ b/Source/WebKit2/UIProcess/API/C/WKHTTPCookieStorageRef.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2017 Metrological Group B.V.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WKHTTPCookieStorageRef.h"
+
+#include "APIHTTPCookieStorage.h"
+#include "APIWebCookie.h"
+#include "WKArray.h"
+#include "WKCookie.h"
+#include <WebCore/Cookie.h>
+
+WKTypeID WKHTTPCookieStorageGetTypeID()
+{
+    return WebKit::toAPI(API::HTTPCookieStorage::APIType);
+}
+
+void WKHTTPCookieStorageDeleteAllCookies(WKHTTPCookieStorageRef cookieStorage)
+{
+    WebKit::toImpl(cookieStorage)->deleteAllCookies();
+}
+
+void WKHTTPCookieStorageSetCookies(WKHTTPCookieStorageRef cookieStorage, WKArrayRef cookies)
+{
+    size_t size = cookies ? WKArrayGetSize(cookies) : 0;
+
+    Vector<WebCore::Cookie> passCookies(size);
+
+    for (size_t i = 0; i < size; ++i)
+        passCookies[i] = WebKit::toImpl(static_cast<WKCookieRef>(WKArrayGetItemAtIndex(cookies, i)))->cookie();
+
+    WebKit::toImpl(cookieStorage)->setCookies(passCookies);
+}
+
+void WKHTTPCookieStorageGetCookies(WKHTTPCookieStorageRef cookieStorage, void* context, WKHTTPCookieStorageGetCookiesFunction callback)
+{
+    WebKit::toImpl(cookieStorage)->getCookies(WebKit::toGenericCallbackFunction(context, callback));
+}
+
+void WKHTTPCookieStorageStartObservingCookieChanges(WKHTTPCookieStorageRef cookieStorage)
+{
+    WebKit::toImpl(cookieStorage)->startObservingCookieChanges();
+}
+
+void WKHTTPCookieStorageStopObservingCookieChanges(WKHTTPCookieStorageRef cookieStorage)
+{
+    WebKit::toImpl(cookieStorage)->stopObservingCookieChanges();
+}

--- a/Source/WebKit2/UIProcess/API/C/WKHTTPCookieStorageRef.h
+++ b/Source/WebKit2/UIProcess/API/C/WKHTTPCookieStorageRef.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2017 Metrological Group B.V.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef WKHTTPCookieStorageRef_h
+#define WKHTTPCookieStorageRef_h
+
+#include <WebKit/WKBase.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+WK_EXPORT WKTypeID WKHTTPCookieStorageGetTypeID();
+
+WK_EXPORT void WKHTTPCookieStorageDeleteAllCookies(WKHTTPCookieStorageRef cookieStorage);
+
+WK_EXPORT void WKHTTPCookieStorageSetCookies(WKHTTPCookieStorageRef cookieStorage, WKArrayRef cookieList);
+
+typedef void (*WKHTTPCookieStorageGetCookiesFunction)(WKArrayRef, WKErrorRef, void*);
+WK_EXPORT void WKHTTPCookieStorageGetCookies(WKHTTPCookieStorageRef cookieStorage, void* context, WKHTTPCookieStorageGetCookiesFunction callback);
+
+WK_EXPORT void WKHTTPCookieStorageStartObservingCookieChanges(WKHTTPCookieStorageRef cookieStorage);
+WK_EXPORT void WKHTTPCookieStorageStopObservingCookieChanges(WKHTTPCookieStorageRef cookieStorage);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* WKHTTPCookieStorageRef_h */

--- a/Source/WebKit2/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit2/UIProcess/API/C/WKPage.cpp
@@ -36,6 +36,7 @@
 #include "APIFrameHandle.h"
 #include "APIFrameInfo.h"
 #include "APIGeometry.h"
+#include "APIHTTPCookieStorage.h"
 #include "APIHitTestResult.h"
 #include "APILoaderClient.h"
 #include "APINavigationAction.h"
@@ -101,7 +102,7 @@ using namespace WebKit;
 
 namespace API {
 template<> struct ClientTraits<WKPageLoaderClientBase> {
-    typedef std::tuple<WKPageLoaderClientV0, WKPageLoaderClientV1, WKPageLoaderClientV2, WKPageLoaderClientV3, WKPageLoaderClientV4, WKPageLoaderClientV5, WKPageLoaderClientV6> Versions;
+    typedef std::tuple<WKPageLoaderClientV0, WKPageLoaderClientV1, WKPageLoaderClientV2, WKPageLoaderClientV3, WKPageLoaderClientV4, WKPageLoaderClientV5, WKPageLoaderClientV6, WKPageLoaderClientV7> Versions;
 };
 
 template<> struct ClientTraits<WKPageNavigationClientBase> {
@@ -1278,6 +1279,12 @@ void WKPageSetPageLoaderClient(WKPageRef pageRef, const WKPageLoaderClientBase* 
         {
             if (m_client.navigationGestureDidEnd)
                 m_client.navigationGestureDidEnd(toAPI(&page), willNavigate, toAPI(&item), m_client.base.clientInfo);
+        }
+
+        void cookiesDidChange(WebPageProxy& page) override
+        {
+            if (m_client.cookiesDidChange)
+                m_client.cookiesDidChange(toAPI(&page), m_client.base.clientInfo);
         }
 
 #if ENABLE(NETSCAPE_PLUGIN_API)
@@ -2832,6 +2839,11 @@ void WKPageSetIgnoresViewportScaleLimits(WKPageRef page, bool ignoresViewportSca
 pid_t WKPageGetProcessIdentifier(WKPageRef page)
 {
     return toImpl(page)->processIdentifier();
+}
+
+WKHTTPCookieStorageRef WKPageGetHTTPCookieStorage(WKPageRef page)
+{
+    return toAPI(&toImpl(page)->httpCookieStorage());
 }
 
 #if ENABLE(NETSCAPE_PLUGIN_API)

--- a/Source/WebKit2/UIProcess/API/C/WKPage.h
+++ b/Source/WebKit2/UIProcess/API/C/WKPage.h
@@ -31,6 +31,7 @@
 #include <WebKit/WKEvent.h>
 #include <WebKit/WKFindOptions.h>
 #include <WebKit/WKGeometry.h>
+#include <WebKit/WKHTTPCookieStorageRef.h>
 #include <WebKit/WKNativeEvent.h>
 #include <WebKit/WKPageContextMenuClient.h>
 #include <WebKit/WKPageDiagnosticLoggingClient.h>
@@ -275,7 +276,7 @@ WK_EXPORT void WKPagePostSynchronousMessageToInjectedBundle(WKPageRef page, WKSt
 
 WK_EXPORT void WKPageSelectContextMenuItem(WKPageRef page, WKContextMenuItemRef item);
 
-
+WK_EXPORT WKHTTPCookieStorageRef WKPageGetHTTPCookieStorage(WKPageRef page);
 
 /* DEPRECATED -  Please use constants from WKPluginInformation instead. */
 

--- a/Source/WebKit2/UIProcess/API/C/WKPageLoaderClient.h
+++ b/Source/WebKit2/UIProcess/API/C/WKPageLoaderClient.h
@@ -462,6 +462,77 @@ typedef struct WKPageLoaderClientV6 {
     WKPageNavigationGestureDidEndCallback                               navigationGestureDidEnd;
 } WKPageLoaderClientV6;
 
+typedef struct WKPageLoaderClientV7 {
+    WKPageLoaderClientBase                                              base;
+
+    // Version 0.
+    WKPageDidStartProvisionalLoadForFrameCallback                       didStartProvisionalLoadForFrame;
+    WKPageDidReceiveServerRedirectForProvisionalLoadForFrameCallback    didReceiveServerRedirectForProvisionalLoadForFrame;
+    WKPageDidFailProvisionalLoadWithErrorForFrameCallback               didFailProvisionalLoadWithErrorForFrame;
+    WKPageDidCommitLoadForFrameCallback                                 didCommitLoadForFrame;
+    WKPageDidFinishDocumentLoadForFrameCallback                         didFinishDocumentLoadForFrame;
+    WKPageDidFinishLoadForFrameCallback                                 didFinishLoadForFrame;
+    WKPageDidFailLoadWithErrorForFrameCallback                          didFailLoadWithErrorForFrame;
+    WKPageDidSameDocumentNavigationForFrameCallback                     didSameDocumentNavigationForFrame;
+    WKPageDidReceiveTitleForFrameCallback                               didReceiveTitleForFrame;
+    WKPageDidFirstLayoutForFrameCallback                                didFirstLayoutForFrame;
+    WKPageDidFirstVisuallyNonEmptyLayoutForFrameCallback                didFirstVisuallyNonEmptyLayoutForFrame;
+    WKPageDidRemoveFrameFromHierarchyCallback                           didRemoveFrameFromHierarchy;
+    WKPageDidDisplayInsecureContentForFrameCallback                     didDisplayInsecureContentForFrame;
+    WKPageDidRunInsecureContentForFrameCallback                         didRunInsecureContentForFrame;
+    WKPageCanAuthenticateAgainstProtectionSpaceInFrameCallback          canAuthenticateAgainstProtectionSpaceInFrame;
+    WKPageDidReceiveAuthenticationChallengeInFrameCallback              didReceiveAuthenticationChallengeInFrame;
+
+    // FIXME: Move to progress client.
+    WKPageLoaderClientCallback                                          didStartProgress;
+    WKPageLoaderClientCallback                                          didChangeProgress;
+    WKPageLoaderClientCallback                                          didFinishProgress;
+
+    // FIXME: These three functions should not be part of this client.
+    WKPageLoaderClientCallback                                          processDidBecomeUnresponsive;
+    WKPageLoaderClientCallback                                          processDidBecomeResponsive;
+    WKPageLoaderClientCallback                                          processDidCrash;
+    WKPageDidChangeBackForwardListCallback                              didChangeBackForwardList;
+    WKPageShouldGoToBackForwardListItemCallback                         shouldGoToBackForwardListItem;
+    WKPageDidFailToInitializePluginCallback_deprecatedForUseWithV0      didFailToInitializePlugin_deprecatedForUseWithV0;
+
+    // Version 1.
+    WKPageDidDetectXSSForFrameCallback                                  didDetectXSSForFrame;
+
+    void*                                                               didNewFirstVisuallyNonEmptyLayout_unavailable;
+
+    WKPageWillGoToBackForwardListItemCallback                           willGoToBackForwardListItem;
+
+    WKPageLoaderClientCallback                                          interactionOccurredWhileProcessUnresponsive;
+    WKPagePluginDidFailCallback_deprecatedForUseWithV1                  pluginDidFail_deprecatedForUseWithV1;
+
+    // Version 2.
+    void                                                                (*didReceiveIntentForFrame_unavailable)(void);
+    void                                                                (*registerIntentServiceForFrame_unavailable)(void);
+
+    WKPageDidLayoutCallback                                             didLayout;
+    WKPagePluginLoadPolicyCallback_deprecatedForUseWithV2               pluginLoadPolicy_deprecatedForUseWithV2;
+    WKPagePluginDidFailCallback                                         pluginDidFail;
+
+    // Version 3.
+    WKPagePluginLoadPolicyCallback                                      pluginLoadPolicy;
+
+    // Version 4.
+    WKPageWebGLLoadPolicyCallback                                       webGLLoadPolicy;
+    WKPageWebGLLoadPolicyCallback                                       resolveWebGLLoadPolicy;
+
+    // Version 5.
+    WKPageShouldKeepCurrentBackForwardListItemInListCallback            shouldKeepCurrentBackForwardListItemInList;
+
+    // Version 6.
+    WKPageNavigationGestureDidBeginCallback                             navigationGestureDidBegin;
+    WKPageNavigationGestureWillEndCallback                              navigationGestureWillEnd;
+    WKPageNavigationGestureDidEndCallback                               navigationGestureDidEnd;
+
+    // Version 7.
+    WKPageLoaderClientCallback                                          cookiesDidChange;
+} WKPageLoaderClientV7;
+
 #ifdef __cplusplus
 }
 #endif

--- a/Source/WebKit2/UIProcess/API/gtk/WebKitCookieManager.cpp
+++ b/Source/WebKit2/UIProcess/API/gtk/WebKitCookieManager.cpp
@@ -55,7 +55,7 @@ enum {
 struct _WebKitCookieManagerPrivate {
     ~_WebKitCookieManagerPrivate()
     {
-        webCookieManager->stopObservingCookieChanges();
+        webCookieManager->stopObservingCookieChanges(WebCore::SessionID::defaultSessionID());
     }
 
     RefPtr<WebCookieManagerProxy> webCookieManager;
@@ -145,7 +145,7 @@ WebKitCookieManager* webkitCookieManagerCreate(WebCookieManagerProxy* webCookieM
         cookiesDidChange
     };
     WKCookieManagerSetClient(toAPI(webCookieManager), &wkCookieManagerClient.base);
-    manager->priv->webCookieManager->startObservingCookieChanges();
+    manager->priv->webCookieManager->startObservingCookieChanges(WebCore::SessionID::defaultSessionID());
 
     return manager;
 }
@@ -169,9 +169,9 @@ void webkit_cookie_manager_set_persistent_storage(WebKitCookieManager* manager, 
     g_return_if_fail(WEBKIT_IS_COOKIE_MANAGER(manager));
     g_return_if_fail(filename);
 
-    manager->priv->webCookieManager->stopObservingCookieChanges();
+    manager->priv->webCookieManager->stopObservingCookieChanges(WebCore::SessionID::defaultSessionID());
     manager->priv->webCookieManager->setCookiePersistentStorage(String::fromUTF8(filename), toSoupCookiePersistentStorageType(storage));
-    manager->priv->webCookieManager->startObservingCookieChanges();
+    manager->priv->webCookieManager->startObservingCookieChanges(WebCore::SessionID::defaultSessionID());
 }
 
 /**
@@ -269,7 +269,7 @@ void webkit_cookie_manager_get_domains_with_cookies(WebKitCookieManager* manager
     g_return_if_fail(WEBKIT_IS_COOKIE_MANAGER(manager));
 
     GTask* task = g_task_new(manager, cancellable, callback, userData);
-    manager->priv->webCookieManager->getHostnamesWithCookies(toGenericCallbackFunction(task, webkitCookieManagerGetDomainsWithCookiesCallback));
+    manager->priv->webCookieManager->getHostnamesWithCookies(WebCore::SessionID::defaultSessionID(), toGenericCallbackFunction(task, webkitCookieManagerGetDomainsWithCookiesCallback));
 }
 
 /**
@@ -305,7 +305,7 @@ void webkit_cookie_manager_delete_cookies_for_domain(WebKitCookieManager* manage
     g_return_if_fail(WEBKIT_IS_COOKIE_MANAGER(manager));
     g_return_if_fail(domain);
 
-    manager->priv->webCookieManager->deleteCookiesForHostname(String::fromUTF8(domain));
+    manager->priv->webCookieManager->deleteCookiesForHostname(WebCore::SessionID::defaultSessionID(), String::fromUTF8(domain));
 }
 
 /**
@@ -318,5 +318,5 @@ void webkit_cookie_manager_delete_all_cookies(WebKitCookieManager* manager)
 {
     g_return_if_fail(WEBKIT_IS_COOKIE_MANAGER(manager));
 
-    manager->priv->webCookieManager->deleteAllCookies();
+    manager->priv->webCookieManager->deleteAllCookies(WebCore::SessionID::defaultSessionID());
 }

--- a/Source/WebKit2/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit2/UIProcess/Automation/WebAutomationSession.cpp
@@ -845,7 +845,7 @@ void WebAutomationSession::addSingleCookie(ErrorString& errorString, const Strin
         FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS(MissingParameter, "The parameter 'httpOnly' was not found.");
 
     WebCookieManagerProxy* cookieManager = m_processPool->supplement<WebCookieManagerProxy>();
-    cookieManager->addCookie(cookie, activeURL.host());
+    cookieManager->addCookie(WebCore::SessionID::defaultSessionID(), cookie, activeURL.host());
 
     callback->sendSuccess();
 }
@@ -860,7 +860,7 @@ void WebAutomationSession::deleteAllCookies(ErrorString& errorString, const Stri
     ASSERT(activeURL.isValid());
 
     WebCookieManagerProxy* cookieManager = m_processPool->supplement<WebCookieManagerProxy>();
-    cookieManager->deleteCookiesForHostname(activeURL.host());
+    cookieManager->deleteCookiesForHostname(WebCore::SessionID::defaultSessionID(), activeURL.host());
 }
 
 #if USE(APPKIT)

--- a/Source/WebKit2/UIProcess/WebCookieManagerProxy.cpp
+++ b/Source/WebKit2/UIProcess/WebCookieManagerProxy.cpp
@@ -94,15 +94,15 @@ void WebCookieManagerProxy::derefWebContextSupplement()
     API::Object::deref();
 }
 
-void WebCookieManagerProxy::getHostnamesWithCookies(std::function<void (API::Array*, CallbackBase::Error)> callbackFunction)
+void WebCookieManagerProxy::getHostnamesWithCookies(WebCore::SessionID sessionID, std::function<void (API::Array*, CallbackBase::Error)> callbackFunction)
 {
     auto callback = ArrayCallback::create(WTFMove(callbackFunction));
     uint64_t callbackID = callback->callbackID();
     m_arrayCallbacks.set(callbackID, WTFMove(callback));
 
-    processPool()->sendToNetworkingProcessRelaunchingIfNecessary(Messages::WebCookieManager::GetHostnamesWithCookies(callbackID));
+    processPool()->sendToNetworkingProcessRelaunchingIfNecessary(Messages::WebCookieManager::GetHostnamesWithCookies(sessionID, callbackID));
 }
-    
+
 void WebCookieManagerProxy::didGetHostnamesWithCookies(const Vector<String>& hostnames, uint64_t callbackID)
 {
     RefPtr<ArrayCallback> callback = m_arrayCallbacks.take(callbackID);
@@ -114,39 +114,44 @@ void WebCookieManagerProxy::didGetHostnamesWithCookies(const Vector<String>& hos
     callback->performCallbackWithReturnValue(API::Array::createStringArray(hostnames).ptr());
 }
 
-void WebCookieManagerProxy::deleteCookiesForHostname(const String& hostname)
+void WebCookieManagerProxy::deleteCookiesForHostname(WebCore::SessionID sessionID, const String& hostname)
 {
-    processPool()->sendToNetworkingProcessRelaunchingIfNecessary(Messages::WebCookieManager::DeleteCookiesForHostname(hostname));
+    processPool()->sendToNetworkingProcessRelaunchingIfNecessary(Messages::WebCookieManager::DeleteCookiesForHostname(sessionID, hostname));
 }
 
-void WebCookieManagerProxy::deleteAllCookies()
+void WebCookieManagerProxy::deleteAllCookies(WebCore::SessionID sessionID)
 {
-    processPool()->sendToNetworkingProcessRelaunchingIfNecessary(Messages::WebCookieManager::DeleteAllCookies());
+    processPool()->sendToNetworkingProcessRelaunchingIfNecessary(Messages::WebCookieManager::DeleteAllCookies(sessionID));
 }
 
-void WebCookieManagerProxy::deleteAllCookiesModifiedSince(std::chrono::system_clock::time_point time)
+void WebCookieManagerProxy::deleteAllCookiesModifiedSince(WebCore::SessionID sessionID, std::chrono::system_clock::time_point time)
 {
-    processPool()->sendToNetworkingProcessRelaunchingIfNecessary(Messages::WebCookieManager::DeleteAllCookiesModifiedSince(time));
+    processPool()->sendToNetworkingProcessRelaunchingIfNecessary(Messages::WebCookieManager::DeleteAllCookiesModifiedSince(sessionID, time));
 }
 
-void WebCookieManagerProxy::addCookie(const WebCore::Cookie& cookie, const String& hostname)
+void WebCookieManagerProxy::addCookie(WebCore::SessionID sessionID, const WebCore::Cookie& cookie, const String& hostname)
 {
-    processPool()->sendToNetworkingProcessRelaunchingIfNecessary(Messages::WebCookieManager::AddCookie(cookie, hostname));
+    processPool()->sendToNetworkingProcessRelaunchingIfNecessary(Messages::WebCookieManager::AddCookie(sessionID, cookie, hostname));
 }
 
-void WebCookieManagerProxy::startObservingCookieChanges()
+void WebCookieManagerProxy::startObservingCookieChanges(WebCore::SessionID sessionID, std::function<void ()>&& callback)
 {
-    processPool()->sendToNetworkingProcessRelaunchingIfNecessary(Messages::WebCookieManager::StartObservingCookieChanges());
+    if (callback)
+        m_cookieObservers.set(sessionID, WTFMove(callback));
+    processPool()->sendToNetworkingProcessRelaunchingIfNecessary(Messages::WebCookieManager::StartObservingCookieChanges(sessionID));
 }
 
-void WebCookieManagerProxy::stopObservingCookieChanges()
+void WebCookieManagerProxy::stopObservingCookieChanges(WebCore::SessionID sessionID)
 {
-    processPool()->sendToNetworkingProcessRelaunchingIfNecessary(Messages::WebCookieManager::StopObservingCookieChanges());
+    m_cookieObservers.remove(sessionID);
+    processPool()->sendToNetworkingProcessRelaunchingIfNecessary(Messages::WebCookieManager::StopObservingCookieChanges(sessionID));
 }
 
-void WebCookieManagerProxy::cookiesDidChange()
+void WebCookieManagerProxy::cookiesDidChange(WebCore::SessionID sessionID)
 {
     m_client.cookiesDidChange(this);
+    if (auto callback = m_cookieObservers.get(sessionID))
+        callback();
 }
 
 void WebCookieManagerProxy::setHTTPCookieAcceptPolicy(HTTPCookieAcceptPolicy policy)
@@ -187,18 +192,18 @@ void WebCookieManagerProxy::didGetHTTPCookieAcceptPolicy(uint32_t policy, uint64
     callback->performCallbackWithReturnValue(policy);
 }
 
-void WebCookieManagerProxy::setCookies(const Vector<WebCore::Cookie>& cookies)
+void WebCookieManagerProxy::setCookies(WebCore::SessionID sessionID, const Vector<WebCore::Cookie>& cookies)
 {
-    processPool()->sendToNetworkingProcessRelaunchingIfNecessary(Messages::WebCookieManager::SetCookies(cookies));
+    processPool()->sendToNetworkingProcessRelaunchingIfNecessary(Messages::WebCookieManager::SetCookies(sessionID, cookies));
 }
 
-void WebCookieManagerProxy::getCookies(std::function<void (API::Array*, CallbackBase::Error)> callbackFunction)
+void WebCookieManagerProxy::getCookies(WebCore::SessionID sessionID, std::function<void (API::Array*, CallbackBase::Error)> callbackFunction)
 {
     RefPtr<ArrayCallback> callback = ArrayCallback::create(WTFMove(callbackFunction));
     uint64_t callbackID = callback->callbackID();
     m_arrayCallbacks.set(callbackID, callback.release());
 
-    processPool()->sendToNetworkingProcessRelaunchingIfNecessary(Messages::WebCookieManager::GetCookies(callbackID));
+    processPool()->sendToNetworkingProcessRelaunchingIfNecessary(Messages::WebCookieManager::GetCookies(sessionID, callbackID));
 }
 
 void WebCookieManagerProxy::didGetCookies(Vector<WebCore::Cookie> cookies, uint64_t callbackID)

--- a/Source/WebKit2/UIProcess/WebCookieManagerProxy.cpp
+++ b/Source/WebKit2/UIProcess/WebCookieManagerProxy.cpp
@@ -134,17 +134,22 @@ void WebCookieManagerProxy::addCookie(WebCore::SessionID sessionID, const WebCor
     processPool()->sendToNetworkingProcessRelaunchingIfNecessary(Messages::WebCookieManager::AddCookie(sessionID, cookie, hostname));
 }
 
-void WebCookieManagerProxy::startObservingCookieChanges(WebCore::SessionID sessionID, std::function<void ()>&& callback)
+void WebCookieManagerProxy::startObservingCookieChanges(WebCore::SessionID sessionID)
 {
-    if (callback)
-        m_cookieObservers.set(sessionID, WTFMove(callback));
     processPool()->sendToNetworkingProcessRelaunchingIfNecessary(Messages::WebCookieManager::StartObservingCookieChanges(sessionID));
 }
 
 void WebCookieManagerProxy::stopObservingCookieChanges(WebCore::SessionID sessionID)
 {
-    m_cookieObservers.remove(sessionID);
     processPool()->sendToNetworkingProcessRelaunchingIfNecessary(Messages::WebCookieManager::StopObservingCookieChanges(sessionID));
+}
+
+void WebCookieManagerProxy::setCookieObserverCallback(WebCore::SessionID sessionID, std::function<void ()>&& callback)
+{
+    if (callback)
+        m_cookieObservers.set(sessionID, WTFMove(callback));
+    else
+        m_cookieObservers.remove(sessionID);
 }
 
 void WebCookieManagerProxy::cookiesDidChange(WebCore::SessionID sessionID)

--- a/Source/WebKit2/UIProcess/WebCookieManagerProxy.h
+++ b/Source/WebKit2/UIProcess/WebCookieManagerProxy.h
@@ -78,8 +78,10 @@ public:
     void getCookies(WebCore::SessionID, std::function<void (API::Array*, CallbackBase::Error)>);
     void didGetCookies(Vector<WebCore::Cookie> cookies,  uint64_t callbackID);
 
-    void startObservingCookieChanges(WebCore::SessionID, std::function<void ()>&& = nullptr);
+    void startObservingCookieChanges(WebCore::SessionID);
     void stopObservingCookieChanges(WebCore::SessionID);
+
+    void setCookieObserverCallback(WebCore::SessionID, std::function<void ()>&&);
 
 #if USE(SOUP)
     void setCookiePersistentStorage(const String& storagePath, uint32_t storageType);

--- a/Source/WebKit2/UIProcess/WebCookieManagerProxy.h
+++ b/Source/WebKit2/UIProcess/WebCookieManagerProxy.h
@@ -31,6 +31,7 @@
 #include "MessageReceiver.h"
 #include "WebContextSupplement.h"
 #include "WebCookieManagerProxyClient.h"
+#include <WebCore/SessionID.h>
 #include <wtf/PassRefPtr.h>
 #include <wtf/RefPtr.h>
 #include <wtf/Vector.h>
@@ -64,21 +65,21 @@ public:
 
     void initializeClient(const WKCookieManagerClientBase*);
     
-    void getHostnamesWithCookies(std::function<void (API::Array*, CallbackBase::Error)>);
-    void deleteCookiesForHostname(const String& hostname);
-    void deleteAllCookies();
-    void deleteAllCookiesModifiedSince(std::chrono::system_clock::time_point);
-    void addCookie(const WebCore::Cookie&, const String& hostname);
+    void getHostnamesWithCookies(WebCore::SessionID, std::function<void (API::Array*, CallbackBase::Error)>);
+    void deleteCookiesForHostname(WebCore::SessionID, const String& hostname);
+    void deleteAllCookies(WebCore::SessionID);
+    void deleteAllCookiesModifiedSince(WebCore::SessionID, std::chrono::system_clock::time_point);
+    void addCookie(WebCore::SessionID, const WebCore::Cookie&, const String& hostname);
 
     void setHTTPCookieAcceptPolicy(HTTPCookieAcceptPolicy);
     void getHTTPCookieAcceptPolicy(std::function<void (HTTPCookieAcceptPolicy, CallbackBase::Error)>);
 
-    void setCookies(const Vector<WebCore::Cookie>& cookies);
-    void getCookies(std::function<void (API::Array*, CallbackBase::Error)>);
+    void setCookies(WebCore::SessionID, const Vector<WebCore::Cookie>& cookies);
+    void getCookies(WebCore::SessionID, std::function<void (API::Array*, CallbackBase::Error)>);
     void didGetCookies(Vector<WebCore::Cookie> cookies,  uint64_t callbackID);
 
-    void startObservingCookieChanges();
-    void stopObservingCookieChanges();
+    void startObservingCookieChanges(WebCore::SessionID, std::function<void ()>&& = nullptr);
+    void stopObservingCookieChanges(WebCore::SessionID);
 
 #if USE(SOUP)
     void setCookiePersistentStorage(const String& storagePath, uint32_t storageType);
@@ -94,7 +95,7 @@ private:
     void didGetHostnamesWithCookies(const Vector<String>&, uint64_t callbackID);
     void didGetHTTPCookieAcceptPolicy(uint32_t policy, uint64_t callbackID);
 
-    void cookiesDidChange();
+    void cookiesDidChange(WebCore::SessionID);
 
     // WebContextSupplement
     void processPoolDestroyed() override;
@@ -112,6 +113,8 @@ private:
 
     HashMap<uint64_t, RefPtr<ArrayCallback>> m_arrayCallbacks;
     HashMap<uint64_t, RefPtr<HTTPCookieAcceptPolicyCallback>> m_httpCookieAcceptPolicyCallbacks;
+
+    HashMap<WebCore::SessionID, std::function<void ()>> m_cookieObservers;
 
     WebCookieManagerProxyClient m_client;
 

--- a/Source/WebKit2/UIProcess/WebCookieManagerProxy.messages.in
+++ b/Source/WebKit2/UIProcess/WebCookieManagerProxy.messages.in
@@ -26,5 +26,5 @@ messages -> WebCookieManagerProxy {
 
     DidGetCookies(Vector<WebCore::Cookie> cookies, uint64_t callbackID)
 
-    CookiesDidChange()
+    CookiesDidChange(WebCore::SessionID sessionID)
 }

--- a/Source/WebKit2/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit2/UIProcess/WebPageProxy.cpp
@@ -35,6 +35,7 @@
 #include "APIFrameInfo.h"
 #include "APIFullscreenClient.h"
 #include "APIGeometry.h"
+#include "APIHTTPCookieStorage.h"
 #include "APIHistoryClient.h"
 #include "APIHitTestResult.h"
 #include "APILegacyContextHistoryClient.h"
@@ -458,6 +459,7 @@ WebPageProxy::WebPageProxy(PageClient& pageClient, WebProcessProxy& process, uin
     , m_configurationPreferenceValues(m_configuration->preferenceValues())
     , m_potentiallyChangedActivityStateFlags(ActivityState::NoFlags)
     , m_activityStateChangeWantsSynchronousReply(false)
+    , m_httpCookieStorage(API::HTTPCookieStorage::create(*this))
     , m_weakPtrFactory(this)
 {
     m_webProcessLifetimeTracker.addObserver(m_visitedLinkStore);
@@ -5586,6 +5588,11 @@ void WebPageProxy::updateAcceleratedCompositingMode(const LayerTreeContext& laye
 void WebPageProxy::backForwardClear()
 {
     m_backForwardList->clear();
+}
+
+void WebPageProxy::cookiesDidChange()
+{
+    m_loaderClient->cookiesDidChange(*this);
 }
 
 #if ENABLE(GAMEPAD)

--- a/Source/WebKit2/UIProcess/WebPageProxy.h
+++ b/Source/WebKit2/UIProcess/WebPageProxy.h
@@ -129,6 +129,7 @@ class FindClient;
 class FindMatchesClient;
 class FormClient;
 class FullscreenClient;
+class HTTPCookieStorage;
 class HistoryClient;
 class LoaderClient;
 class Navigation;
@@ -366,6 +367,8 @@ public:
 
     API::UIClient& uiClient() { return *m_uiClient; }
     void setUIClient(std::unique_ptr<API::UIClient>);
+
+    API::HTTPCookieStorage& httpCookieStorage() { return m_httpCookieStorage.get(); }
 
     void initializeWebPage();
 
@@ -1153,6 +1156,8 @@ public:
 
     void canAuthenticateAgainstProtectionSpace(uint64_t loaderID, uint64_t frameID, const WebCore::ProtectionSpace&);
 
+    void cookiesDidChange();
+
 #if ENABLE(GAMEPAD)
     void gamepadActivity(const Vector<GamepadData>&);
 #endif
@@ -1918,6 +1923,8 @@ private:
     bool m_hasHadSelectionChangesFromUserInteraction { false };
     bool m_needsHiddenContentEditableQuirk { false };
     bool m_needsPlainTextQuirk { false };
+
+    Ref<API::HTTPCookieStorage> m_httpCookieStorage;
 
 #if ENABLE(MEDIA_SESSION)
     bool m_hasMediaSessionWithActiveMediaElements { false };

--- a/Source/WebKit2/WebProcess/Cookies/WebCookieManager.cpp
+++ b/Source/WebKit2/WebProcess/Cookies/WebCookieManager.cpp
@@ -89,12 +89,17 @@ void WebCookieManager::addCookie(SessionID sessionID, const Cookie& cookie, cons
         WebCore::addCookie(*storageSession, URL(URL(), hostname), cookie);
 }
 
+void WebCookieManager::notifyCookiesDidChange(SessionID sessionID)
+{
+    ASSERT(RunLoop::isMain());
+    m_process->send(Messages::WebCookieManagerProxy::CookiesDidChange(sessionID), 0);
+}
+
 void WebCookieManager::startObservingCookieChanges(SessionID sessionID)
 {
     if (auto* storageSession = NetworkStorageSession::storageSession(sessionID)) {
         WebCore::startObservingCookieChanges(*storageSession, [this, sessionID] {
-            ASSERT(RunLoop::isMain());
-            m_process->send(Messages::WebCookieManagerProxy::CookiesDidChange(sessionID), 0);
+            notifyCookiesDidChange(sessionID);
         });
     }
 }

--- a/Source/WebKit2/WebProcess/Cookies/WebCookieManager.cpp
+++ b/Source/WebKit2/WebProcess/Cookies/WebCookieManager.cpp
@@ -42,8 +42,6 @@ using namespace WebCore;
 
 namespace WebKit {
 
-static WebCookieManager* sharedCookieManager;
-
 const char* WebCookieManager::supplementName()
 {
     return "WebCookieManager";
@@ -53,15 +51,13 @@ WebCookieManager::WebCookieManager(ChildProcess* process)
     : m_process(process)
 {
     m_process->addMessageReceiver(Messages::WebCookieManager::messageReceiverName(), *this);
-
-    ASSERT(!sharedCookieManager);
-    sharedCookieManager = this;
 }
 
-void WebCookieManager::getHostnamesWithCookies(uint64_t callbackID)
+void WebCookieManager::getHostnamesWithCookies(SessionID sessionID, uint64_t callbackID)
 {
     HashSet<String> hostnames;
-    WebCore::getHostnamesWithCookies(NetworkStorageSession::defaultStorageSession(), hostnames);
+    if (auto* storageSession = NetworkStorageSession::storageSession(sessionID))
+        WebCore::getHostnamesWithCookies(*storageSession, hostnames);
 
     Vector<String> hostnameList;
     copyToVector(hostnames, hostnameList);
@@ -69,45 +65,44 @@ void WebCookieManager::getHostnamesWithCookies(uint64_t callbackID)
     m_process->send(Messages::WebCookieManagerProxy::DidGetHostnamesWithCookies(hostnameList, callbackID), 0);
 }
 
-void WebCookieManager::deleteCookiesForHostname(const String& hostname)
+void WebCookieManager::deleteCookiesForHostname(SessionID sessionID, const String& hostname)
 {
-    WebCore::deleteCookiesForHostnames(NetworkStorageSession::defaultStorageSession(), { hostname });
+    if (auto* storageSession = NetworkStorageSession::storageSession(sessionID))
+        WebCore::deleteCookiesForHostnames(*storageSession, { hostname });
 }
 
-void WebCookieManager::deleteAllCookies()
+void WebCookieManager::deleteAllCookies(SessionID sessionID)
 {
-    WebCore::deleteAllCookies(NetworkStorageSession::defaultStorageSession());
+    if (auto* storageSession = NetworkStorageSession::storageSession(sessionID))
+        WebCore::deleteAllCookies(*storageSession);
 }
 
-void WebCookieManager::deleteAllCookiesModifiedSince(std::chrono::system_clock::time_point time)
+void WebCookieManager::deleteAllCookiesModifiedSince(SessionID sessionID, std::chrono::system_clock::time_point time)
 {
-    WebCore::deleteAllCookiesModifiedSince(NetworkStorageSession::defaultStorageSession(), time);
+    if (auto* storageSession = NetworkStorageSession::storageSession(sessionID))
+        WebCore::deleteAllCookiesModifiedSince(*storageSession, time);
 }
 
-void WebCookieManager::addCookie(const Cookie& cookie, const String& hostname)
+void WebCookieManager::addCookie(SessionID sessionID, const Cookie& cookie, const String& hostname)
 {
-    WebCore::addCookie(NetworkStorageSession::defaultStorageSession(), URL(URL(), hostname), cookie);
+    if (auto* storageSession = NetworkStorageSession::storageSession(sessionID))
+        WebCore::addCookie(*storageSession, URL(URL(), hostname), cookie);
 }
 
-void WebCookieManager::startObservingCookieChanges()
+void WebCookieManager::startObservingCookieChanges(SessionID sessionID)
 {
-    WebCore::startObservingCookieChanges(cookiesDidChange);
+    if (auto* storageSession = NetworkStorageSession::storageSession(sessionID)) {
+        WebCore::startObservingCookieChanges(*storageSession, [this, sessionID] {
+            ASSERT(RunLoop::isMain());
+            m_process->send(Messages::WebCookieManagerProxy::CookiesDidChange(sessionID), 0);
+        });
+    }
 }
 
-void WebCookieManager::stopObservingCookieChanges()
+void WebCookieManager::stopObservingCookieChanges(SessionID sessionID)
 {
-    WebCore::stopObservingCookieChanges();
-}
-
-void WebCookieManager::cookiesDidChange()
-{
-    sharedCookieManager->dispatchCookiesDidChange();
-}
-
-void WebCookieManager::dispatchCookiesDidChange()
-{
-    ASSERT(RunLoop::isMain());
-    m_process->send(Messages::WebCookieManagerProxy::CookiesDidChange(), 0);
+    if (auto* storageSession = NetworkStorageSession::storageSession(sessionID))
+        WebCore::stopObservingCookieChanges(*storageSession);
 }
 
 void WebCookieManager::setHTTPCookieAcceptPolicy(HTTPCookieAcceptPolicy policy)
@@ -120,15 +115,17 @@ void WebCookieManager::getHTTPCookieAcceptPolicy(uint64_t callbackID)
     m_process->send(Messages::WebCookieManagerProxy::DidGetHTTPCookieAcceptPolicy(platformGetHTTPCookieAcceptPolicy(), callbackID), 0);
 }
 
-void WebCookieManager::setCookies(const Vector<WebCore::Cookie>& cookies)
+void WebCookieManager::setCookies(SessionID sessionID, const Vector<WebCore::Cookie>& cookies)
 {
-    WebCore::setCookies(NetworkStorageSession::defaultStorageSession(), cookies);
+    if (auto* storageSession = NetworkStorageSession::storageSession(sessionID))
+        WebCore::setCookies(*storageSession, cookies);
 }
 
-void WebCookieManager::getCookies(uint64_t callbackID)
+void WebCookieManager::getCookies(SessionID sessionID, uint64_t callbackID)
 {
     Vector<WebCore::Cookie> cookies;
-    WebCore::getCookies(NetworkStorageSession::defaultStorageSession(), cookies);
+    if (auto* storageSession = NetworkStorageSession::storageSession(sessionID))
+        WebCore::getCookies(*storageSession, cookies);
     m_process->send(Messages::WebCookieManagerProxy::DidGetCookies(cookies, callbackID), 0);
 }
 

--- a/Source/WebKit2/WebProcess/Cookies/WebCookieManager.h
+++ b/Source/WebKit2/WebProcess/Cookies/WebCookieManager.h
@@ -60,6 +60,8 @@ public:
     void setCookiePersistentStorage(const String& storagePath, uint32_t storageType);
 #endif
 
+    void notifyCookiesDidChange(WebCore::SessionID);
+
 private:
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;

--- a/Source/WebKit2/WebProcess/Cookies/WebCookieManager.h
+++ b/Source/WebKit2/WebProcess/Cookies/WebCookieManager.h
@@ -30,6 +30,7 @@
 #include "MessageReceiver.h"
 #include "NetworkProcessSupplement.h"
 #include "WebProcessSupplement.h"
+#include <WebCore/SessionID.h>
 #include <stdint.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
@@ -63,25 +64,21 @@ private:
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
 
-    void getHostnamesWithCookies(uint64_t callbackID);
-    void deleteCookiesForHostname(const String&);
-    void deleteAllCookies();
-    void deleteAllCookiesModifiedSince(std::chrono::system_clock::time_point);
-    void addCookie(const WebCore::Cookie&, const String& hostname);
+    void getHostnamesWithCookies(WebCore::SessionID, uint64_t callbackID);
+    void deleteCookiesForHostname(WebCore::SessionID, const String&);
+    void deleteAllCookies(WebCore::SessionID);
+    void deleteAllCookiesModifiedSince(WebCore::SessionID, std::chrono::system_clock::time_point);
+    void addCookie(WebCore::SessionID, const WebCore::Cookie&, const String& hostname);
 
     void platformSetHTTPCookieAcceptPolicy(HTTPCookieAcceptPolicy);
     void getHTTPCookieAcceptPolicy(uint64_t callbackID);
     HTTPCookieAcceptPolicy platformGetHTTPCookieAcceptPolicy();
 
-    void setCookies(const Vector<WebCore::Cookie>& cookies);
-    void getCookies(uint64_t callbackID);
+    void setCookies(WebCore::SessionID, const Vector<WebCore::Cookie>& cookies);
+    void getCookies(WebCore::SessionID, uint64_t callbackID);
 
-    void startObservingCookieChanges();
-    void stopObservingCookieChanges();
-
-    static void cookiesDidChange();
-    void dispatchCookiesDidChange();
-
+    void startObservingCookieChanges(WebCore::SessionID);
+    void stopObservingCookieChanges(WebCore::SessionID);
 
     ChildProcess* m_process;
 };

--- a/Source/WebKit2/WebProcess/Cookies/WebCookieManager.messages.in
+++ b/Source/WebKit2/WebProcess/Cookies/WebCookieManager.messages.in
@@ -24,20 +24,20 @@
  */
  
  messages -> WebCookieManager {
-    void GetHostnamesWithCookies(uint64_t callbackID)
-    void DeleteCookiesForHostname(String hostname)
-    void DeleteAllCookies()
-    void DeleteAllCookiesModifiedSince(std::chrono::system_clock::time_point time)
-    void AddCookie(struct WebCore::Cookie cookie, String hostname)
+    void GetHostnamesWithCookies(WebCore::SessionID sessionID, uint64_t callbackID)
+    void DeleteCookiesForHostname(WebCore::SessionID sessionID, String hostname)
+    void DeleteAllCookies(WebCore::SessionID sessionID)
+    void DeleteAllCookiesModifiedSince(WebCore::SessionID sessionID, std::chrono::system_clock::time_point time)
+    void AddCookie(WebCore::SessionID sessionID, struct WebCore::Cookie cookie, String hostname)
 
     void SetHTTPCookieAcceptPolicy(uint32_t policy)
     void GetHTTPCookieAcceptPolicy(uint64_t callbackID)
 
-    void SetCookies(Vector<WebCore::Cookie> cookies)
-    void GetCookies(uint64_t callbackID)
+    void SetCookies(WebCore::SessionID sessionID, Vector<WebCore::Cookie> cookies)
+    void GetCookies(WebCore::SessionID sessionID, uint64_t callbackID)
 
-    void StartObservingCookieChanges()
-    void StopObservingCookieChanges()
+    void StartObservingCookieChanges(WebCore::SessionID sessionID)
+    void StopObservingCookieChanges(WebCore::SessionID sessionID)
 
 #if USE(SOUP)
     SetCookiePersistentStorage(String storagePath, uint32_t storageType)

--- a/Source/WebKit2/WebProcess/Cookies/soup/WebCookieManagerSoup.cpp
+++ b/Source/WebKit2/WebProcess/Cookies/soup/WebCookieManagerSoup.cpp
@@ -27,7 +27,6 @@
 #include "WebCookieManager.h"
 
 #include "ChildProcess.h"
-#include "WebFrameNetworkingContext.h"
 #include "WebKitSoupCookieJarSqlite.h"
 #include <WebCore/NetworkStorageSession.h>
 #include <WebCore/SoupNetworkSession.h>
@@ -41,7 +40,22 @@ namespace WebKit {
 
 void WebCookieManager::platformSetHTTPCookieAcceptPolicy(HTTPCookieAcceptPolicy policy)
 {
-    WebFrameNetworkingContext::setCookieAcceptPolicyForAllContexts(policy);
+    SoupCookieJarAcceptPolicy soupPolicy = SOUP_COOKIE_JAR_ACCEPT_NO_THIRD_PARTY;
+    switch (policy) {
+    case HTTPCookieAcceptPolicyAlways:
+        soupPolicy = SOUP_COOKIE_JAR_ACCEPT_ALWAYS;
+        break;
+    case HTTPCookieAcceptPolicyNever:
+        soupPolicy = SOUP_COOKIE_JAR_ACCEPT_NEVER;
+        break;
+    case HTTPCookieAcceptPolicyOnlyFromMainDocumentDomain:
+        soupPolicy = SOUP_COOKIE_JAR_ACCEPT_NO_THIRD_PARTY;
+        break;
+    }
+
+    NetworkStorageSession::forEach([soupPolicy] (const NetworkStorageSession& session) {
+        soup_cookie_jar_set_accept_policy(session.cookieStorage(), soupPolicy);
+    });
 }
 
 HTTPCookieAcceptPolicy WebCookieManager::platformGetHTTPCookieAcceptPolicy()
@@ -75,7 +89,7 @@ void WebCookieManager::setCookiePersistentStorage(const String& storagePath, uin
 
     auto& storageSession = NetworkStorageSession::defaultStorageSession();
     soup_cookie_jar_set_accept_policy(jar.get(), soup_cookie_jar_get_accept_policy(storageSession.cookieStorage()));
-    storageSession.getOrCreateSoupNetworkSession().setCookieJar(jar.get());
+    storageSession.setCookieStorage(jar.get());
 }
 
 } // namespace WebKit

--- a/Source/WebKit2/WebProcess/WebCoreSupport/soup/WebFrameNetworkingContext.cpp
+++ b/Source/WebKit2/WebProcess/WebCoreSupport/soup/WebFrameNetworkingContext.cpp
@@ -52,28 +52,6 @@ void WebFrameNetworkingContext::ensurePrivateBrowsingSession(SessionID sessionID
     SessionTracker::setSession(sessionID, NetworkSession::create(sessionID));
 }
 
-void WebFrameNetworkingContext::setCookieAcceptPolicyForAllContexts(HTTPCookieAcceptPolicy policy)
-{
-    SoupCookieJarAcceptPolicy soupPolicy = SOUP_COOKIE_JAR_ACCEPT_ALWAYS;
-    switch (policy) {
-    case HTTPCookieAcceptPolicyAlways:
-        soupPolicy = SOUP_COOKIE_JAR_ACCEPT_ALWAYS;
-        break;
-    case HTTPCookieAcceptPolicyNever:
-        soupPolicy = SOUP_COOKIE_JAR_ACCEPT_NEVER;
-        break;
-    case HTTPCookieAcceptPolicyOnlyFromMainDocumentDomain:
-        soupPolicy = SOUP_COOKIE_JAR_ACCEPT_NO_THIRD_PARTY;
-        break;
-    }
-
-    soup_cookie_jar_set_accept_policy(NetworkStorageSession::defaultStorageSession().cookieStorage(), soupPolicy);
-
-    NetworkStorageSession::forEach([&] (const NetworkStorageSession& session) {
-        soup_cookie_jar_set_accept_policy(session.cookieStorage(), soupPolicy);
-    });
-}
-
 WebFrameNetworkingContext::WebFrameNetworkingContext(WebFrame* frame)
     : FrameNetworkingContext(frame->coreFrame())
 {

--- a/Source/WebKit2/WebProcess/WebCoreSupport/soup/WebFrameNetworkingContext.h
+++ b/Source/WebKit2/WebProcess/WebCoreSupport/soup/WebFrameNetworkingContext.h
@@ -25,10 +25,8 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef WebFrameNetworkingContext_h
-#define WebFrameNetworkingContext_h
+#pragma once
 
-#include "HTTPCookieAcceptPolicy.h"
 #include <WebCore/FrameNetworkingContext.h>
 #include <WebCore/SessionID.h>
 
@@ -45,7 +43,6 @@ public:
     }
 
     static void ensurePrivateBrowsingSession(WebCore::SessionID);
-    static void setCookieAcceptPolicyForAllContexts(HTTPCookieAcceptPolicy);
 
     WebFrameLoaderClient* webFrameLoaderClient() const;
 
@@ -56,5 +53,3 @@ private:
 };
 
 }
-
-#endif // WebFrameNetworkingContext_h


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=168229

Reviewed by Alex Christensen.

Source/WebCore:

Update cookie observer API to use a std::function instead of a function pointer and make it work with multiple
sessions in the backends that support it.

* platform/network/CookieStorage.h:
* platform/network/cf/CookieStorageCFNet.cpp:
(WebCore::cookieChangeCallbackMap):
(WebCore::notifyCookiesChanged):
(WebCore::startObservingCookieChanges):
(WebCore::stopObservingCookieChanges):
* platform/network/mac/CookieStorageMac.mm:
(-[WebCookieStorageObjCAdapter startListeningForCookieChangeNotificationsWithCallback:]):
(-[WebCookieStorageObjCAdapter stopListeningForCookieChangeNotifications]):
(WebCore::startObservingCookieChanges):
(WebCore::stopObservingCookieChanges):
* platform/network/soup/CookieStorageSoup.cpp:
(WebCore::cookieChangeCallbackMap):
(WebCore::soupCookiesChanged):
(WebCore::startObservingCookieChanges):
(WebCore::stopObservingCookieChanges):

Source/WebKit2:

Make CookieManager session aware by adding a SessionID parameter to all its functions, and update all the callers
to pass the default session ID, preserving the current
behavior. WebCookieManagerProxy::startObservingCookieChanges() now also receives an optional callback to be
called on every change.

* UIProcess/API/C/WKCookieManager.cpp:
(WKCookieManagerGetHostnamesWithCookies):
(WKCookieManagerDeleteCookiesForHostname):
(WKCookieManagerDeleteAllCookies):
(WKCookieManagerDeleteAllCookiesModifiedAfterDate):
(WKCookieManagerStartObservingCookieChanges):
(WKCookieManagerStopObservingCookieChanges):
* UIProcess/API/gtk/WebKitCookieManager.cpp:
(_WebKitCookieManagerPrivate::~_WebKitCookieManagerPrivate):
(webkitCookieManagerCreate):
(webkit_cookie_manager_set_persistent_storage):
(webkit_cookie_manager_get_domains_with_cookies):
(webkit_cookie_manager_delete_cookies_for_domain):
(webkit_cookie_manager_delete_all_cookies):
* UIProcess/Automation/WebAutomationSession.cpp:
(WebKit::WebAutomationSession::addSingleCookie):
(WebKit::WebAutomationSession::deleteAllCookies):
* UIProcess/WebCookieManagerProxy.cpp:
(WebKit::WebCookieManagerProxy::getHostnamesWithCookies):
(WebKit::WebCookieManagerProxy::deleteCookiesForHostname):
(WebKit::WebCookieManagerProxy::deleteAllCookies):
(WebKit::WebCookieManagerProxy::deleteAllCookiesModifiedSince):
(WebKit::WebCookieManagerProxy::addCookie):
(WebKit::WebCookieManagerProxy::startObservingCookieChanges):
(WebKit::WebCookieManagerProxy::stopObservingCookieChanges):
(WebKit::WebCookieManagerProxy::cookiesDidChange):
* UIProcess/WebCookieManagerProxy.h:
* UIProcess/WebCookieManagerProxy.messages.in:
* WebProcess/Cookies/WebCookieManager.cpp:
(WebKit::WebCookieManager::WebCookieManager):
(WebKit::WebCookieManager::getHostnamesWithCookies):
(WebKit::WebCookieManager::deleteCookiesForHostname):
(WebKit::WebCookieManager::deleteAllCookies):
(WebKit::WebCookieManager::deleteAllCookiesModifiedSince):
(WebKit::WebCookieManager::addCookie):
(WebKit::WebCookieManager::startObservingCookieChanges):
(WebKit::WebCookieManager::stopObservingCookieChanges):
* WebProcess/Cookies/WebCookieManager.h:
* WebProcess/Cookies/WebCookieManager.messages.in:

git-svn-id: http://svn.webkit.org/repository/webkit/trunk@212283 268f45cc-cd09-0410-ab3c-d52691b4dbfc