### PR TITLE
GLContextEGLWPE.cpp: check target pointer after creation

### DIFF
--- a/Source/WebCore/platform/graphics/egl/GLContextEGLWPE.cpp
+++ b/Source/WebCore/platform/graphics/egl/GLContextEGLWPE.cpp
@@ -60,6 +60,10 @@ std::unique_ptr<GLContextEGL> GLContextEGL::createWPEContext(PlatformDisplay& pl
     }
 
     auto* target = wpe_renderer_backend_egl_offscreen_target_create();
+    if (!target) {
+        WTFLogAlways("Cannot create EGL offscreen target");
+        return nullptr;
+    }
     wpe_renderer_backend_egl_offscreen_target_initialize(target, downcast<PlatformDisplayWPE>(platformDisplay).backend());
     EGLNativeWindowType window = wpe_renderer_backend_egl_offscreen_target_get_native_window(target);
     if (!window) {


### PR DESCRIPTION
The wpe_renderer_backend_egl_offscreen_target_create() function
returns null pointer on fail. But the return value was not checked
in the WPEWebkit. It may lead to null pointer deference and the segmentation
fault, such as the one described in following issue:

https://github.com/Igalia/meta-webkit/issues/31#issuecomment-427983230

Signed-off-by: Maciej Pijanowski <maciej.pijanowski@3mdeb.com>

I'm not sure if it is the correct branch to PR to. Please let me know if it is not.