### PR TITLE
Reorder the way JSRunLoopTimer sets 'm_isScheduled' flag.

### DIFF
--- a/Source/JavaScriptCore/runtime/JSRunLoopTimer.cpp
+++ b/Source/JavaScriptCore/runtime/JSRunLoopTimer.cpp
@@ -141,8 +141,8 @@ void JSRunLoopTimer::timerDidFireCallback()
 
 void JSRunLoopTimer::scheduleTimer(Seconds intervalInSeconds)
 {
-    m_timer.startOneShot(intervalInSeconds);
     m_isScheduled = true;
+    m_timer.startOneShot(intervalInSeconds);
 
     auto locker = holdLock(m_timerCallbacksLock);
     for (auto& task : m_timerSetCallbacks)


### PR DESCRIPTION
This is similar to https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/455