### PR TITLE
Try to play AVC codec even if H.264 decoder only advertises byte-stream profile.

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -798,11 +798,10 @@ const static HashSet<AtomicString>& codecSet()
             Vector<AtomicString> webkitCodecs;
         };
 
-        std::array<GstCapsWebKitMapping, 3> mapping = { {
-            { VideoDecoder, "video/x-h264,  profile=(string){ constrained-baseline, baseline }", { "x-h264" } },
-            { VideoDecoder, "video/x-h264, stream-format=avc", { "avc*"} },
+        GstCapsWebKitMapping mapping[] = {
+            { VideoDecoder, "video/x-h264,  profile=(string){ constrained-baseline, baseline }", { "x-h264", "avc*" } },
             { VideoDecoder, "video/mpeg, mpegversion=(int){1,2}, systemstream=(boolean)false", { "mpeg" } }
-        } };
+        };
 
         for (auto& current : mapping) {
             GList* factories = nullptr;


### PR DESCRIPTION
The playbin figures out that a conversion is needed automatically, so there's
no point special casing this here. Also remove the std::array, we have to
update two things to change, the length of the array and the thing to add, and it
adds nothing over a stack array in this case.

This fixes the EncryptedEventData test in the YouTube 2018 EME conformance suite.

* platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp:
(WebCore::codecSet):