### PR TITLE
DelayedAudio unittest is failing [memento]

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -448,6 +448,11 @@ bool MediaPlayerPrivateGStreamer::changePipelineState(GstState newState)
         return true;
     }
 
+    if (m_readyState <= MediaPlayer::HaveMetadata && newState == GST_STATE_PLAYING) {
+        GST_DEBUG("Rejected state change to playing, buffers are not ready yet");
+        return true;
+    }
+
     GST_DEBUG("Changing state change to %s from %s with %s pending", gst_element_state_get_name(newState),
         gst_element_state_get_name(currentState), gst_element_state_get_name(pending));
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -613,6 +613,9 @@ void MediaPlayerPrivateGStreamerMSE::updateStates()
                 GST_DEBUG("m_readyState=%s", dumpReadyState(m_readyState));
                 m_networkState = MediaPlayer::Loaded;
             } else {
+                if (m_mediaSource)
+                    m_mediaSource->monitorSourceBuffers();
+
                 m_readyState = MediaPlayer::HaveFutureData;
                 GST_DEBUG("m_readyState=%s", dumpReadyState(m_readyState));
                 m_networkState = MediaPlayer::Loading;


### PR DESCRIPTION
MSE media player should not return
playing state if it has been stopped  when not all buffers
have current time.

http://yt-dash-mse-test.commondatastorage.googleapis.com/unit-
tests/2016.html?enablewebm=false