### PR TITLE
Fix cache model assertion when WPE_RAM_SIZE < 256

### DIFF
--- a/Source/WebKit2/Shared/CacheModel.cpp
+++ b/Source/WebKit2/Shared/CacheModel.cpp
@@ -54,6 +54,8 @@ void calculateMemoryCacheSizes(CacheModel cacheModel, unsigned& cacheTotalCapaci
             cacheTotalCapacity = 32 * MB;
         else if (memorySize >= 512)
             cacheTotalCapacity = 16 * MB;
+        else
+            cacheTotalCapacity = 8 * MB;
 
         cacheMinDeadCapacity = 0;
         cacheMaxDeadCapacity = 0;
@@ -78,6 +80,8 @@ void calculateMemoryCacheSizes(CacheModel cacheModel, unsigned& cacheTotalCapaci
             cacheTotalCapacity = 32 * MB;
         else if (memorySize >= 512)
             cacheTotalCapacity = 16 * MB;
+        else
+            cacheTotalCapacity = 8 * MB;
 
         cacheMinDeadCapacity = cacheTotalCapacity / 8;
         cacheMaxDeadCapacity = cacheTotalCapacity / 4;
@@ -105,6 +109,8 @@ void calculateMemoryCacheSizes(CacheModel cacheModel, unsigned& cacheTotalCapaci
             cacheTotalCapacity = 64 * MB;
         else if (memorySize >= 512)
             cacheTotalCapacity = 32 * MB;
+        else
+            cacheTotalCapacity = 16 * MB;
 
         cacheMinDeadCapacity = cacheTotalCapacity / 4;
         cacheMaxDeadCapacity = cacheTotalCapacity / 2;


### PR DESCRIPTION
webbrige sets WPE_RAM_SIZE to 128M, which tickles a logic error in the cache model.

https://bugs.webkit.org/show_bug.cgi?id=175571
This was reviewed upstream, so I am going to merge without review.