### PR TITLE
wpewebkit: fix compilation error

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/wpe/AcceleratedSurfaceWPE.cpp
+++ b/Source/WebKit/WebProcess/WebPage/wpe/AcceleratedSurfaceWPE.cpp
@@ -80,7 +80,7 @@ void AcceleratedSurfaceWPE::finalize()
 uint64_t AcceleratedSurfaceWPE::window() const
 {
     ASSERT(m_backend);
-    return reinterpret_cast<uint64_t>(wpe_renderer_backend_egl_target_get_native_window(m_backend));
+    return static_cast<uint64_t>(wpe_renderer_backend_egl_target_get_native_window(m_backend));
 }
 
 uint64_t AcceleratedSurfaceWPE::surfaceID() const


### PR DESCRIPTION
Source/WebKit/WebProcess/WebPage/wpe/AcceleratedSurfaceWPE.cpp:87:99: error: invalid cast from type 'EGLNativeWindowType {aka long unsigned int}' to type 'uint64_t {aka long long unsigned int}'
     return reinterpret_cast<uint64_t>(wpe_renderer_backend_egl_target_get_native_window(m_backend));