### PR TITLE
Issue seek

### DIFF
--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -1975,7 +1975,9 @@ void SourceBuffer::reenqueueMediaForTime(TrackBuffer& trackBuffer, AtomicString 
     }
 
     // Fill the decode queue with the remaining samples.
-    for (auto iter = currentSampleDTSIterator; iter != trackBuffer.samples.decodeOrder().end(); ++iter)
+    // Insert only the new buffered samples, don't insert the samples of the last buffered range.
+    // use case: backward seek to unbuffered range before a buffered one.
+    for (auto iter = currentSampleDTSIterator; iter->first.first <= trackBuffer.lastDecodeTimestamp; ++iter)
         trackBuffer.decodeQueue.insert(*iter);
     provideMediaData(trackBuffer, trackID);
 


### PR DESCRIPTION
[MSE]During seek to unbuffered range before a buffered one, reenqueueing happens and playback becomes choppy
    
In reenqueueing function, we insert the new buffered samples following the seek and we also
insert the samples previously buffered before the seek. We'll remove them later, when the
new samples would ovelap the samples already buffered before the seek.
    
This commit insert only the new buffered samples following the seek.
    
Fix for https://github.com/WebPlatformForEmbedded/WPEWebKit/issues/271
