### PR TITLE
Revert "[EME] Modify decryptor to always assume key ids are available."

### DIFF
--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
@@ -480,7 +480,7 @@ void MediaKeySession::close(Ref<DeferredPromise>&& promise)
 {
     // https://w3c.github.io/encrypted-media/#dom-mediakeysession-close
     // W3C Editor's Draft 09 November 2016
-    LOG(EME, "EME - closing session with id [%s]", m_sessionId.utf8().data());
+    LOG(EME, "EME - closing session %s", m_sessionId.utf8().data());
 
     // 1. Let session be the associated MediaKeySession object.
     // 2. If session is closed, return a resolved promise.
@@ -500,7 +500,7 @@ void MediaKeySession::close(Ref<DeferredPromise>&& promise)
     m_taskQueue.enqueueTask([this, promise = WTFMove(promise)] () mutable {
         // 5.1. Let cdm be the CDM instance represented by session's cdm instance value.
         // 5.2. Use cdm to close the key session associated with session.
-        LOG(EME, "EME - closing CDM session with id [%s]", m_sessionId.utf8().data());
+        LOG(EME, "EME - closing CDM session %s", m_sessionId.utf8().data());
         m_instance->closeSession(m_sessionId, [this, weakThis = m_weakPtrFactory.createWeakPtr(*this), promise = WTFMove(promise)] () mutable {
             if (!weakThis)
                 return;
@@ -670,7 +670,7 @@ void MediaKeySession::sessionClosed()
 {
     // https://w3c.github.io/encrypted-media/#session-closed
     // W3C Editor's Draft 09 November 2016
-    LOG(EME, "EME - sessionClosed %s", m_sessionId.utf8().data());
+    LOG(EME, "EME - closing session %s", m_sessionId.utf8().data());
 
     // 1. Let session be the associated MediaKeySession object.
     // 2. If session's session type is "persistent-usage-record", execute the following steps in parallel:

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -84,33 +84,4 @@ inline GstClockTime toGstClockTime(const MediaTime &mediaTime)
 bool gstRegistryHasElementForMediaType(GList* elementFactories, const char* capsString);
 }
 
-class GstMappedBuffer {
-    WTF_MAKE_NONCOPYABLE(GstMappedBuffer);
-public:
-    explicit GstMappedBuffer(GstBuffer* buffer, GstMapFlags flags)
-        : m_buffer(buffer)
-    {
-        m_isValid = gst_buffer_map(m_buffer, &m_info, flags);
-    }
-    // Unfortunately, GST_MAP_READWRITE is defined out of line from the MapFlags
-    // enum, and C++ is careful to not implicity convert it to an enum.
-    explicit GstMappedBuffer(GstBuffer* buffer, int flags)
-        : GstMappedBuffer(buffer, static_cast<GstMapFlags>(flags)) { }
-
-    ~GstMappedBuffer()
-    {
-        if (m_isValid)
-            gst_buffer_unmap(m_buffer, &m_info);
-    }
-
-    uint8_t* data() { ASSERT(m_isValid); return static_cast<uint8_t*>(m_info.data); }
-    size_t size() const { ASSERT(m_isValid); return static_cast<size_t>(m_info.size); }
-
-    explicit operator bool() const { return m_isValid; }
-private:
-    GstBuffer* m_buffer;
-    GstMapInfo m_info;
-    bool m_isValid { false };
-};
-
 #endif // USE(GSTREAMER)

--- a/Source/WebCore/platform/graphics/gstreamer/InbandTextTrackPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/InbandTextTrackPrivateGStreamer.cpp
@@ -103,16 +103,18 @@ void InbandTextTrackPrivateGStreamer::notifyTrackOfSample()
             GST_WARNING("Track %d got sample with no buffer.", m_index);
             continue;
         }
-        GstMappedBuffer mappedBuffer(buffer, GST_MAP_READ);
-        ASSERT(mappedBuffer);
-        if (!mappedBuffer) {
+        GstMapInfo info;
+        gboolean ret = gst_buffer_map(buffer, &info, GST_MAP_READ);
+        ASSERT(ret);
+        if (!ret) {
             GST_WARNING("Track %d unable to map buffer.", m_index);
             continue;
         }
 
-        GST_INFO("Track %d parsing sample: %.*s", m_index, static_cast<int>(mappedBuffer.size()),
-            reinterpret_cast<char*>(mappedBuffer.data()));
-        client()->parseWebVTTCueData(reinterpret_cast<char*>(mappedBuffer.data()), mappedBuffer.size());
+        GST_INFO("Track %d parsing sample: %.*s", m_index, static_cast<int>(info.size),
+            reinterpret_cast<char*>(info.data));
+        client()->parseWebVTTCueData(reinterpret_cast<char*>(info.data), info.size);
+        gst_buffer_unmap(buffer, &info);
     }
 }
 

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerBase.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerBase.cpp
@@ -1268,16 +1268,17 @@ void MediaPlayerPrivateGStreamerBase::handleProtectionStructure(const GstStructu
     GRefPtr<GstBuffer> data;
     gst_structure_get(structure, "init-data", GST_TYPE_BUFFER, &data.outPtr(), "key-system-uuid", G_TYPE_STRING, &keySystemUUID.outPtr(), nullptr);
 
-    GstMappedBuffer mappedInitData(data.get(), GST_MAP_READ);
-    if (!mappedInitData) {
+    GstMapInfo mapInfo;
+    if (!gst_buffer_map(data.get(), &mapInfo, GST_MAP_READ)) {
         GST_WARNING("cannot map protection data");
         return;
     }
 
     String keySystemUUIDString = keySystemUUID ? keySystemUUID.get() : "(unspecified)";
-    InitData initData(mappedInitData.data(), mappedInitData.size());
-    GST_TRACE("init data encountered for %s of size %" G_GSIZE_FORMAT " with MD5 %s", keySystemUUIDString.utf8().data(), mappedInitData.size(), GStreamerEMEUtilities::initDataMD5(initData));
-    GST_MEMDUMP("init data", mappedInitData.data(), mappedInitData.size());
+    GST_TRACE("init data encountered for %s of size %" G_GSIZE_FORMAT " with MD5 %s", keySystemUUIDString.utf8().data(), mapInfo.size, GStreamerEMEUtilities::initDataMD5(InitData(reinterpret_cast<const uint8_t*>(mapInfo.data), mapInfo.size)).utf8().data());
+    GST_MEMDUMP("init data", reinterpret_cast<const uint8_t*>(mapInfo.data), mapInfo.size);
+    InitData initData(reinterpret_cast<const uint8_t*>(mapInfo.data), mapInfo.size);
+    gst_buffer_unmap(data.get(), &mapInfo);
 
     RunLoop::main().dispatch([weakThis = m_weakPtrFactory.createWeakPtr(*this), keySystemUUID = keySystemUUIDString, initData] {
         if (!weakThis)

--- a/Source/WebCore/platform/graphics/gstreamer/eme/WebKitClearKeyDecryptorGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/WebKitClearKeyDecryptorGStreamer.cpp
@@ -120,20 +120,23 @@ static bool webKitMediaClearKeyDecryptorSetupCipher(WebKitMediaCommonEncryptionD
     gcry_error_t error;
 
     GRefPtr<GstBuffer> keyBuffer;
-    GstMappedBuffer mappedKeyIDBuffer(keyIDBuffer, GST_MAP_READ);
-    if (!mappedKeyIDBuffer) {
+    {
+        GstMapInfo keyIDBufferMap;
+        if (!gst_buffer_map(keyIDBuffer, &keyIDBufferMap, GST_MAP_READ)) {
             GST_ERROR_OBJECT(self, "Failed to map key ID buffer");
             return false;
-    }
+        }
 
 #if ENABLE(ENCRYPTED_MEDIA)
         for (auto& key : priv->keys) {
-            if (!gst_buffer_memcmp(key.keyID.get(), 0, mappedKeyIDBuffer.data(), mappedKeyIDBuffer.size())) {
+            if (!gst_buffer_memcmp(key.keyID.get(), 0, keyIDBufferMap.data, keyIDBufferMap.size)) {
                 keyBuffer = key.keyValue;
                 break;
             }
         }
 #endif
+
+        gst_buffer_unmap(keyIDBuffer, &keyIDBufferMap);
     }
 
     if (!keyBuffer) {
@@ -147,14 +150,15 @@ static bool webKitMediaClearKeyDecryptorSetupCipher(WebKitMediaCommonEncryptionD
         return false;
     }
 
-    GstMappedBuffer mappedKeyBuffer(keyBuffer.get(), GST_MAP_READ);
-    if (!mappedKeyBuffer) {
+    GstMapInfo keyMap;
+    if (!gst_buffer_map(keyBuffer.get(), &keyMap, GST_MAP_READ)) {
         GST_ERROR_OBJECT(self, "Failed to map decryption key");
         return false;
     }
 
-    ASSERT(keyBufferMapped.size() == CLEARKEY_SIZE);
-    error = gcry_cipher_setkey(priv->handle, mappedKeyBuffer.data(), mappedKeyBuffer.size());
+    ASSERT(keyMap.size == CLEARKEY_SIZE);
+    error = gcry_cipher_setkey(priv->handle, keyMap.data, keyMap.size);
+    gst_buffer_unmap(keyBuffer.get(), &keyMap);
     if (error) {
         GST_ERROR_OBJECT(self, "gcry_cipher_setkey failed: %s", gpg_strerror(error));
         return false;
@@ -167,20 +171,21 @@ static bool webKitMediaClearKeyDecryptorDecrypt(WebKitMediaCommonEncryptionDecry
 {
     UNUSED_PARAM(keyIDBuffer);
 
-    GstMappedBuffer mappedIVBuffer(ivBuffer, GST_MAP_READ);
-    if (!mappedIVBuffer) {
+    GstMapInfo ivMap;
+    if (!gst_buffer_map(ivBuffer, &ivMap, GST_MAP_READ)) {
         GST_ERROR_OBJECT(self, "Failed to map IV");
         return false;
     }
 
     uint8_t ctr[CLEARKEY_SIZE];
-    if (mappedIVBuffer.size() == 8) {
+    if (ivMap.size == 8) {
         memset(ctr + 8, 0, 8);
-        memcpy(ctr, mappedIVBuffer.data(), 8);
+        memcpy(ctr, ivMap.data, 8);
     } else {
-        ASSERT(mappedIVBuffer.size() == CLEARKEY_SIZE);
-        memcpy(ctr, mappedIVBuffer.data(), CLEARKEY_SIZE);
+        ASSERT(ivMap.size == CLEARKEY_SIZE);
+        memcpy(ctr, ivMap.data, CLEARKEY_SIZE);
     }
+    gst_buffer_unmap(ivBuffer, &ivMap);
 
     WebKitMediaClearKeyDecryptPrivate* priv = WEBKIT_MEDIA_CK_DECRYPT_GET_PRIVATE(WEBKIT_MEDIA_CK_DECRYPT(self));
     gcry_error_t error = gcry_cipher_setctr(priv->handle, ctr, CLEARKEY_SIZE);
@@ -189,25 +194,28 @@ static bool webKitMediaClearKeyDecryptorDecrypt(WebKitMediaCommonEncryptionDecry
         return false;
     }
 
-    GstMappedBuffer mappedBuffer(buffer, GST_MAP_READWRITE);
-    if (!mappedBuffer) {
+    GstMapInfo map;
+    gboolean bufferMapped = gst_buffer_map(buffer, &map, static_cast<GstMapFlags>(GST_MAP_READWRITE));
+    if (!bufferMapped) {
         GST_ERROR_OBJECT(self, "Failed to map buffer");
         return false;
     }
 
-    GstMappedBuffer mappedSubsamplesBuffer(subSamplesBuffer, GST_MAP_READ);
-    if (!mappedSubsamplesBuffer) {
+    GstMapInfo subSamplesMap;
+    gboolean subsamplesBufferMapped = gst_buffer_map(subSamplesBuffer, &subSamplesMap, GST_MAP_READ);
+    if (!subsamplesBufferMapped) {
         GST_ERROR_OBJECT(self, "Failed to map subsample buffer");
+        gst_buffer_unmap(buffer, &map);
         return false;
     }
 
-    GstByteReader* reader = gst_byte_reader_new(mappedSubsamplesBuffer.data(), mappedSubsamplesBuffer.size());
+    GstByteReader* reader = gst_byte_reader_new(subSamplesMap.data, subSamplesMap.size);
     unsigned position = 0;
     unsigned sampleIndex = 0;
 
     GST_DEBUG_OBJECT(self, "position: %d, size: %zu", position, map.size);
 
-    while (position < mappedBuffer.size()) {
+    while (position < map.size) {
         guint16 nBytesClear = 0;
         guint32 nBytesEncrypted = 0;
 
@@ -216,23 +224,27 @@ static bool webKitMediaClearKeyDecryptorDecrypt(WebKitMediaCommonEncryptionDecry
                 || !gst_byte_reader_get_uint32_be(reader, &nBytesEncrypted)) {
                 GST_DEBUG_OBJECT(self, "unsupported");
                 gst_byte_reader_free(reader);
+                gst_buffer_unmap(buffer, &map);
+                gst_buffer_unmap(subSamplesBuffer, &subSamplesMap);
                 return false;
             }
 
             sampleIndex++;
         } else {
             nBytesClear = 0;
-            nBytesEncrypted = mappedBuffer.size() - position;
+            nBytesEncrypted = map.size - position;
         }
 
-        GST_TRACE_OBJECT(self, "%d bytes clear (todo=%zu)", nBytesClear, mappedBuffer.size() - position);
+        GST_TRACE_OBJECT(self, "%d bytes clear (todo=%zu)", nBytesClear, map.size - position);
         position += nBytesClear;
         if (nBytesEncrypted) {
-            GST_TRACE_OBJECT(self, "%d bytes encrypted (todo=%zu)", nBytesEncrypted, mappedBuffer.size() - position);
-            error = gcry_cipher_decrypt(priv->handle, mappedBuffer.data() + position, nBytesEncrypted, 0, 0);
+            GST_TRACE_OBJECT(self, "%d bytes encrypted (todo=%zu)", nBytesEncrypted, map.size - position);
+            error = gcry_cipher_decrypt(priv->handle, map.data + position, nBytesEncrypted, 0, 0);
             if (error) {
                 GST_ERROR_OBJECT(self, "decryption failed: %s", gpg_strerror(error));
                 gst_byte_reader_free(reader);
+                gst_buffer_unmap(buffer, &map);
+                gst_buffer_unmap(subSamplesBuffer, &subSamplesMap);
                 return false;
             }
             position += nBytesEncrypted;
@@ -240,6 +252,8 @@ static bool webKitMediaClearKeyDecryptorDecrypt(WebKitMediaCommonEncryptionDecry
     }
 
     gst_byte_reader_free(reader);
+    gst_buffer_unmap(buffer, &map);
+    gst_buffer_unmap(subSamplesBuffer, &subSamplesMap);
     return true;
 }
 

--- a/Source/WebCore/platform/graphics/gstreamer/eme/WebKitClearKeyDecryptorGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/WebKitClearKeyDecryptorGStreamer.cpp
@@ -45,7 +45,7 @@ struct _WebKitMediaClearKeyDecryptPrivate {
 
 static void webKitMediaClearKeyDecryptorFinalize(GObject*);
 static bool webKitMediaClearKeyDecryptorSetupCipher(WebKitMediaCommonEncryptionDecrypt*, GstBuffer*);
-static bool webKitMediaClearKeyDecryptorDecrypt(WebKitMediaCommonEncryptionDecrypt*, GstBuffer* keyIDBuffer, GstBuffer* iv, GstBuffer* sample, unsigned subSamplesCount, GstBuffer* subSamples);
+static bool webKitMediaClearKeyDecryptorDecrypt(WebKitMediaCommonEncryptionDecrypt*, GstBuffer* iv, GstBuffer* sample, unsigned subSamplesCount, GstBuffer* subSamples);
 static void webKitMediaClearKeyDecryptorReleaseCipher(WebKitMediaCommonEncryptionDecrypt*);
 
 GST_DEBUG_CATEGORY_STATIC(webkit_media_clear_key_decrypt_debug_category);
@@ -167,10 +167,8 @@ static bool webKitMediaClearKeyDecryptorSetupCipher(WebKitMediaCommonEncryptionD
     return true;
 }
 
-static bool webKitMediaClearKeyDecryptorDecrypt(WebKitMediaCommonEncryptionDecrypt* self, GstBuffer* keyIDBuffer, GstBuffer* ivBuffer, GstBuffer* buffer, unsigned subSampleCount, GstBuffer* subSamplesBuffer)
+static bool webKitMediaClearKeyDecryptorDecrypt(WebKitMediaCommonEncryptionDecrypt* self, GstBuffer* ivBuffer, GstBuffer* buffer, unsigned subSampleCount, GstBuffer* subSamplesBuffer)
 {
-    UNUSED_PARAM(keyIDBuffer);
-
     GstMapInfo ivMap;
     if (!gst_buffer_map(ivBuffer, &ivMap, GST_MAP_READ)) {
         GST_ERROR_OBJECT(self, "Failed to map IV");

--- a/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp
@@ -286,20 +286,8 @@ static GstFlowReturn webkitMediaCommonEncryptionDecryptTransformInPlace(GstBaseT
 
     value = gst_structure_get_value(protectionMeta->info, "kid");
     GstBuffer* keyIDBuffer = nullptr;
-    if (!value) {
-        GST_ERROR_OBJECT(self, "No key ID available for encrypted sample");
-        return GST_FLOW_NOT_SUPPORTED;
-    }
-
-    keyIDBuffer = gst_value_get_buffer(value);
-#ifndef GST_DISABLE_GST_DEBUG
-    if (gst_debug_category_get_threshold(GST_CAT_DEFAULT) >= GST_LEVEL_MEMDUMP) {
-        GstMapInfo map;
-        gst_buffer_map (keyIDBuffer, &map, GST_MAP_READ);
-        GST_MEMDUMP_OBJECT(self, "key ID for sample", map.data, map.size);
-        gst_buffer_unmap (keyIDBuffer, &map);
-    }
-#endif
+    if (value)
+        keyIDBuffer = gst_value_get_buffer(value);
 
     WebKitMediaCommonEncryptionDecryptClass* klass = WEBKIT_MEDIA_CENC_DECRYPT_GET_CLASS(self);
     if (!klass->setupCipher(self, keyIDBuffer)) {
@@ -318,7 +306,7 @@ static GstFlowReturn webkitMediaCommonEncryptionDecryptTransformInPlace(GstBaseT
 
     GstBuffer* ivBuffer = gst_value_get_buffer(value);
     GST_TRACE_OBJECT(self, "decrypting");
-    if (!klass->decrypt(self, keyIDBuffer, ivBuffer, buffer, subSampleCount, subSamplesBuffer)) {
+    if (!klass->decrypt(self, ivBuffer, buffer, subSampleCount, subSamplesBuffer)) {
         GST_ERROR_OBJECT(self, "Decryption failed");
         klass->releaseCipher(self);
         gst_buffer_remove_meta(buffer, reinterpret_cast<GstMeta*>(protectionMeta));

--- a/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp
@@ -294,12 +294,10 @@ static GstFlowReturn webkitMediaCommonEncryptionDecryptTransformInPlace(GstBaseT
     keyIDBuffer = gst_value_get_buffer(value);
 #ifndef GST_DISABLE_GST_DEBUG
     if (gst_debug_category_get_threshold(GST_CAT_DEFAULT) >= GST_LEVEL_MEMDUMP) {
-        GstMappedBuffer mappedKeyID(keyIDBuffer, GST_MAP_READ);
-        if (!mappedKeyID) {
-            GST_ERROR_OBJECT(self, "failed to map key ID buffer");
-            return GST_FLOW_NOT_SUPPORTED;
-        }
-        GST_MEMDUMP_OBJECT(self, "key ID for sample", mappedKeyID.data(), mappedKeyID.size());
+        GstMapInfo map;
+        gst_buffer_map (keyIDBuffer, &map, GST_MAP_READ);
+        GST_MEMDUMP_OBJECT(self, "key ID for sample", map.data, map.size);
+        gst_buffer_unmap (keyIDBuffer, &map);
     }
 #endif
 
@@ -364,16 +362,17 @@ static void webkitMediaCommonEncryptionDecryptProcessPendingProtectionEvents(Web
         priv->m_currentEvent = GST_EVENT_SEQNUM(event.get());
 
         if (initData.isEmpty() || gst_buffer_memcmp(buffer, 0, initData.characters8(), initData.sizeInBytes())) {
-            GstMappedBuffer mappedBuffer(buffer, GST_MAP_READ);
-            if (!mappedBuffer) {
+            GstMapInfo mapInfo;
+            if (!gst_buffer_map(buffer, &mapInfo, GST_MAP_READ)) {
                 GST_WARNING_OBJECT(self, "cannot map protection data");
                 continue;
             }
 
-            initData = WebCore::InitData(mappedBuffer.data(), mappedBuffer.size());
-            GST_DEBUG_OBJECT(self, "init data of size %u", mappedBuffer.size());
+            initData = WebCore::InitData(reinterpret_cast<const uint8_t*>(mapInfo.data), mapInfo.size);
+            GST_DEBUG_OBJECT(self, "init data of size %u", mapInfo.size);
             GST_TRACE_OBJECT(self, "init data MD5 %s", WebCore::GStreamerEMEUtilities::initDataMD5(initData).utf8().data());
-            GST_MEMDUMP_OBJECT(self, "init data", mappedBuffer.data(), mappedBuffer.size());
+            GST_MEMDUMP_OBJECT(self, "init data", reinterpret_cast<const uint8_t*>(mapInfo.data), mapInfo.size);
+            gst_buffer_unmap(buffer, &mapInfo);
             priv->m_initDatas.set(eventKeySystemUUID, initData);
 
             priv->m_keyReceived = priv->m_cdmInstance && !klass->handleInitData(self, initData);
@@ -403,12 +402,13 @@ static void webkitMediaCommonEncryptionDecryptProcessPendingProtectionEvents(Web
 
     if (!priv->m_cdmInstance && !concatenatedInitDatas.isEmpty()) {
         GRefPtr<GstBuffer> buffer = adoptGRef(gst_buffer_new_allocate(nullptr, concatenatedInitDatas.sizeInBytes(), nullptr));
-        GstMappedBuffer mappedBuffer(buffer.get(), GST_MAP_WRITE);
-        if (!mappedBuffer) {
+        GstMapInfo mapInfo;
+        if (!gst_buffer_map(buffer.get(), &mapInfo, GST_MAP_WRITE)) {
             GST_WARNING_OBJECT(self, "cannot map writable init data");
             return;
         }
-        memcpy(mappedBuffer.data(), concatenatedInitDatas.characters8(), concatenatedInitDatas.sizeInBytes());
+        memcpy(mapInfo.data, concatenatedInitDatas.characters8(), concatenatedInitDatas.sizeInBytes());
+        gst_buffer_unmap(buffer.get(), &mapInfo);
         GST_DEBUG_OBJECT(self, "reporting concatenated init datas of size %u", concatenatedInitDatas.sizeInBytes());
         GST_TRACE_OBJECT(self, "init data MD5 %s", WebCore::GStreamerEMEUtilities::initDataMD5(concatenatedInitDatas).utf8().data());
         GST_MEMDUMP_OBJECT(self, "init data", reinterpret_cast<const uint8_t*>(concatenatedInitDatas.characters8()), concatenatedInitDatas.sizeInBytes());

--- a/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.h
@@ -59,7 +59,7 @@ struct _WebKitMediaCommonEncryptionDecryptClass {
     GstBaseTransformClass parentClass;
 
     bool (*setupCipher)(WebKitMediaCommonEncryptionDecrypt*, GstBuffer*);
-    bool (*decrypt)(WebKitMediaCommonEncryptionDecrypt*, GstBuffer* keyIDBuffer, GstBuffer* ivBuffer, GstBuffer* buffer, unsigned subSamplesCount, GstBuffer* subSamplesBuffer);
+    bool (*decrypt)(WebKitMediaCommonEncryptionDecrypt*, GstBuffer* ivBuffer, GstBuffer* buffer, unsigned subSamplesCount, GstBuffer* subSamplesBuffer);
     void (*releaseCipher)(WebKitMediaCommonEncryptionDecrypt*);
     void (*receivedProtectionEvent)(WebKitMediaCommonEncryptionDecrypt*, unsigned);
     bool (*handleInitData)(WebKitMediaCommonEncryptionDecrypt*, const WebCore::InitData&);

--- a/Source/WebCore/platform/graphics/gstreamer/eme/WebKitOpenCDMDecryptorGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/WebKitOpenCDMDecryptorGStreamer.cpp
@@ -40,7 +40,7 @@ struct _WebKitOpenCDMDecryptPrivate {
 };
 
 static void webKitMediaOpenCDMDecryptorFinalize(GObject*);
-static bool webKitMediaOpenCDMDecryptorDecrypt(WebKitMediaCommonEncryptionDecrypt*, GstBuffer* keyIDBuffer, GstBuffer* iv, GstBuffer* sample, unsigned subSamplesCount, GstBuffer* subSamples);
+static bool webKitMediaOpenCDMDecryptorDecrypt(WebKitMediaCommonEncryptionDecrypt*, GstBuffer*, GstBuffer*, unsigned, GstBuffer*);
 static bool webKitMediaOpenCDMDecryptorHandleInitData(WebKitMediaCommonEncryptionDecrypt* self, const WebCore::InitData& initData);
 static bool webKitMediaOpenCDMDecryptorAttemptToDecryptWithLocalInstance(WebKitMediaCommonEncryptionDecrypt* self, const WebCore::InitData&);
 
@@ -177,14 +177,13 @@ static bool webKitMediaOpenCDMDecryptorAttemptToDecryptWithLocalInstance(WebKitM
     return webKitMediaOpenCDMDecryptorResetSessionFromInitDataIfNeeded(self, initData) != InvalidSession;
 }
 
-static bool webKitMediaOpenCDMDecryptorDecrypt(WebKitMediaCommonEncryptionDecrypt* self, GstBuffer* keyIDBuffer, GstBuffer* ivBuffer, GstBuffer* buffer, unsigned subSampleCount, GstBuffer* subSamplesBuffer)
+static bool webKitMediaOpenCDMDecryptorDecrypt(WebKitMediaCommonEncryptionDecrypt* self, GstBuffer* ivBuffer, GstBuffer* buffer, unsigned subSampleCount, GstBuffer* subSamplesBuffer)
 {
     GstMapInfo ivMap;
     if (!gst_buffer_map(ivBuffer, &ivMap, GST_MAP_READ)) {
         GST_ERROR_OBJECT(self, "Failed to map IV");
         return false;
     }
-    GST_MEMDUMP_OBJECT(self, "IV for sample", ivMap.data, ivMap.size);
 
     GstMapInfo map;
     if (!gst_buffer_map(buffer, &map, static_cast<GstMapFlags>(GST_MAP_READWRITE))) {
@@ -193,13 +192,7 @@ static bool webKitMediaOpenCDMDecryptorDecrypt(WebKitMediaCommonEncryptionDecryp
         return false;
     }
 
-    GstMapInfo keyIDBufferMap;
-    if (!gst_buffer_map(keyIDBuffer, &keyIDBufferMap, GST_MAP_READ)) {
-        gst_buffer_unmap(ivBuffer, &ivMap);
-        gst_buffer_unmap(buffer, &map);
-        GST_ERROR_OBJECT(self, "Failed to map key ID buffer");
-        return false;
-    }
+    WebKitOpenCDMDecryptPrivate* priv = GST_WEBKIT_OPENCDM_DECRYPT_GET_PRIVATE(WEBKIT_OPENCDM_DECRYPT(self));
 
     int errorCode;
     bool returnValue = true;
@@ -238,9 +231,8 @@ static bool webKitMediaOpenCDMDecryptorDecrypt(WebKitMediaCommonEncryptionDecryp
         gst_byte_reader_set_pos(reader.get(), 0);
 
         // Decrypt cipher.
-        GST_TRACE_OBJECT(self, "decrypting (subsample)");
-        auto decryptor = std::make_unique<media::OpenCdm>(keyIDBufferMap.data, keyIDBufferMap.size);
-        if ((errorCode = decryptor->Decrypt(holdEncryptedData.get(), static_cast<uint32_t>(totalEncrypted),
+        GST_TRACE_OBJECT(self, "decrypting");
+        if ((errorCode = priv->m_openCdm->Decrypt(holdEncryptedData.get(), static_cast<uint32_t>(totalEncrypted),
             ivMap.data, static_cast<uint32_t>(ivMap.size)))) {
             GST_WARNING_OBJECT(self, "ERROR - packet decryption failed [%d]", errorCode);
             gst_buffer_unmap(subSamplesBuffer, &subSamplesMap);
@@ -264,9 +256,8 @@ static bool webKitMediaOpenCDMDecryptorDecrypt(WebKitMediaCommonEncryptionDecryp
         gst_buffer_unmap(subSamplesBuffer, &subSamplesMap);
     } else {
         // Decrypt cipher.
-        GST_TRACE_OBJECT(self, "decrypting (no subsamples)");
-        auto decryptor = std::make_unique<media::OpenCdm>(keyIDBufferMap.data, keyIDBufferMap.size);
-        if ((errorCode = decryptor->Decrypt(map.data, static_cast<uint32_t>(map.size),
+        GST_TRACE_OBJECT(self, "decrypting");
+        if ((errorCode = priv->m_openCdm->Decrypt(map.data, static_cast<uint32_t>(map.size),
             ivMap.data, static_cast<uint32_t>(ivMap.size)))) {
             GST_WARNING_OBJECT(self, "ERROR - packet decryption failed [%d]", errorCode);
             returnValue = false;


### PR DESCRIPTION
Reverts WebPlatformForEmbedded/WPEWebKit#492

I am reverting this because it depends on,
  - My gstreamer patches for buildroot being accepted &
  - WPEFramework & Plugins being updated in master

This is avoid breakage.