### PR TITLE
Don't drop privilege as making libgcrypt calls

### DIFF
--- a/Source/WebCore/PAL/pal/crypto/gcrypt/Initialization.h
+++ b/Source/WebCore/PAL/pal/crypto/gcrypt/Initialization.h
@@ -37,6 +37,9 @@ static inline void initialize()
     // returned version string.
     gcry_check_version(nullptr);
 
+    // Before issuing GCRYCTL_INIT_SECMEM, set GCRY_SECMEM_FLAG_NO_PRIV_DROP
+    // to make sure no privileges drop
+    gcry_control(GCRYCTL_DISABLE_PRIV_DROP, nullptr);
     // Pre-allocate 16kB of secure memory and finish the initialization.
     gcry_control(GCRYCTL_INIT_SECMEM, 16384, nullptr);
     gcry_control(GCRYCTL_INITIALIZATION_FINISHED, nullptr);


### PR DESCRIPTION
This change fixes the issue that wpe-webkit is unable to
render webpages on westeros backend.(drm)

After libgcrypt GCRYCTL_INIT_SECMEM call, some ioctls made to
/dev/dri/card0 are failed due to privilege drop on WPEWebProcess.

This can be observed by reading /sys/kernel/debug/dri/0/clients.
```
      command   pid dev master a   uid      magic
     westeros  5133   0   y    y     0          0
  WPELauncher  9820   0   n    y     0          0
WPEWebProcess  9818   0   n    n     0          0
```
Linux drm driver, drm_ioctl_permit(), will check incoming ioctls
with permission of calling client. If client is not authenticated,
-EACCES will be returned.

We can set GCRYCTL_DISABLE_PRIV_DROP to make libgcrypt not to drop
any privilege of WPEWebProcess.

Signed-off-by: Mingyen Hung <mingyen.hung@amlogic.com>