### PR TITLE
Define MESA_EGL_NO_X11_HEADERS when not using GLX

### DIFF
--- a/Source/WebCore/platform/graphics/epoxy/EpoxyEGL.h
+++ b/Source/WebCore/platform/graphics/epoxy/EpoxyEGL.h
@@ -24,7 +24,10 @@
  */
 
 #pragma once
-
+#if !USE(GLX)
+// This define is used in mesa and other GL implementations to exlcude X11 headers.
+#define MESA_EGL_NO_X11_HEADERS 1
+#endif
 #include <epoxy/egl.h>
 
 // Provide the EGL_CAST macro in case the eglplatform.h header doesn't define it already.

--- a/Source/WebKit/WebProcess/WebPage/wpe/AcceleratedSurfaceWPE.cpp
+++ b/Source/WebKit/WebProcess/WebPage/wpe/AcceleratedSurfaceWPE.cpp
@@ -28,6 +28,10 @@
 
 #include "WebPage.h"
 #include <WebCore/PlatformDisplayWPE.h>
+#if !USE(GLX)
+// This define is used in mesa and other GL implementations to exlcude X11 headers.
+#define MESA_EGL_NO_X11_HEADERS 1
+#endif
 #include <wpe/renderer-backend-egl.h>
 
 using namespace WebCore;


### PR DESCRIPTION
GL implementations like mesa, mali use this to exclude
X11 headers in eglplatform.h

Signed-off-by: Khem Raj <raj.khem@gmail.com>