### PR TITLE
[GStreamer][MSE] Make setAppendState thread safe

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.h
@@ -87,6 +87,8 @@ public:
     void connectDemuxerSrcPadToAppsinkFromAnyThread(GstPad*);
     void connectDemuxerSrcPadToAppsink(GstPad*);
 
+    void transitionTo(AppendState);
+
     void reportAppsrcAtLeastABufferLeft();
     void reportAppsrcNeedDataReceived();
 
@@ -127,6 +129,8 @@ private:
     Condition m_newSampleCondition;
     Lock m_padAddRemoveLock;
     Condition m_padAddRemoveCondition;
+    Lock m_appendStateTransitionLock;
+    Condition m_appendStateTransitionCondition;
 
     GRefPtr<GstCaps> m_appsinkCaps;
     GRefPtr<GstCaps> m_demuxerSrcPadCaps;


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=175540

setAppendState is indirectly called by other threads, despite
assertion that existed about it only running on the main
thread. One way this can happen which was causing problems was in
response to the sync-message::need-context glib signal. This was
invoking setAppendState from a non-main thread.