### PR TITLE
[WPE] Fix packageconfig include path.

### DIFF
--- a/Source/WebKit/wpe/wpe-webkit.pc.in
+++ b/Source/WebKit/wpe/wpe-webkit.pc.in
@@ -9,4 +9,4 @@ URL: https://wpewebkit.org
 Version: @PROJECT_VERSION@
 Requires: glib-2.0 libsoup-2.4
 Libs: -L${libdir} -lWPEWebKit-@WPE_API_VERSION@
-Cflags: -I${includedir}/wpe-webkit-@WPE_API_VERSION@
+Cflags: -I${includedir}/wpe-@WPE_API_VERSION@


### PR DESCRIPTION
Headers are written to /usr/include/wpe-0.1/ and not /usr/include/wpe-webkit-0.1/ by the install step. This fixes any component that tries to link to WPEWebKit using  package config

Signed-off-by: wouterlucas <wouter@wouterlucas.com>