### PR TITLE
Adding support for fonts with two family names (XRE-11923)

### DIFF
--- a/Source/WebCore/platform/graphics/freetype/FontCacheFreeType.cpp
+++ b/Source/WebCore/platform/graphics/freetype/FontCacheFreeType.cpp
@@ -368,7 +368,7 @@ std::unique_ptr<FontPlatformData> FontCache::createFontPlatformData(const FontDe
 
     FcChar8* fontConfigFamilyNameAfterMatching;
 
-    //When a font has two family names: use the second (more descriptive) one instead
+    // When a font has two family names: use the second (more descriptive) one instead
     if (FcPatternGetString(resultPattern.get(), FC_FAMILY, 1, &fontConfigFamilyNameAfterMatching) != FcResultMatch)
         FcPatternGetString(resultPattern.get(), FC_FAMILY, 0, &fontConfigFamilyNameAfterMatching);
 

--- a/Source/WebCore/platform/graphics/freetype/FontCacheFreeType.cpp
+++ b/Source/WebCore/platform/graphics/freetype/FontCacheFreeType.cpp
@@ -367,7 +367,11 @@ std::unique_ptr<FontPlatformData> FontCache::createFontPlatformData(const FontDe
         return nullptr;
 
     FcChar8* fontConfigFamilyNameAfterMatching;
-    FcPatternGetString(resultPattern.get(), FC_FAMILY, 0, &fontConfigFamilyNameAfterMatching);
+
+    //When a font has two family names: use the second (more descriptive) one instead
+    if (FcPatternGetString(resultPattern.get(), FC_FAMILY, 1, &fontConfigFamilyNameAfterMatching) != FcResultMatch)
+        FcPatternGetString(resultPattern.get(), FC_FAMILY, 0, &fontConfigFamilyNameAfterMatching);
+
     String familyNameAfterMatching = String::fromUTF8(reinterpret_cast<char*>(fontConfigFamilyNameAfterMatching));
 
     // If Fontconfig gave us a different font family than the one we requested, we should ignore it


### PR DESCRIPTION
On desktop Ubuntu, the output of fc-list (family names only shown, coma separated if there are more then one):

> └── fc-list : family
> STIXIntegralsUp
> wasy10
> Noto Sans Mono CJK TC,Noto Sans Mono CJK TC Bold
> Noto Sans CJK TC,Noto Sans CJK TC Medium
> Lato,Lato Heavy
> XFINITY Sans TT,XFINITY Sans TT Lgt
> Noto Sans CJK TC,Noto Sans CJK TC DemiLight
> Lato
> Century Schoolbook L
> OpenSymbol
> Khmer OS System
> msam10
> Noto Sans CJK KR,Noto Sans CJK KR Black
> Noto Sans CJK TC,Noto Sans CJK TC Black
> Noto Sans Mono CJK TC,Noto Sans Mono CJK TC Regular
> Symbola
> Noto Sans CJK SC,Noto Sans CJK SC Light
>...


Fonts that used on webpages specifying their secondary family name won't be discovered unless the code first checks for the presence of a secondary family name.

For example (from fc-list output):
XFINITY Sans TT,XFINITY Sans TT Lgt
XFINITY Sans TT,XFINITY Sans TT Ex Lgt
XFINITY Sans TT,XFINITY Sans TT Reg

all three different fonts.  Used on webpages as 
```
    <div style="font-family: 'XFINITY Sans TT Ex Lgt'">(font-family: XFINITY Sans TT Ex Lgt) Lorem</div>
    <div style="font-family: 'XFINITY Sans TT Lgt'">(font-family: XFINITY Sans TT Lgt) Lorem</div>
```

would not be discovered otherwise.  The original code would return "XFINITY Sans TT"  for all of them, which won't pass further checks.