### PR TITLE
Fix for a race condition leading to a resource leak

### DIFF
--- a/Source/WebKit2/Platform/IPC/Connection.cpp
+++ b/Source/WebKit2/Platform/IPC/Connection.cpp
@@ -873,6 +873,9 @@ void Connection::didFailToSendSyncMessage()
     if (!m_shouldExitOnSyncMessageSendFailure)
         return;
 
+    invalidate();
+    m_client.didClose(*this);
+
     exit(0);
 }
 

--- a/Source/WebKit2/WebProcess/WebProcess.cpp
+++ b/Source/WebKit2/WebProcess/WebProcess.cpp
@@ -656,7 +656,6 @@ void WebProcess::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& de
 
 void WebProcess::didClose(IPC::Connection&)
 {
-#ifndef NDEBUG
     m_inDidClose = true;
 
     // Close all the live pages.
@@ -665,6 +664,8 @@ void WebProcess::didClose(IPC::Connection&)
     for (auto& page : pages)
         page->close();
     pages.clear();
+
+#ifndef NDEBUG
 
     GCController::singleton().garbageCollectSoon();
     FontCache::singleton().invalidate();


### PR DESCRIPTION
When WKPageClose is called,
previously Close message was send asynchronously from UI to Web process.
There was a race condition when after sending this message:

connection to Network Process might be invalidated
( WebPageProxy::close -> WebProcessProxy::removeWebPage ->
WebProcessProxy::shutDown -> ChildProcessProxy::shutDownProcess ->
Connection::invalidate --(ConnectionWorkQueue)-> Connection::platformInvalidate
and other work related to shutting down connection in  WebPageProxy::close )

then Web Process might terminate (didFailToSendSyncMessage -> exit()),

And since gstreamer pipeline was not set to NULL state, gstreamer resources might be not released.

This patch tries to fix this race condition by calling
Connection::didFailToSendSyncMessage -> WebProcess::didClose -> WebPage::close (for all webpages in this process).
