### PR TITLE
[EME] Bump license delay timeouts

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -26,11 +26,14 @@
 #include <gst/video/video-format.h>
 #include <gst/video/video-info.h>
 #include <wtf/MediaTime.h>
+#include <wtf/Seconds.h>
 
 namespace WebCore {
 
 using GstEventSeqNum = uint32_t;
 class IntSize;
+// NOTE: YouTube 2018 has tests that expect this to be >= 5s.
+const WTF::Seconds GST_EME_LICENSE_KEY_RESPONSE_TIMEOUT = WTF::Seconds(6);
 
 inline bool webkitGstCheckVersion(guint major, guint minor, guint micro)
 {

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerBase.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerBase.cpp
@@ -487,7 +487,7 @@ bool MediaPlayerPrivateGStreamerBase::handleSyncMessage(GstMessage* message)
         });
 
         GST_INFO("waiting for a CDM instance");
-        m_protectionCondition.waitFor(m_protectionMutex, Seconds(4), [this] {
+        m_protectionCondition.waitFor(m_protectionMutex, GST_EME_LICENSE_KEY_RESPONSE_TIMEOUT, [this] {
             return this->m_cdmInstance;
         });
         if (m_cdmInstance && !m_cdmInstance->keySystem().isEmpty()) {
@@ -1486,7 +1486,7 @@ void MediaPlayerPrivateGStreamerBase::handleProtectionEvent(GstEvent* event)
         m_reportedProtectionEvents.remove(eventPosition);
 #if USE(OPENCDM)
         GST_DEBUG("waiting for a CDM instance");
-        m_protectionCondition.waitFor(m_protectionMutex, Seconds(4), [this] {
+        m_protectionCondition.waitFor(m_protectionMutex, GST_EME_LICENSE_KEY_RESPONSE_TIMEOUT, [this] {
             return this->m_cdmInstance;
             });
         if (!m_cdmInstance) {

--- a/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp
@@ -195,7 +195,7 @@ static GstFlowReturn webkitMediaCommonEncryptionDecryptTransformInPlace(GstBaseT
             GST_ERROR_OBJECT(self, "can't process key requests in less than PAUSED state");
             return GST_FLOW_NOT_SUPPORTED;
         }
-        priv->condition.waitFor(priv->mutex, Seconds(5), [priv] {
+        priv->condition.waitFor(priv->mutex, GST_EME_LICENSE_KEY_RESPONSE_TIMEOUT, [priv] {
             return priv->keyReceived;
         });
         if (!priv->keyReceived) {


### PR DESCRIPTION
These were hardcoded in the player base class and the decryptor elements. They
had already drifted apart due to this, so it makes sense to put all license key
timeouts in one place.

YouTube 2018 has a test that forces the license key response to be delayed by 5
seconds, so I increased the value to 6 in all places.

* platform/graphics/gstreamer/MediaPlayerPrivateGStreamerBase.cpp:
(WebCore::MediaPlayerPrivateGStreamerBase::handleSyncMessage):
(WebCore::MediaPlayerPrivateGStreamerBase::handleProtectionEvent):
* platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp:
(webkitMediaCommonEncryptionDecryptTransformInPlace):
* platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.h: