### PR TITLE
[EME] Use key-id based decryption API.

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp
@@ -465,7 +465,7 @@ static gboolean webkitMediaCommonEncryptionDecryptSinkEventHandler(GstBaseTransf
                 if (!priv->m_pendingProtectionEvents.isEmpty())
                     webkitMediaCommonEncryptionDecryptProcessPendingProtectionEvents(self);
             } else
-                GST_TRACE_OBJECT(self, "got attach CDMInstance for the same instance %p we already have", cdmInstance);
+                GST_TRACE_OBJECT(self, "ignoring cdm-instance %p, we already have it", cdmInstance);
         } else if (gst_structure_has_name(structure, "drm-cdm-instance-detached")) {
             WebCore::CDMInstance* cdmInstance = nullptr;
             gst_structure_get(structure, "cdm-instance", G_TYPE_POINTER, &cdmInstance, nullptr);
@@ -475,9 +475,9 @@ static gboolean webkitMediaCommonEncryptionDecryptSinkEventHandler(GstBaseTransf
             LockHolder locker(priv->m_mutex);
             if (priv->m_cdmInstance == cdmInstance) {
                 webKitMediaCommonEncryptionDecryptorPrivClearStateWithInstance(priv, nullptr);
-                GST_INFO_OBJECT(self, "got CDMInstance %p detached and cleared state", cdmInstance);
+                GST_INFO_OBJECT(self, "our cdm-instance %p was detached, state cleared", cdmInstance);
             } else
-                GST_TRACE_OBJECT(self, "got detaching message for CDMInstance %p but ours is %p", cdmInstance, priv->m_cdmInstance.get());
+                GST_TRACE_OBJECT(self, "cdm-instance %p detached, ignored since ours was %p", cdmInstance, priv->m_cdmInstance.get());
         } else if (gst_structure_has_name(structure, "drm-attempt-to-decrypt-with-local-instance")) {
             gst_event_unref(event);
             result = TRUE;


### PR DESCRIPTION
This is a minimal change to just use the new API, in theory all the blocking on
m_keyReceived is now unnecessary. Patching incoming for cleaning this up.

* platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp:
(webkitMediaCommonEncryptionDecryptSinkEventHandler): Rephrase some error messages.
* platform/graphics/gstreamer/eme/WebKitOpenCDMDecryptorGStreamer.cpp: Place the
openCdm instance in the private section to avoid allocating for each buffer, and
switch to the blocking API.
(webkit_media_opencdm_decrypt_init): Initialize the now cached openCdm instance.
(webKitMediaOpenCDMDecryptorDecrypt): Use blocking decryption API.