### PR TITLE
ASAN: Fix global-buffer-overflow @WTF::StringImpl::createFromLiteral()

### DIFF
--- a/Source/WebCore/css/make-css-file-arrays.pl
+++ b/Source/WebCore/css/make-css-file-arrays.pl
@@ -66,11 +66,11 @@ for my $in (@ARGV) {
     # Write out a C array of the characters.
     my $length = length $text;
     if ($in =~ /(\w+)\.css$/) {
-        print HEADER "extern const char ${name}UserAgentStyleSheet[${length}];\n";
-        print OUT "extern const char ${name}UserAgentStyleSheet[${length}] = {\n";
+        print HEADER "extern const char ${name}UserAgentStyleSheet[${length}+1];\n";
+        print OUT "extern const char ${name}UserAgentStyleSheet[${length}+1] = {\n";
     } else {
-        print HEADER "extern const char ${name}JavaScript[${length}];\n";
-        print OUT "extern const char ${name}JavaScript[${length}] = {\n";
+        print HEADER "extern const char ${name}JavaScript[${length}+1];\n";
+        print OUT "extern const char ${name}JavaScript[${length}+1] = {\n";
     }
     my $i = 0;
     while ($i < $length) {
@@ -82,9 +82,10 @@ for my $in (@ARGV) {
             ++$i;
             ++$j;
         }
-        print OUT "," unless $i == $length;
-        print OUT "\n";
+        print OUT ",";
+        print OUT "\n" unless $i == $length;
     }
+    print OUT " 0\n";
     print OUT "};\n";
 
 }


### PR DESCRIPTION
strlen() is invoked on strings located in UserAgentStyleSheetsData.cpp,
however, those strings does not contain valid C strings with
'\0' character in the end.

GDB callstack excerpt:
(complete is available at https://github.com/WebPlatformForEmbedded/WPEWebKit/issues/592)

(gdb) bt
(gdb) bt

(gdb) fr 4
158	    return createFromLiteral(characters, strlen(characters));
(gdb) l
153	    return adoptRef(*new StringImpl(reinterpret_cast<const LChar*>(characters), length, ConstructWithoutCopying));
154	}
155
156	Ref<StringImpl> StringImpl::createFromLiteral(const char* characters)
157	{
158	    return createFromLiteral(characters, strlen(characters));
159	}

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>