### PR TITLE
Live content duration support

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourceClientGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourceClientGStreamerMSE.cpp
@@ -84,7 +84,7 @@ void MediaSourceClientGStreamerMSE::durationChanged(const MediaTime& duration)
     ASSERT(WTF::isMainThread());
 
     GST_TRACE("duration: %f", duration.toFloat());
-    if (!duration.isValid() || duration.isPositiveInfinite() || duration.isNegativeInfinite())
+    if (!duration.isValid() || duration.isNegativeInfinite())
         return;
 
     m_duration = duration;


### PR DESCRIPTION
In live content in the TKHD, MVHD, & MDHD boxes report 1's when the duration is unknown, then MSE report's a MediaTime duration of positiveInfinity. GStreamer ignores that value and HTMLMediaElement.duration remains at 0.
```
MediaSource::setDurationInternal(0x9a5b8540) - duration(inf)
console log HTMLMediaElement.duration == 0
```
This causes a playback failure in Comcast's MSE player. This change fixes that.