### PR TITLE
Fix to handle DRM key Session for different and same keys based on Protection events

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerBase.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerBase.cpp
@@ -378,31 +378,6 @@ void MediaPlayerPrivateGStreamerBase::clearSamples()
     m_sample = nullptr;
 }
 
-#if ENABLE(ENCRYPTED_MEDIA)
-static std::pair<Vector<GRefPtr<GstEvent>>, Vector<String>> extractEventsAndSystemsFromMessage(GstMessage* message)
-{
-    const GstStructure* structure = gst_message_get_structure(message);
-
-    const GValue* streamEncryptionAllowedSystemsValue = gst_structure_get_value(structure, "stream-encryption-systems");
-    ASSERT(streamEncryptionAllowedSystemsValue && G_VALUE_HOLDS(streamEncryptionAllowedSystemsValue, G_TYPE_STRV));
-    const char** streamEncryptionAllowedSystems = reinterpret_cast<const char**>(g_value_get_boxed(streamEncryptionAllowedSystemsValue));
-    ASSERT(streamEncryptionAllowedSystems);
-    Vector<String> streamEncryptionAllowedSystemsVector;
-    unsigned i;
-    for (i = 0; streamEncryptionAllowedSystems[i]; ++i)
-        streamEncryptionAllowedSystemsVector.append(streamEncryptionAllowedSystems[i]);
-
-    const GValue* streamEncryptionEventsList = gst_structure_get_value(structure, "stream-encryption-events");
-    ASSERT(streamEncryptionEventsList && GST_VALUE_HOLDS_LIST(streamEncryptionEventsList));
-    unsigned streamEncryptionEventsListSize = gst_value_list_get_size(streamEncryptionEventsList);
-    Vector<GRefPtr<GstEvent>> streamEncryptionEventsVector;
-    for (i = 0; i < streamEncryptionEventsListSize; ++i)
-        streamEncryptionEventsVector.append(GRefPtr<GstEvent>(static_cast<GstEvent*>(g_value_get_boxed(gst_value_list_get_value(streamEncryptionEventsList, i)))));
-
-    return std::make_pair(streamEncryptionEventsVector, streamEncryptionAllowedSystemsVector);
-}
-#endif
-
 bool MediaPlayerPrivateGStreamerBase::handleSyncMessage(GstMessage* message)
 {
     UNUSED_PARAM(message);
@@ -436,7 +411,7 @@ bool MediaPlayerPrivateGStreamerBase::handleSyncMessage(GstMessage* message)
         String eventKeySystemIdString;
 #if USE(OPENCDM)
         HashMap<String, uint32_t> keySystemProtectionEventMap;
-        Vector<char> initDataChunks;
+        Vector<uint8_t> initDataChunks;
 #endif
 
         for (auto& event : streamEncryptionInformation.first) {
@@ -467,13 +442,7 @@ bool MediaPlayerPrivateGStreamerBase::handleSyncMessage(GstMessage* message)
             }
             gst_buffer_unmap(data, &mapInfo);
         }
-#if USE(OPENCDM)
-        Ref<SharedBuffer> initData = SharedBuffer::create(WTFMove(initDataChunks));
-        if (!(isInitDataCached(initData)))
-            m_initDataCount++;
 
-        m_initDataProtectionEventsMap.append(std::make_pair(WTFMove(initData), keySystemProtectionEventMap));
-#endif
         if (!concatenatedInitDataChunksNumber)
             return false;
 
@@ -501,6 +470,14 @@ bool MediaPlayerPrivateGStreamerBase::handleSyncMessage(GstMessage* message)
             GstStructure* contextStructure = gst_context_writable_structure(context.get());
             gst_structure_set(contextStructure, "decryption-system-id", G_TYPE_STRING, preferredKeySystemUuid, nullptr);
             gst_element_set_context(GST_ELEMENT(GST_MESSAGE_SRC(message)), context.get());
+#if USE(OPENCDM)
+            if (!findAndSetPendingProtectionEventByInitData(initDataChunks, keySystemProtectionEventMap.get(preferredKeySystemUuid))) {
+                HashSet<uint32_t> protectionEvents;
+                protectionEvents.add(keySystemProtectionEventMap.get(preferredKeySystemUuid));
+                m_initDataProtectionEventsMapping.append(std::make_pair(initDataChunks, protectionEvents));
+                m_initDataCount++;
+            }
+#endif
         } else
             GST_WARNING("no proper CDM instance attached");
 
@@ -1394,22 +1371,28 @@ void MediaPlayerPrivateGStreamerBase::attemptToDecryptWithLocalInstance()
         GST_DEBUG("handling OpenCDM %s keys", m_cdmInstance->keySystem().utf8().data());
         auto& cdmInstanceOpenCDM = downcast<CDMInstanceOpenCDM>(*m_cdmInstance);
         size_t index = 0;
-        for (auto& initDataProtectionEventsMap : m_initDataProtectionEventsMap) {
+        // Optimized this in case there's only one init data to avoid comparisons and because in some cases,
+        // the JS app send us down a new init data we can't map (in this case it would be a FIXME for the case
+        // it has more than one unmapped init datas).
+        LockHolder lock(m_protectionMutex);
+        for (auto& initDataProtectionEventsMapping : m_initDataProtectionEventsMapping) {
             // Retrieve SessionId using initData.
-            String sessionId = cdmInstanceOpenCDM.getSessionIdByInitData(initDataProtectionEventsMap.first);
-            // FIXME: If initData is not mapped, then retrieve the current sessionId in case of single initData.
-            if (sessionId.isEmpty()) {
-                if (m_initDataCount == 1)
-                    sessionId = cdmInstanceOpenCDM.getCurrentSessionId();
-            }
+            String sessionId;
+            if (m_initDataCount == 1)
+                sessionId = cdmInstanceOpenCDM.getCurrentSessionId();
+            else
+                sessionId = cdmInstanceOpenCDM.sessionIdByInitData(initDataProtectionEventsMapping.first);
 
             if (!sessionId.isEmpty()) {
-                dispatchOrStoreDecryptionSession(sessionId, initDataProtectionEventsMap.second.get(GStreamerEMEUtilities::keySystemToUuid(m_cdmInstance->keySystem())));
-                m_initDataProtectionEventsMap.remove(index);
+                for (auto& protectionEvent : initDataProtectionEventsMapping.second)
+                    dispatchOrStoreDecryptionSession(sessionId, protectionEvent);
+
+                m_initDataProtectionEventsMapping.remove(index);
                 break;
             }
             index++;
         }
+        lock.unlockEarly();
     }
 #endif
 }
@@ -1423,12 +1406,12 @@ void MediaPlayerPrivateGStreamerBase::dispatchDecryptionKey(GstBuffer* buffer)
 }
 
 #if USE(OPENCDM)
-bool MediaPlayerPrivateGStreamerBase::isInitDataCached(const Ref<SharedBuffer>& initData)
+bool MediaPlayerPrivateGStreamerBase::findAndSetPendingProtectionEventByInitData(const Vector<uint8_t>& initData, const uint32_t protectionEvent)
 {
-    for (auto& initDataProtectionEventsMap : m_initDataProtectionEventsMap) {
-        if (initDataProtectionEventsMap.first->size() == initData->size()) {
-            if (!(memcmp(initDataProtectionEventsMap.first->data(), initData->data(), initData->size())))
-                return true;
+    for (auto& initDataProtectionEventsMapping : m_initDataProtectionEventsMapping) {
+        if (initDataProtectionEventsMapping.first == initData) {
+            initDataProtectionEventsMapping.second.add(protectionEvent);
+            return true;
         }
     }
 
@@ -1437,12 +1420,15 @@ bool MediaPlayerPrivateGStreamerBase::isInitDataCached(const Ref<SharedBuffer>& 
 
 void MediaPlayerPrivateGStreamerBase::dispatchOrStoreDecryptionSession(const String& sessionId, const unsigned& protectionEvent)
 {
-    if (m_handledProtectionEvents.contains(protectionEvent)) {
+    if (m_triggeredProtectionEvents.contains(protectionEvent)) {
         bool eventHandled = gst_element_send_event(m_pipeline.get(), gst_event_new_custom(GST_EVENT_CUSTOM_DOWNSTREAM_OOB,
             gst_structure_new("drm-session", "session", G_TYPE_STRING, sessionId.utf8().data(), "protectionevent", G_TYPE_UINT, protectionEvent, nullptr)));
         GST_TRACE("emitted decryption session %s on pipeline, event handled %s", sessionId.utf8().data(), boolForPrinting(eventHandled));
-        m_handledProtectionEvents.remove(protectionEvent);
-        m_protectionEventSessionMap.remove(protectionEvent);
+
+        m_triggeredProtectionEvents.remove(protectionEvent);
+
+        if (m_protectionEventSessionMap.contains(protectionEvent))
+            m_protectionEventSessionMap.remove(protectionEvent);
     } else
         m_protectionEventSessionMap.add(protectionEvent, sessionId);
 }
@@ -1450,18 +1436,27 @@ void MediaPlayerPrivateGStreamerBase::dispatchOrStoreDecryptionSession(const Str
 
 void MediaPlayerPrivateGStreamerBase::handleProtectionEvent(GstEvent* event)
 {
+    if (m_handledProtectionEvents.contains(GST_EVENT_SEQNUM(event))) {
+        GST_DEBUG("event %u already handled", GST_EVENT_SEQNUM(event));
+        m_handledProtectionEvents.remove(GST_EVENT_SEQNUM(event));
+        if (m_needToResendCredentials) {
+            GST_DEBUG("resending credentials");
+            attemptToDecryptWithLocalInstance();
+        }
 #if USE(OPENCDM)
-    m_handledProtectionEvents.add(GST_EVENT_SEQNUM(event));
-
-    if (!m_protectionEventSessionMap.isEmpty())
-        dispatchOrStoreDecryptionSession(m_protectionEventSessionMap.get(GST_EVENT_SEQNUM(event)), GST_EVENT_SEQNUM(event));
-    else {
-        const gchar* eventKeySystemId = nullptr;
-        gst_event_parse_protection(event, &eventKeySystemId, nullptr, nullptr);
-        GST_WARNING("FIXME: unhandled protection event for %s", eventKeySystemId);
-        ASSERT_NOT_REACHED();
-    }
+        else {
+            m_triggeredProtectionEvents.add(GST_EVENT_SEQNUM(event));
+            if (!m_protectionEventSessionMap.isEmpty())
+                dispatchOrStoreDecryptionSession(m_protectionEventSessionMap.get(GST_EVENT_SEQNUM(event)), GST_EVENT_SEQNUM(event));
+        }
 #endif
+        return;
+    }
+
+    const gchar* eventKeySystemId = nullptr;
+    gst_event_parse_protection(event, &eventKeySystemId, nullptr, nullptr);
+    GST_WARNING("FIXME: unhandled protection event for %s", eventKeySystemId);
+    ASSERT_NOT_REACHED();
 }
 #endif
 

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerBase.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerBase.cpp
@@ -283,6 +283,7 @@ MediaPlayerPrivateGStreamerBase::MediaPlayerPrivateGStreamerBase(MediaPlayer* pl
     , m_isEndReached(false)
     , m_usingFallbackVideoSink(false)
     , m_drawTimer(RunLoop::main(), this, &MediaPlayerPrivateGStreamerBase::repaint)
+    , m_initDataCount(0)
 {
     g_mutex_init(&m_sampleMutex);
 #if USE(COORDINATED_GRAPHICS_THREADED)
@@ -428,11 +429,15 @@ bool MediaPlayerPrivateGStreamerBase::handleSyncMessage(GstMessage* message)
         }
         GST_DEBUG("handling drm-preferred-decryption-system-id need context message");
         LockHolder lock(m_protectionMutex);
-        std::pair<Vector<GRefPtr<GstEvent>>, Vector<String>> streamEncryptionInformation = extractEventsAndSystemsFromMessage(message);
+        std::pair<Vector<GRefPtr<GstEvent>>, Vector<String>> streamEncryptionInformation = GStreamerEMEUtilities::extractEventsAndSystemsFromMessage(message);
         GST_TRACE("found %" G_GSIZE_FORMAT " protection events", streamEncryptionInformation.first.size());
         Vector<uint8_t> concatenatedInitDataChunks;
         unsigned concatenatedInitDataChunksNumber = 0;
         String eventKeySystemIdString;
+#if USE(OPENCDM)
+        HashMap<String, uint32_t> keySystemProtectionEventMap;
+        Vector<char> initDataChunks;
+#endif
 
         for (auto& event : streamEncryptionInformation.first) {
             GST_TRACE("handling protection event %u", GST_EVENT_SEQNUM(event.get()));
@@ -448,15 +453,27 @@ bool MediaPlayerPrivateGStreamerBase::handleSyncMessage(GstMessage* message)
             GST_TRACE("appending init data for %s of size %" G_GSIZE_FORMAT, eventKeySystemId, mapInfo.size);
             GST_MEMDUMP("init data", reinterpret_cast<const unsigned char *>(mapInfo.data), mapInfo.size);
             concatenatedInitDataChunks.append(mapInfo.data, mapInfo.size);
+#if USE(OPENCDM)
+            initDataChunks.append(mapInfo.data, mapInfo.size);
+#endif
             ++concatenatedInitDataChunksNumber;
             eventKeySystemIdString = eventKeySystemId;
             if (streamEncryptionInformation.second.contains(eventKeySystemId)) {
                 GST_TRACE("considering init data handled for %s", eventKeySystemId);
                 m_handledProtectionEvents.add(GST_EVENT_SEQNUM(event.get()));
+#if USE(OPENCDM)
+                keySystemProtectionEventMap.add(eventKeySystemId, GST_EVENT_SEQNUM(event.get()));
+#endif
             }
             gst_buffer_unmap(data, &mapInfo);
         }
+#if USE(OPENCDM)
+        Ref<SharedBuffer> initData = SharedBuffer::create(WTFMove(initDataChunks));
+        if (!(isInitDataCached(initData)))
+            m_initDataCount++;
 
+        m_initDataProtectionEventsMap.append(std::make_pair(WTFMove(initData), keySystemProtectionEventMap));
+#endif
         if (!concatenatedInitDataChunksNumber)
             return false;
 
@@ -1376,9 +1393,23 @@ void MediaPlayerPrivateGStreamerBase::attemptToDecryptWithLocalInstance()
     if (is<CDMInstanceOpenCDM>(*m_cdmInstance)) {
         GST_DEBUG("handling OpenCDM %s keys", m_cdmInstance->keySystem().utf8().data());
         auto& cdmInstanceOpenCDM = downcast<CDMInstanceOpenCDM>(*m_cdmInstance);
-        String sessionId = cdmInstanceOpenCDM.getCurrentSessionId();
-        ASSERT(!sessionId.isEmpty());
-        dispatchDecryptionSession(sessionId);
+        size_t index = 0;
+        for (auto& initDataProtectionEventsMap : m_initDataProtectionEventsMap) {
+            // Retrieve SessionId using initData.
+            String sessionId = cdmInstanceOpenCDM.getSessionIdByInitData(initDataProtectionEventsMap.first);
+            // FIXME: If initData is not mapped, then retrieve the current sessionId in case of single initData.
+            if (sessionId.isEmpty()) {
+                if (m_initDataCount == 1)
+                    sessionId = cdmInstanceOpenCDM.getCurrentSessionId();
+            }
+
+            if (!sessionId.isEmpty()) {
+                dispatchOrStoreDecryptionSession(sessionId, initDataProtectionEventsMap.second.get(GStreamerEMEUtilities::keySystemToUuid(m_cdmInstance->keySystem())));
+                m_initDataProtectionEventsMap.remove(index);
+                break;
+            }
+            index++;
+        }
     }
 #endif
 }
@@ -1391,30 +1422,46 @@ void MediaPlayerPrivateGStreamerBase::dispatchDecryptionKey(GstBuffer* buffer)
     GST_TRACE("emitted decryption cipher key on pipeline, event handled %s, need to resend credentials %s", boolForPrinting(eventHandled), boolForPrinting(m_needToResendCredentials));
 }
 
-void MediaPlayerPrivateGStreamerBase::dispatchDecryptionSession(const String& sessionId)
+#if USE(OPENCDM)
+bool MediaPlayerPrivateGStreamerBase::isInitDataCached(const Ref<SharedBuffer>& initData)
 {
-    bool eventHandled = gst_element_send_event(m_pipeline.get(), gst_event_new_custom(GST_EVENT_CUSTOM_DOWNSTREAM_OOB,
-        gst_structure_new("drm-session", "session", G_TYPE_STRING, sessionId.utf8().data(), nullptr)));
-    m_needToResendCredentials = m_handledProtectionEvents.size() > 0;
-    GST_TRACE("emitted decryption session %s on pipeline, event handled %s, need to resend credentials %s", sessionId.utf8().data(), boolForPrinting(eventHandled), boolForPrinting(m_needToResendCredentials));
+    for (auto& initDataProtectionEventsMap : m_initDataProtectionEventsMap) {
+        if (initDataProtectionEventsMap.first->size() == initData->size()) {
+            if (!(memcmp(initDataProtectionEventsMap.first->data(), initData->data(), initData->size())))
+                return true;
+        }
+    }
+
+    return false;
 }
+
+void MediaPlayerPrivateGStreamerBase::dispatchOrStoreDecryptionSession(const String& sessionId, const unsigned& protectionEvent)
+{
+    if (m_handledProtectionEvents.contains(protectionEvent)) {
+        bool eventHandled = gst_element_send_event(m_pipeline.get(), gst_event_new_custom(GST_EVENT_CUSTOM_DOWNSTREAM_OOB,
+            gst_structure_new("drm-session", "session", G_TYPE_STRING, sessionId.utf8().data(), "protectionevent", G_TYPE_UINT, protectionEvent, nullptr)));
+        GST_TRACE("emitted decryption session %s on pipeline, event handled %s", sessionId.utf8().data(), boolForPrinting(eventHandled));
+        m_handledProtectionEvents.remove(protectionEvent);
+        m_protectionEventSessionMap.remove(protectionEvent);
+    } else
+        m_protectionEventSessionMap.add(protectionEvent, sessionId);
+}
+#endif
 
 void MediaPlayerPrivateGStreamerBase::handleProtectionEvent(GstEvent* event)
 {
-    if (m_handledProtectionEvents.contains(GST_EVENT_SEQNUM(event))) {
-        GST_DEBUG("event %u already handled", GST_EVENT_SEQNUM(event));
-        m_handledProtectionEvents.remove(GST_EVENT_SEQNUM(event));
-        if (m_needToResendCredentials) {
-            GST_DEBUG("resending credentials");
-            attemptToDecryptWithLocalInstance();
-        }
-        return;
-    }
+#if USE(OPENCDM)
+    m_handledProtectionEvents.add(GST_EVENT_SEQNUM(event));
 
-    const gchar* eventKeySystemId = nullptr;
-    gst_event_parse_protection(event, &eventKeySystemId, nullptr, nullptr);
-    GST_WARNING("FIXME: unhandled protection event for %s", eventKeySystemId);
-    ASSERT_NOT_REACHED();
+    if (!m_protectionEventSessionMap.isEmpty())
+        dispatchOrStoreDecryptionSession(m_protectionEventSessionMap.get(GST_EVENT_SEQNUM(event)), GST_EVENT_SEQNUM(event));
+    else {
+        const gchar* eventKeySystemId = nullptr;
+        gst_event_parse_protection(event, &eventKeySystemId, nullptr, nullptr);
+        GST_WARNING("FIXME: unhandled protection event for %s", eventKeySystemId);
+        ASSERT_NOT_REACHED();
+    }
+#endif
 }
 #endif
 

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerBase.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerBase.cpp
@@ -1375,7 +1375,7 @@ void MediaPlayerPrivateGStreamerBase::attemptToDecryptWithLocalInstance()
         // the JS app send us down a new init data we can't map (in this case it would be a FIXME for the case
         // it has more than one unmapped init datas).
         LockHolder lock(m_protectionMutex);
-        for (auto& initDataProtectionEventsMapping : m_initDataProtectionEventsMapping) {
+        for (const auto& initDataProtectionEventsMapping : m_initDataProtectionEventsMapping) {
             // Retrieve SessionId using initData.
             String sessionId;
             if (m_initDataCount == 1)
@@ -1406,7 +1406,7 @@ void MediaPlayerPrivateGStreamerBase::dispatchDecryptionKey(GstBuffer* buffer)
 }
 
 #if USE(OPENCDM)
-bool MediaPlayerPrivateGStreamerBase::findAndSetPendingProtectionEventByInitData(const Vector<uint8_t>& initData, const uint32_t protectionEvent)
+bool MediaPlayerPrivateGStreamerBase::findAndSetPendingProtectionEventByInitData(const Vector<uint8_t>& initData, uint32_t protectionEvent)
 {
     for (auto& initDataProtectionEventsMapping : m_initDataProtectionEventsMapping) {
         if (initDataProtectionEventsMapping.first == initData) {

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerBase.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerBase.cpp
@@ -283,7 +283,6 @@ MediaPlayerPrivateGStreamerBase::MediaPlayerPrivateGStreamerBase(MediaPlayer* pl
     , m_isEndReached(false)
     , m_usingFallbackVideoSink(false)
     , m_drawTimer(RunLoop::main(), this, &MediaPlayerPrivateGStreamerBase::repaint)
-    , m_initDataCount(0)
 {
     g_mutex_init(&m_sampleMutex);
 #if USE(COORDINATED_GRAPHICS_THREADED)
@@ -471,12 +470,7 @@ bool MediaPlayerPrivateGStreamerBase::handleSyncMessage(GstMessage* message)
             gst_structure_set(contextStructure, "decryption-system-id", G_TYPE_STRING, preferredKeySystemUuid, nullptr);
             gst_element_set_context(GST_ELEMENT(GST_MESSAGE_SRC(message)), context.get());
 #if USE(OPENCDM)
-            if (!findAndSetPendingProtectionEventByInitData(initDataChunks, keySystemProtectionEventMap.get(preferredKeySystemUuid))) {
-                HashSet<uint32_t> protectionEvents;
-                protectionEvents.add(keySystemProtectionEventMap.get(preferredKeySystemUuid));
-                m_initDataProtectionEventsMapping.append(std::make_pair(initDataChunks, protectionEvents));
-                m_initDataCount++;
-            }
+            addPendingProtectionEventToInitDataMapping(initDataChunks, keySystemProtectionEventMap.get(preferredKeySystemUuid));
 #endif
         } else
             GST_WARNING("no proper CDM instance attached");
@@ -1371,20 +1365,18 @@ void MediaPlayerPrivateGStreamerBase::attemptToDecryptWithLocalInstance()
         GST_DEBUG("handling OpenCDM %s keys", m_cdmInstance->keySystem().utf8().data());
         auto& cdmInstanceOpenCDM = downcast<CDMInstanceOpenCDM>(*m_cdmInstance);
         size_t index = 0;
-        // Optimized this in case there's only one init data to avoid comparisons and because in some cases,
-        // the JS app send us down a new init data we can't map (in this case it would be a FIXME for the case
-        // it has more than one unmapped init datas).
+        // In case we don't get the sessionId after searching the map, we will use the current SessionId if there is only one cached init data.
+        // In some cases, the JS app will send us new init data rather than the one reported by the media stream (in this case, this would be a FIXME).
         LockHolder lock(m_protectionMutex);
         for (const auto& initDataProtectionEventsMapping : m_initDataProtectionEventsMapping) {
             // Retrieve SessionId using initData.
-            String sessionId;
-            if (m_initDataCount == 1)
-                sessionId = cdmInstanceOpenCDM.getCurrentSessionId();
-            else
-                sessionId = cdmInstanceOpenCDM.sessionIdByInitData(initDataProtectionEventsMapping.first);
-
+            String sessionId = cdmInstanceOpenCDM.sessionIdByInitData(initDataProtectionEventsMapping.first);
+            if (sessionId.isEmpty()) {
+                if (m_initDataProtectionEventsMapping.size() == 1)
+                    sessionId = cdmInstanceOpenCDM.getCurrentSessionId();
+            }
             if (!sessionId.isEmpty()) {
-                for (auto& protectionEvent : initDataProtectionEventsMapping.second)
+                for (const auto& protectionEvent : initDataProtectionEventsMapping.second)
                     dispatchOrStoreDecryptionSession(sessionId, protectionEvent);
 
                 m_initDataProtectionEventsMapping.remove(index);
@@ -1406,31 +1398,32 @@ void MediaPlayerPrivateGStreamerBase::dispatchDecryptionKey(GstBuffer* buffer)
 }
 
 #if USE(OPENCDM)
-bool MediaPlayerPrivateGStreamerBase::findAndSetPendingProtectionEventByInitData(const Vector<uint8_t>& initData, uint32_t protectionEvent)
+void MediaPlayerPrivateGStreamerBase::addPendingProtectionEventToInitDataMapping(const Vector<uint8_t>& initData, uint32_t protectionEvent)
 {
     for (auto& initDataProtectionEventsMapping : m_initDataProtectionEventsMapping) {
         if (initDataProtectionEventsMapping.first == initData) {
             initDataProtectionEventsMapping.second.add(protectionEvent);
-            return true;
+            return;
         }
     }
 
-    return false;
+    HashSet<uint32_t> protectionEvents;
+    protectionEvents.add(protectionEvent);
+    m_initDataProtectionEventsMapping.append(std::make_pair(initData, protectionEvents));
 }
 
 void MediaPlayerPrivateGStreamerBase::dispatchOrStoreDecryptionSession(const String& sessionId, const unsigned& protectionEvent)
 {
-    if (m_triggeredProtectionEvents.contains(protectionEvent)) {
+    if (m_handledProtectionEvents.contains(protectionEvent))
+        m_protectionEventSessionMap.add(protectionEvent, sessionId);
+    else {
         bool eventHandled = gst_element_send_event(m_pipeline.get(), gst_event_new_custom(GST_EVENT_CUSTOM_DOWNSTREAM_OOB,
             gst_structure_new("drm-session", "session", G_TYPE_STRING, sessionId.utf8().data(), "protectionevent", G_TYPE_UINT, protectionEvent, nullptr)));
         GST_TRACE("emitted decryption session %s on pipeline, event handled %s", sessionId.utf8().data(), boolForPrinting(eventHandled));
 
-        m_triggeredProtectionEvents.remove(protectionEvent);
-
         if (m_protectionEventSessionMap.contains(protectionEvent))
             m_protectionEventSessionMap.remove(protectionEvent);
-    } else
-        m_protectionEventSessionMap.add(protectionEvent, sessionId);
+    }
 }
 #endif
 
@@ -1445,8 +1438,7 @@ void MediaPlayerPrivateGStreamerBase::handleProtectionEvent(GstEvent* event)
         }
 #if USE(OPENCDM)
         else {
-            m_triggeredProtectionEvents.add(GST_EVENT_SEQNUM(event));
-            if (!m_protectionEventSessionMap.isEmpty())
+            if (m_protectionEventSessionMap.contains(GST_EVENT_SEQNUM(event)))
                 dispatchOrStoreDecryptionSession(m_protectionEventSessionMap.get(GST_EVENT_SEQNUM(event)), GST_EVENT_SEQNUM(event));
         }
 #endif

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerBase.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerBase.h
@@ -147,10 +147,13 @@ public:
     void cdmInstanceAttached(const CDMInstance&) override;
     void cdmInstanceDetached(const CDMInstance&) override;
     void dispatchDecryptionKey(GstBuffer*);
-    void dispatchDecryptionSession(const String&);
+    void dispatchOrStoreDecryptionSession(const String&, const unsigned&);
     void handleProtectionEvent(GstEvent*);
     void attemptToDecryptWithLocalInstance();
     void attemptToDecryptWithInstance(const CDMInstance&) override;
+#endif
+#if USE(OPENCDM)
+    bool isInitDataCached(const Ref<SharedBuffer>&);
 #endif
 
     static bool supportsKeySystem(const String& keySystem, const String& mimeType);
@@ -278,6 +281,11 @@ protected:
 #endif
 
     WeakPtrFactory<MediaPlayerPrivateGStreamerBase> m_weakPtrFactory;
+#if USE(OPENCDM)
+    Vector<std::pair<Ref<SharedBuffer>, HashMap<String, uint32_t>>> m_initDataProtectionEventsMap;
+    HashMap<unsigned, String> m_protectionEventSessionMap;
+    size_t m_initDataCount;
+#endif
 };
 
 }

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerBase.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerBase.h
@@ -153,7 +153,7 @@ public:
     void attemptToDecryptWithInstance(const CDMInstance&) override;
 #endif
 #if USE(OPENCDM)
-    bool isInitDataCached(const Ref<SharedBuffer>&);
+    bool findAndSetPendingProtectionEventByInitData(const Vector<uint8_t>&, const uint32_t);
 #endif
 
     static bool supportsKeySystem(const String& keySystem, const String& mimeType);
@@ -282,9 +282,10 @@ protected:
 
     WeakPtrFactory<MediaPlayerPrivateGStreamerBase> m_weakPtrFactory;
 #if USE(OPENCDM)
-    Vector<std::pair<Ref<SharedBuffer>, HashMap<String, uint32_t>>> m_initDataProtectionEventsMap;
-    HashMap<unsigned, String> m_protectionEventSessionMap;
     size_t m_initDataCount;
+    HashSet<uint32_t> m_triggeredProtectionEvents;
+    HashMap<unsigned, String> m_protectionEventSessionMap;
+    Vector<std::pair<Vector<uint8_t>, HashSet<uint32_t>>> m_initDataProtectionEventsMapping;
 #endif
 };
 

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerBase.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerBase.h
@@ -153,7 +153,7 @@ public:
     void attemptToDecryptWithInstance(const CDMInstance&) override;
 #endif
 #if USE(OPENCDM)
-    bool findAndSetPendingProtectionEventByInitData(const Vector<uint8_t>&, const uint32_t);
+    bool findAndSetPendingProtectionEventByInitData(const Vector<uint8_t>&, uint32_t);
 #endif
 
     static bool supportsKeySystem(const String& keySystem, const String& mimeType);

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerBase.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerBase.h
@@ -147,13 +147,13 @@ public:
     void cdmInstanceAttached(const CDMInstance&) override;
     void cdmInstanceDetached(const CDMInstance&) override;
     void dispatchDecryptionKey(GstBuffer*);
-    void dispatchOrStoreDecryptionSession(const String&, const unsigned&);
+    virtual void dispatchOrStoreDecryptionSession(const String&, const unsigned&);
     void handleProtectionEvent(GstEvent*);
     void attemptToDecryptWithLocalInstance();
     void attemptToDecryptWithInstance(const CDMInstance&) override;
 #endif
 #if USE(OPENCDM)
-    bool findAndSetPendingProtectionEventByInitData(const Vector<uint8_t>&, uint32_t);
+    void addPendingProtectionEventToInitDataMapping(const Vector<uint8_t>&, uint32_t);
 #endif
 
     static bool supportsKeySystem(const String& keySystem, const String& mimeType);
@@ -282,8 +282,6 @@ protected:
 
     WeakPtrFactory<MediaPlayerPrivateGStreamerBase> m_weakPtrFactory;
 #if USE(OPENCDM)
-    size_t m_initDataCount;
-    HashSet<uint32_t> m_triggeredProtectionEvents;
     HashMap<unsigned, String> m_protectionEventSessionMap;
     Vector<std::pair<Vector<uint8_t>, HashSet<uint32_t>>> m_initDataProtectionEventsMapping;
 #endif

--- a/Source/WebCore/platform/graphics/gstreamer/eme/CDMOpenCDM.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/CDMOpenCDM.cpp
@@ -314,6 +314,7 @@ void CDMInstanceOpenCDM::updateLicense(const String& sessionId, LicenseType, con
 {
     // FIXME: At some point we will probably need to fix the API in OpenCDM, handle a key status vector and probably call the update key statuses algoritm.
     std::string responseMessage;
+    m_openCdmSession->SelectSession(sessionId.utf8().data());
     media::OpenCdm::KeyStatus keyStatus = m_openCdmSession->Update(reinterpret_cast<unsigned char*>(const_cast<char*>(response.data())), response.size(), responseMessage);
     GST_DEBUG("session id %s, key status is %ld", sessionId.utf8().data(), static_cast<long>(keyStatus));
     if (keyStatus == media::OpenCdm::KeyStatus::Usable) {
@@ -462,6 +463,23 @@ String CDMInstanceOpenCDM::getCurrentSessionId() const
         GST_WARNING("more than one session");
 
     return sessionIdMap.begin()->key;
+}
+
+String CDMInstanceOpenCDM::getSessionIdByInitData(const Ref<SharedBuffer>& initData) const
+{
+    if (sessionIdMap.isEmpty()) {
+        GST_WARNING("no sessions");
+        return { };
+    }
+
+    for (auto& sessionIdInitDataMap : sessionIdMap) {
+        if (sessionIdInitDataMap.value->size() == initData->size()) {
+            if (!(memcmp(sessionIdInitDataMap.value->data(), initData->data(), initData->size())))
+                return sessionIdInitDataMap.key;
+        }
+    }
+
+    return { };
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/gstreamer/eme/CDMOpenCDM.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/CDMOpenCDM.cpp
@@ -465,7 +465,7 @@ String CDMInstanceOpenCDM::getCurrentSessionId() const
     return sessionIdMap.begin()->key;
 }
 
-String CDMInstanceOpenCDM::getSessionIdByInitData(const Ref<SharedBuffer>& initData) const
+String CDMInstanceOpenCDM::sessionIdByInitData(const Vector<uint8_t>& initData) const
 {
     if (sessionIdMap.isEmpty()) {
         GST_WARNING("no sessions");
@@ -473,8 +473,8 @@ String CDMInstanceOpenCDM::getSessionIdByInitData(const Ref<SharedBuffer>& initD
     }
 
     for (auto& sessionIdInitDataMap : sessionIdMap) {
-        if (sessionIdInitDataMap.value->size() == initData->size()) {
-            if (!(memcmp(sessionIdInitDataMap.value->data(), initData->data(), initData->size())))
+        if (sessionIdInitDataMap.value->size() == initData.size()) {
+            if (!memcmp(sessionIdInitDataMap.value->data(), initData.data(), sessionIdInitDataMap.value->size()))
                 return sessionIdInitDataMap.key;
         }
     }

--- a/Source/WebCore/platform/graphics/gstreamer/eme/CDMOpenCDM.h
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/CDMOpenCDM.h
@@ -71,6 +71,7 @@ public:
 
     // FIXME: Session handling needs a lot of love here.
     String getCurrentSessionId() const;
+    String getSessionIdByInitData(const Ref<SharedBuffer>&) const;
 
 private:
     MediaKeyStatus getKeyStatus(std::string &);

--- a/Source/WebCore/platform/graphics/gstreamer/eme/CDMOpenCDM.h
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/CDMOpenCDM.h
@@ -71,7 +71,7 @@ public:
 
     // FIXME: Session handling needs a lot of love here.
     String getCurrentSessionId() const;
-    String getSessionIdByInitData(const Ref<SharedBuffer>&) const;
+    String sessionIdByInitData(const Vector<uint8_t>&) const;
 
 private:
     MediaKeyStatus getKeyStatus(std::string &);

--- a/Source/WebCore/platform/graphics/gstreamer/eme/GStreamerEMEUtilities.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/GStreamerEMEUtilities.cpp
@@ -86,6 +86,29 @@ GstElement* GStreamerEMEUtilities::createDecryptor(const char* protectionSystem)
 #error "At least a GStreamer version 1.5.3 is required to enable ENCRYPTED_MEDIA."
 #endif
 
+std::pair<Vector<GRefPtr<GstEvent>>, Vector<String>>  GStreamerEMEUtilities::extractEventsAndSystemsFromMessage(GstMessage* message)
+{
+    const GstStructure* structure = gst_message_get_structure(message);
+
+    const GValue* streamEncryptionAllowedSystemsValue = gst_structure_get_value(structure, "stream-encryption-systems");
+    ASSERT(streamEncryptionAllowedSystemsValue && G_VALUE_HOLDS(streamEncryptionAllowedSystemsValue, G_TYPE_STRV));
+    const char** streamEncryptionAllowedSystems = reinterpret_cast<const char**>(g_value_get_boxed(streamEncryptionAllowedSystemsValue));
+    ASSERT(streamEncryptionAllowedSystems);
+    Vector<String> streamEncryptionAllowedSystemsVector;
+    unsigned i;
+    for (i = 0; streamEncryptionAllowedSystems[i]; ++i)
+        streamEncryptionAllowedSystemsVector.append(streamEncryptionAllowedSystems[i]);
+
+    const GValue* streamEncryptionEventsList = gst_structure_get_value(structure, "stream-encryption-events");
+    ASSERT(streamEncryptionEventsList && GST_VALUE_HOLDS_LIST(streamEncryptionEventsList));
+    unsigned streamEncryptionEventsListSize = gst_value_list_get_size(streamEncryptionEventsList);
+    Vector<GRefPtr<GstEvent>> streamEncryptionEventsVector;
+    for (i = 0; i < streamEncryptionEventsListSize; ++i)
+        streamEncryptionEventsVector.append(GRefPtr<GstEvent>(static_cast<GstEvent*>(g_value_get_boxed(gst_value_list_get_value(streamEncryptionEventsList, i)))));
+
+    return std::make_pair(streamEncryptionEventsVector, streamEncryptionAllowedSystemsVector);
+}
+
 }
 
 #endif // ENABLE(ENCRYPTED_MEDIA) && USE(GSTREAMER)

--- a/Source/WebCore/platform/graphics/gstreamer/eme/GStreamerEMEUtilities.h
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/GStreamerEMEUtilities.h
@@ -23,6 +23,7 @@
 
 #if ENABLE(ENCRYPTED_MEDIA) && USE(GSTREAMER)
 
+#include "GRefPtrGStreamer.h"
 #include <gst/gst.h>
 #include <wtf/text/WTFString.h>
 
@@ -88,6 +89,7 @@ public:
     }
 
     static GstElement* createDecryptor(const char* protectionSystem);
+    static std::pair<Vector<GRefPtr<GstEvent>>, Vector<String>> extractEventsAndSystemsFromMessage(GstMessage*);
 };
 
 }

--- a/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp
@@ -302,6 +302,7 @@ static gboolean webkitMediaCommonEncryptionDecryptSinkEventHandler(GstBaseTransf
         GST_TRACE_OBJECT(self, "received protection event for %s", systemId);
 
         if (!g_strcmp0(systemId, klass->protectionSystemId)) {
+            klass->receivedProtectionEvent(self, GST_EVENT_SEQNUM(event));
             GST_DEBUG_OBJECT(self, "sending protection event to the pipeline");
             gst_element_post_message(GST_ELEMENT(self),
                 gst_message_new_element(GST_OBJECT(self),

--- a/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.h
@@ -57,6 +57,7 @@ struct _WebKitMediaCommonEncryptionDecryptClass {
     gboolean (*setupCipher)(WebKitMediaCommonEncryptionDecrypt*, GstBuffer*);
     gboolean (*decrypt)(WebKitMediaCommonEncryptionDecrypt*, GstBuffer* ivBuffer, GstBuffer* buffer, unsigned subSamplesCount, GstBuffer* subSamplesBuffer);
     void (*releaseCipher)(WebKitMediaCommonEncryptionDecrypt*);
+    void (*receivedProtectionEvent)(WebKitMediaCommonEncryptionDecrypt*, unsigned);
 };
 
 G_END_DECLS

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -174,8 +174,6 @@ AppendPipeline::AppendPipeline(Ref<MediaSourceClientGStreamerMSE> mediaSourceCli
     , m_appendState(AppendState::NotStarted)
     , m_abortPending(false)
     , m_streamType(Unknown)
-    , m_protectionEventTriggered(false)
-    , m_decryptionStructureDispatched(false)
 {
     ASSERT(WTF::isMainThread());
 
@@ -353,9 +351,6 @@ void AppendPipeline::handleNeedContextSyncMessage(GstMessage* message)
 
             gst_buffer_unmap(data, &mapInfo);
         }
-
-        m_decryptionStructureDispatched = false;
-        m_protectionEventTriggered = false;
 #endif
         if (WTF::isMainThread())
             transitionTo(AppendState::KeyNegotiation, true);
@@ -452,12 +447,6 @@ void AppendPipeline::handleElementMessage(GstMessage* message)
         GST_DEBUG("sending drm-key-needed message from %s to the player", GST_MESSAGE_SRC_NAME(message));
         GRefPtr<GstEvent> event;
         gst_structure_get(structure, "event", GST_TYPE_EVENT, &event.outPtr(), nullptr);
-#if USE(OPENCDM)
-        if (m_pendingDecryptionStructure)
-            gst_element_send_event(m_pipeline.get(), gst_event_new_custom(GST_EVENT_CUSTOM_DOWNSTREAM_OOB, m_pendingDecryptionStructure.release()));
-        else
-            m_protectionEventTriggered = true;
-#endif
         m_playerPrivate->handleProtectionEvent(event.get());
     }
 }
@@ -1346,13 +1335,10 @@ void AppendPipeline::dispatchPendingDecryptionStructure()
 
     // Release the m_pendingDecryptionStructure object since
     // gst_event_new_custom() takes over ownership of it.
-    if (m_protectionEventTriggered) {
-        gst_element_send_event(m_pipeline.get(), gst_event_new_custom(GST_EVENT_CUSTOM_DOWNSTREAM_OOB, m_pendingDecryptionStructure.release()));
-        m_keySystemProtectionEventMap.clear();
-    }
+    gst_element_send_event(m_pipeline.get(), gst_event_new_custom(GST_EVENT_CUSTOM_DOWNSTREAM_OOB, m_pendingDecryptionStructure.release()));
+    m_keySystemProtectionEventMap.clear();
 
     setAppendState(AppendState::Ongoing);
-    m_decryptionStructureDispatched = true;
 }
 
 void AppendPipeline::dispatchDecryptionStructure(GUniquePtr<GstStructure>&& structure)

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -174,6 +174,8 @@ AppendPipeline::AppendPipeline(Ref<MediaSourceClientGStreamerMSE> mediaSourceCli
     , m_appendState(AppendState::NotStarted)
     , m_abortPending(false)
     , m_streamType(Unknown)
+    , m_protectionEventTriggered(false)
+    , m_decryptionStructureDispatched(false)
 {
     ASSERT(WTF::isMainThread());
 
@@ -330,6 +332,26 @@ void AppendPipeline::handleNeedContextSyncMessage(GstMessage* message)
         return;
 
     if (!g_strcmp0(contextType, "drm-preferred-decryption-system-id")) {
+#if USE(OPENCDM)
+        std::pair<Vector<GRefPtr<GstEvent>>, Vector<String>> streamEncryptionInformation = GStreamerEMEUtilities::extractEventsAndSystemsFromMessage(message);
+        for (auto& event : streamEncryptionInformation.first) {
+            const char* eventKeySystemId = nullptr;
+            GstBuffer* data = nullptr;
+            gst_event_parse_protection(event.get(), &eventKeySystemId, &data, nullptr);
+
+            GstMapInfo mapInfo;
+            if (!gst_buffer_map(data, &mapInfo, GST_MAP_READ)) {
+                GST_WARNING("cannot map %s protection data", eventKeySystemId);
+                break;
+            }
+
+            m_initData.append(mapInfo.data, mapInfo.size);
+            if (streamEncryptionInformation.second.contains(eventKeySystemId))
+                m_keySystemProtectionEventMap.add(eventKeySystemId, GST_EVENT_SEQNUM(event.get()));
+
+            gst_buffer_unmap(data, &mapInfo);
+        }
+#endif
         if (WTF::isMainThread())
             transitionTo(AppendState::KeyNegotiation, true);
         else {
@@ -425,6 +447,11 @@ void AppendPipeline::handleElementMessage(GstMessage* message)
         GST_DEBUG("sending drm-key-needed message from %s to the player", GST_MESSAGE_SRC_NAME(message));
         GRefPtr<GstEvent> event;
         gst_structure_get(structure, "event", GST_TYPE_EVENT, &event.outPtr(), nullptr);
+#if USE(OPENCDM)
+        m_protectionEventTriggered = true;
+        if (m_pendingDecryptionStructure)
+            gst_element_send_event(m_pipeline.get(), gst_event_new_custom(GST_EVENT_CUSTOM_DOWNSTREAM_OOB, m_pendingDecryptionStructure.release()));
+#endif
         m_playerPrivate->handleProtectionEvent(event.get());
     }
 }
@@ -1313,9 +1340,11 @@ void AppendPipeline::dispatchPendingDecryptionStructure()
 
     // Release the m_pendingDecryptionStructure object since
     // gst_event_new_custom() takes over ownership of it.
-    gst_element_send_event(m_pipeline.get(), gst_event_new_custom(GST_EVENT_CUSTOM_DOWNSTREAM_OOB, m_pendingDecryptionStructure.release()));
+    if (m_protectionEventTriggered)
+        gst_element_send_event(m_pipeline.get(), gst_event_new_custom(GST_EVENT_CUSTOM_DOWNSTREAM_OOB, m_pendingDecryptionStructure.release()));
 
     setAppendState(AppendState::Ongoing);
+    m_decryptionStructureDispatched = true;
 }
 
 void AppendPipeline::dispatchDecryptionStructure(GUniquePtr<GstStructure>&& structure)
@@ -1329,6 +1358,23 @@ void AppendPipeline::dispatchDecryptionStructure(GUniquePtr<GstStructure>&& stru
             GST_TRACE("no decryptor yet, waiting for it");
     } else
         GST_TRACE("append pipeline %p not in key negotiation", this);
+}
+#endif
+
+#if USE(OPENCDM)
+bool AppendPipeline::isDecryptionStructureDispatched()
+{
+    return m_decryptionStructureDispatched;
+}
+
+Vector<char> AppendPipeline::getInitData()
+{
+    return m_initData;
+}
+
+HashMap<String, unsigned> AppendPipeline::getKeySystemProtectionEventMap()
+{
+    return m_keySystemProtectionEventMap;
 }
 #endif
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -346,11 +346,16 @@ void AppendPipeline::handleNeedContextSyncMessage(GstMessage* message)
             }
 
             m_initData.append(mapInfo.data, mapInfo.size);
+            // Keeping all eventKeySystemId and protection events received, since
+            // Appendpipeline does not know which CDM instance is actually selected.
             if (streamEncryptionInformation.second.contains(eventKeySystemId))
                 m_keySystemProtectionEventMap.add(eventKeySystemId, GST_EVENT_SEQNUM(event.get()));
 
             gst_buffer_unmap(data, &mapInfo);
         }
+
+        m_decryptionStructureDispatched = false;
+        m_protectionEventTriggered = false;
 #endif
         if (WTF::isMainThread())
             transitionTo(AppendState::KeyNegotiation, true);
@@ -448,9 +453,10 @@ void AppendPipeline::handleElementMessage(GstMessage* message)
         GRefPtr<GstEvent> event;
         gst_structure_get(structure, "event", GST_TYPE_EVENT, &event.outPtr(), nullptr);
 #if USE(OPENCDM)
-        m_protectionEventTriggered = true;
         if (m_pendingDecryptionStructure)
             gst_element_send_event(m_pipeline.get(), gst_event_new_custom(GST_EVENT_CUSTOM_DOWNSTREAM_OOB, m_pendingDecryptionStructure.release()));
+        else
+            m_protectionEventTriggered = true;
 #endif
         m_playerPrivate->handleProtectionEvent(event.get());
     }
@@ -1340,8 +1346,10 @@ void AppendPipeline::dispatchPendingDecryptionStructure()
 
     // Release the m_pendingDecryptionStructure object since
     // gst_event_new_custom() takes over ownership of it.
-    if (m_protectionEventTriggered)
+    if (m_protectionEventTriggered) {
         gst_element_send_event(m_pipeline.get(), gst_event_new_custom(GST_EVENT_CUSTOM_DOWNSTREAM_OOB, m_pendingDecryptionStructure.release()));
+        m_keySystemProtectionEventMap.clear();
+    }
 
     setAppendState(AppendState::Ongoing);
     m_decryptionStructureDispatched = true;
@@ -1358,23 +1366,6 @@ void AppendPipeline::dispatchDecryptionStructure(GUniquePtr<GstStructure>&& stru
             GST_TRACE("no decryptor yet, waiting for it");
     } else
         GST_TRACE("append pipeline %p not in key negotiation", this);
-}
-#endif
-
-#if USE(OPENCDM)
-bool AppendPipeline::isDecryptionStructureDispatched()
-{
-    return m_decryptionStructureDispatched;
-}
-
-Vector<char> AppendPipeline::getInitData()
-{
-    return m_initData;
-}
-
-HashMap<String, unsigned> AppendPipeline::getKeySystemProtectionEventMap()
-{
-    return m_keySystemProtectionEventMap;
 }
 #endif
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.h
@@ -64,6 +64,11 @@ public:
 #if ENABLE(ENCRYPTED_MEDIA)
     void dispatchDecryptionStructure(GUniquePtr<GstStructure>&&);
 #endif
+#if USE(OPENCDM)
+    bool isDecryptionStructureDispatched();
+    Vector<char> getInitData();
+    HashMap<String, unsigned> getKeySystemProtectionEventMap();
+#endif
 
     // Takes ownership of caps.
     void parseDemuxerSrcPadCaps(GstCaps*);
@@ -169,6 +174,12 @@ private:
     GRefPtr<GstBuffer> m_pendingBuffer;
 #if ENABLE(ENCRYPTED_MEDIA)
     GUniquePtr<GstStructure> m_pendingDecryptionStructure;
+#endif
+#if USE(OPENCDM)
+    Vector<char> m_initData;
+    HashMap<String, unsigned> m_keySystemProtectionEventMap;
+    bool m_protectionEventTriggered;
+    bool m_decryptionStructureDispatched;
 #endif
 };
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.h
@@ -65,7 +65,6 @@ public:
     void dispatchDecryptionStructure(GUniquePtr<GstStructure>&&);
 #endif
 #if USE(OPENCDM)
-    bool isDecryptionStructureDispatched() const { return m_decryptionStructureDispatched; }
     Vector<uint8_t> initData() { return m_initData; }
     HashMap<String, unsigned> keySystemProtectionEventMap() { return m_keySystemProtectionEventMap; }
 #endif
@@ -178,8 +177,6 @@ private:
 #if USE(OPENCDM)
     Vector<uint8_t> m_initData;
     HashMap<String, unsigned> m_keySystemProtectionEventMap;
-    bool m_protectionEventTriggered;
-    bool m_decryptionStructureDispatched;
 #endif
 };
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.h
@@ -65,9 +65,9 @@ public:
     void dispatchDecryptionStructure(GUniquePtr<GstStructure>&&);
 #endif
 #if USE(OPENCDM)
-    bool isDecryptionStructureDispatched();
-    Vector<char> getInitData();
-    HashMap<String, unsigned> getKeySystemProtectionEventMap();
+    bool isDecryptionStructureDispatched() const { return m_decryptionStructureDispatched; }
+    Vector<uint8_t> initData() { return m_initData; }
+    HashMap<String, unsigned> keySystemProtectionEventMap() { return m_keySystemProtectionEventMap; }
 #endif
 
     // Takes ownership of caps.
@@ -176,7 +176,7 @@ private:
     GUniquePtr<GstStructure> m_pendingDecryptionStructure;
 #endif
 #if USE(OPENCDM)
-    Vector<char> m_initData;
+    Vector<uint8_t> m_initData;
     HashMap<String, unsigned> m_keySystemProtectionEventMap;
     bool m_protectionEventTriggered;
     bool m_decryptionStructureDispatched;

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -1061,15 +1061,14 @@ void MediaPlayerPrivateGStreamerMSE::attemptToDecryptWithInstance(const CDMInsta
 
         for (const auto& it : m_appendPipelinesMap) {
             if (!(it.value->isDecryptionStructureDispatched())) {
-                String sessionId = cdmInstanceOpenCDM.getSessionIdByInitData(SharedBuffer::create(it.value->getInitData()));
-                // FIXME: If initData is not mapped, then retrieve the current sessionId in case of single initData.
-                if (sessionId.isEmpty()) {
-                    if (m_initDataCount == 1)
-                        sessionId = cdmInstanceOpenCDM.getCurrentSessionId();
-                }
+                String sessionId;
+                if (m_initDataCount == 1)
+                    sessionId = cdmInstanceOpenCDM.getCurrentSessionId();
+                else
+                    sessionId = cdmInstanceOpenCDM.sessionIdByInitData(it.value->initData());
 
                 if (!sessionId.isEmpty()) {
-                    GUniquePtr<GstStructure> structure(gst_structure_new("drm-session", "session", G_TYPE_STRING, sessionId.utf8().data(), "protectionevent", G_TYPE_UINT, it.value->getKeySystemProtectionEventMap().get(GStreamerEMEUtilities::keySystemToUuid(cdmInstanceOpenCDM.keySystem())), nullptr));
+                    GUniquePtr<GstStructure> structure(gst_structure_new("drm-session", "session", G_TYPE_STRING, sessionId.utf8().data(), "protectionevent", G_TYPE_UINT, it.value->keySystemProtectionEventMap().get(GStreamerEMEUtilities::keySystemToUuid(cdmInstanceOpenCDM.keySystem())), nullptr));
                     it.value->dispatchDecryptionStructure(GUniquePtr<GstStructure>(gst_structure_copy(structure.get())));
                 }
             }

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
@@ -91,6 +91,7 @@ public:
 
 #if ENABLE(ENCRYPTED_MEDIA)
     void attemptToDecryptWithInstance(const CDMInstance&) final;
+    void dispatchOrStoreDecryptionSession(const String&, const unsigned&) override;
 #endif
 
 private:


### PR DESCRIPTION
This is the fix to handle multiple DRM key sessions for Widevine contents (In widevine contents, the key will be different for Audio and Video)

Successfully tested Regular flow with Video encrypted Stream, Audio encrypted Stream and both ( Video&Audio) encrypted Stream with different keys and MSE flow with YT same keys

Working Branches :
WPEWebKit : staging-emev3-wip
OpenCDM : wpe
OpenCDMi : opencdm