### PR TITLE
[EME] Modify decryptor to always assume key ids are available.

### DIFF
--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
@@ -480,7 +480,7 @@ void MediaKeySession::close(Ref<DeferredPromise>&& promise)
 {
     // https://w3c.github.io/encrypted-media/#dom-mediakeysession-close
     // W3C Editor's Draft 09 November 2016
-    LOG(EME, "EME - closing session %s", m_sessionId.utf8().data());
+    LOG(EME, "EME - closing session with id [%s]", m_sessionId.utf8().data());
 
     // 1. Let session be the associated MediaKeySession object.
     // 2. If session is closed, return a resolved promise.
@@ -500,7 +500,7 @@ void MediaKeySession::close(Ref<DeferredPromise>&& promise)
     m_taskQueue.enqueueTask([this, promise = WTFMove(promise)] () mutable {
         // 5.1. Let cdm be the CDM instance represented by session's cdm instance value.
         // 5.2. Use cdm to close the key session associated with session.
-        LOG(EME, "EME - closing CDM session %s", m_sessionId.utf8().data());
+        LOG(EME, "EME - closing CDM session with id [%s]", m_sessionId.utf8().data());
         m_instance->closeSession(m_sessionId, [this, weakThis = m_weakPtrFactory.createWeakPtr(*this), promise = WTFMove(promise)] () mutable {
             if (!weakThis)
                 return;
@@ -670,7 +670,7 @@ void MediaKeySession::sessionClosed()
 {
     // https://w3c.github.io/encrypted-media/#session-closed
     // W3C Editor's Draft 09 November 2016
-    LOG(EME, "EME - closing session %s", m_sessionId.utf8().data());
+    LOG(EME, "EME - sessionClosed %s", m_sessionId.utf8().data());
 
     // 1. Let session be the associated MediaKeySession object.
     // 2. If session's session type is "persistent-usage-record", execute the following steps in parallel:

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -75,4 +75,33 @@ inline GstClockTime toGstClockTime(const MediaTime &mediaTime)
 bool gstRegistryHasElementForMediaType(GList* elementFactories, const char* capsString);
 }
 
+class GstMappedBuffer {
+    WTF_MAKE_NONCOPYABLE(GstMappedBuffer);
+public:
+    explicit GstMappedBuffer(GstBuffer* buffer, GstMapFlags flags)
+        : m_buffer(buffer)
+    {
+        m_isValid = gst_buffer_map(m_buffer, &m_info, flags);
+    }
+    // Unfortunately, GST_MAP_READWRITE is defined out of line from the MapFlags
+    // enum, and C++ is careful to not implicity convert it to an enum.
+    explicit GstMappedBuffer(GstBuffer* buffer, int flags)
+        : GstMappedBuffer(buffer, static_cast<GstMapFlags>(flags)) { }
+
+    ~GstMappedBuffer()
+    {
+        if (m_isValid)
+            gst_buffer_unmap(m_buffer, &m_info);
+    }
+
+    uint8_t* data() { ASSERT(m_isValid); return static_cast<uint8_t*>(m_info.data); }
+    size_t size() const { ASSERT(m_isValid); return static_cast<size_t>(m_info.size); }
+
+    explicit operator bool() const { return m_isValid; }
+private:
+    GstBuffer* m_buffer;
+    GstMapInfo m_info;
+    bool m_isValid { false };
+};
+
 #endif // USE(GSTREAMER)

--- a/Source/WebCore/platform/graphics/gstreamer/InbandTextTrackPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/InbandTextTrackPrivateGStreamer.cpp
@@ -103,18 +103,16 @@ void InbandTextTrackPrivateGStreamer::notifyTrackOfSample()
             GST_WARNING("Track %d got sample with no buffer.", m_index);
             continue;
         }
-        GstMapInfo info;
-        gboolean ret = gst_buffer_map(buffer, &info, GST_MAP_READ);
-        ASSERT(ret);
-        if (!ret) {
+        GstMappedBuffer mappedBuffer(buffer, GST_MAP_READ);
+        ASSERT(mappedBuffer);
+        if (!mappedBuffer) {
             GST_WARNING("Track %d unable to map buffer.", m_index);
             continue;
         }
 
-        GST_INFO("Track %d parsing sample: %.*s", m_index, static_cast<int>(info.size),
-            reinterpret_cast<char*>(info.data));
-        client()->parseWebVTTCueData(reinterpret_cast<char*>(info.data), info.size);
-        gst_buffer_unmap(buffer, &info);
+        GST_INFO("Track %d parsing sample: %.*s", m_index, static_cast<int>(mappedBuffer.size()),
+            reinterpret_cast<char*>(mappedBuffer.data()));
+        client()->parseWebVTTCueData(reinterpret_cast<char*>(mappedBuffer.data()), mappedBuffer.size());
     }
 }
 

--- a/Source/WebCore/platform/graphics/gstreamer/eme/WebKitClearKeyDecryptorGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/WebKitClearKeyDecryptorGStreamer.cpp
@@ -45,7 +45,7 @@ struct _WebKitMediaClearKeyDecryptPrivate {
 
 static void webKitMediaClearKeyDecryptorFinalize(GObject*);
 static bool webKitMediaClearKeyDecryptorSetupCipher(WebKitMediaCommonEncryptionDecrypt*, GstBuffer*);
-static bool webKitMediaClearKeyDecryptorDecrypt(WebKitMediaCommonEncryptionDecrypt*, GstBuffer* iv, GstBuffer* sample, unsigned subSamplesCount, GstBuffer* subSamples);
+static bool webKitMediaClearKeyDecryptorDecrypt(WebKitMediaCommonEncryptionDecrypt*, GstBuffer* keyIDBuffer, GstBuffer* iv, GstBuffer* sample, unsigned subSamplesCount, GstBuffer* subSamples);
 static void webKitMediaClearKeyDecryptorReleaseCipher(WebKitMediaCommonEncryptionDecrypt*);
 
 GST_DEBUG_CATEGORY_STATIC(webkit_media_clear_key_decrypt_debug_category);
@@ -167,8 +167,10 @@ static bool webKitMediaClearKeyDecryptorSetupCipher(WebKitMediaCommonEncryptionD
     return true;
 }
 
-static bool webKitMediaClearKeyDecryptorDecrypt(WebKitMediaCommonEncryptionDecrypt* self, GstBuffer* ivBuffer, GstBuffer* buffer, unsigned subSampleCount, GstBuffer* subSamplesBuffer)
+static bool webKitMediaClearKeyDecryptorDecrypt(WebKitMediaCommonEncryptionDecrypt* self, GstBuffer* keyIDBuffer, GstBuffer* ivBuffer, GstBuffer* buffer, unsigned subSampleCount, GstBuffer* subSamplesBuffer)
 {
+    UNUSED_PARAM(keyIDBuffer);
+
     GstMapInfo ivMap;
     if (!gst_buffer_map(ivBuffer, &ivMap, GST_MAP_READ)) {
         GST_ERROR_OBJECT(self, "Failed to map IV");

--- a/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp
@@ -272,8 +272,20 @@ static GstFlowReturn webkitMediaCommonEncryptionDecryptTransformInPlace(GstBaseT
 
     value = gst_structure_get_value(protectionMeta->info, "kid");
     GstBuffer* keyIDBuffer = nullptr;
-    if (value)
-        keyIDBuffer = gst_value_get_buffer(value);
+    if (!value) {
+        GST_ERROR_OBJECT(self, "No key ID available for encrypted sample");
+        return GST_FLOW_NOT_SUPPORTED;
+    }
+
+    keyIDBuffer = gst_value_get_buffer(value);
+#ifndef GST_DISABLE_GST_DEBUG
+    if (gst_debug_category_get_threshold(GST_CAT_DEFAULT) >= GST_LEVEL_MEMDUMP) {
+        GstMapInfo map;
+        gst_buffer_map (keyIDBuffer, &map, GST_MAP_READ);
+        GST_MEMDUMP_OBJECT(self, "key ID for sample", map.data, map.size);
+        gst_buffer_unmap (keyIDBuffer, &map);
+    }
+#endif
 
     WebKitMediaCommonEncryptionDecryptClass* klass = WEBKIT_MEDIA_CENC_DECRYPT_GET_CLASS(self);
     if (!klass->setupCipher(self, keyIDBuffer)) {
@@ -292,7 +304,7 @@ static GstFlowReturn webkitMediaCommonEncryptionDecryptTransformInPlace(GstBaseT
 
     GstBuffer* ivBuffer = gst_value_get_buffer(value);
     GST_TRACE_OBJECT(self, "decrypting");
-    if (!klass->decrypt(self, ivBuffer, buffer, subSampleCount, subSamplesBuffer)) {
+    if (!klass->decrypt(self, keyIDBuffer, ivBuffer, buffer, subSampleCount, subSamplesBuffer)) {
         GST_ERROR_OBJECT(self, "Decryption failed");
         klass->releaseCipher(self);
         gst_buffer_remove_meta(buffer, reinterpret_cast<GstMeta*>(protectionMeta));

--- a/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp
@@ -280,10 +280,12 @@ static GstFlowReturn webkitMediaCommonEncryptionDecryptTransformInPlace(GstBaseT
     keyIDBuffer = gst_value_get_buffer(value);
 #ifndef GST_DISABLE_GST_DEBUG
     if (gst_debug_category_get_threshold(GST_CAT_DEFAULT) >= GST_LEVEL_MEMDUMP) {
-        GstMapInfo map;
-        gst_buffer_map (keyIDBuffer, &map, GST_MAP_READ);
-        GST_MEMDUMP_OBJECT(self, "key ID for sample", map.data, map.size);
-        gst_buffer_unmap (keyIDBuffer, &map);
+        GstMappedBuffer mappedKeyID(keyIDBuffer, GST_MAP_READ);
+        if (!mappedKeyID) {
+            GST_ERROR_OBJECT(self, "failed to map key ID buffer");
+            return GST_FLOW_NOT_SUPPORTED;
+        }
+        GST_MEMDUMP_OBJECT(self, "key ID for sample", mappedKeyID.data(), mappedKeyID.size());
     }
 #endif
 
@@ -338,17 +340,16 @@ static void webkitMediaCommonEncryptionDecryptProcessPendingProtectionEvents(Web
         if (priv->m_cdmInstance)
             initData = priv->m_initDatas.get(WebCore::GStreamerEMEUtilities::keySystemToUuid(priv->m_cdmInstance->keySystem()));
         if (initData.isEmpty() || gst_buffer_memcmp(buffer, 0, initData.characters8(), initData.sizeInBytes())) {
-            GstMapInfo mapInfo;
-            if (!gst_buffer_map(buffer, &mapInfo, GST_MAP_READ)) {
+            GstMappedBuffer mappedBuffer(buffer, GST_MAP_READ);
+            if (!mappedBuffer) {
                 GST_WARNING_OBJECT(self, "cannot map protection data");
                 continue;
             }
 
-            initData = WebCore::InitData(reinterpret_cast<const uint8_t*>(mapInfo.data), mapInfo.size);
-            GST_DEBUG_OBJECT(self, "init data of size %u", mapInfo.size);
+            initData = WebCore::InitData(mappedBuffer.data(), mappedBuffer.size());
+            GST_DEBUG_OBJECT(self, "init data of size %u", mappedBuffer.size());
             GST_TRACE_OBJECT(self, "init data MD5 %s", WebCore::GStreamerEMEUtilities::initDataMD5(initData).utf8().data());
-            GST_MEMDUMP_OBJECT(self, "init data", reinterpret_cast<const uint8_t*>(mapInfo.data), mapInfo.size);
-            gst_buffer_unmap(buffer, &mapInfo);
+            GST_MEMDUMP_OBJECT(self, "init data", mappedBuffer.data(), mappedBuffer.size());
             priv->m_initDatas.set(eventKeySystemUUID, initData);
 
             priv->m_keyReceived = priv->m_cdmInstance && !klass->handleInitData(self, initData);
@@ -377,13 +378,12 @@ static void webkitMediaCommonEncryptionDecryptProcessPendingProtectionEvents(Web
 
     if (!priv->m_cdmInstance && !concatenatedInitDatas.isEmpty()) {
         GRefPtr<GstBuffer> buffer = adoptGRef(gst_buffer_new_allocate(nullptr, concatenatedInitDatas.sizeInBytes(), nullptr));
-        GstMapInfo mapInfo;
-        if (!gst_buffer_map(buffer.get(), &mapInfo, GST_MAP_WRITE)) {
+        GstMappedBuffer mappedBuffer(buffer.get(), GST_MAP_WRITE);
+        if (!mappedBuffer) {
             GST_WARNING_OBJECT(self, "cannot map writable init data");
             return;
         }
-        memcpy(mapInfo.data, concatenatedInitDatas.characters8(), concatenatedInitDatas.sizeInBytes());
-        gst_buffer_unmap(buffer.get(), &mapInfo);
+        memcpy(mappedBuffer.data(), concatenatedInitDatas.characters8(), concatenatedInitDatas.sizeInBytes());
         GST_DEBUG_OBJECT(self, "reporting concatenated init datas of size %u", concatenatedInitDatas.sizeInBytes());
         GST_TRACE_OBJECT(self, "init data MD5 %s", WebCore::GStreamerEMEUtilities::initDataMD5(concatenatedInitDatas).utf8().data());
         GST_MEMDUMP_OBJECT(self, "init data", reinterpret_cast<const uint8_t*>(concatenatedInitDatas.characters8()), concatenatedInitDatas.sizeInBytes());

--- a/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.h
@@ -59,7 +59,7 @@ struct _WebKitMediaCommonEncryptionDecryptClass {
     GstBaseTransformClass parentClass;
 
     bool (*setupCipher)(WebKitMediaCommonEncryptionDecrypt*, GstBuffer*);
-    bool (*decrypt)(WebKitMediaCommonEncryptionDecrypt*, GstBuffer* ivBuffer, GstBuffer* buffer, unsigned subSamplesCount, GstBuffer* subSamplesBuffer);
+    bool (*decrypt)(WebKitMediaCommonEncryptionDecrypt*, GstBuffer* keyIDBuffer, GstBuffer* ivBuffer, GstBuffer* buffer, unsigned subSamplesCount, GstBuffer* subSamplesBuffer);
     void (*releaseCipher)(WebKitMediaCommonEncryptionDecrypt*);
     void (*receivedProtectionEvent)(WebKitMediaCommonEncryptionDecrypt*, unsigned);
     bool (*handleInitData)(WebKitMediaCommonEncryptionDecrypt*, const WebCore::InitData&);


### PR DESCRIPTION
Ideally, I would like the opencdm server to offer a blocking decrypt
method (with a configurable timeout) and then removing the keyReceived
logic, this is a minimal patch just to start looking up sessions with
key ids, but there's still a lot of code I don't think is necessary
assuming the above decrypt method which didn't end up being implemented
in the framework.