### PR TITLE
Remove BCM_NEXUS defines not needing gst changes

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -110,9 +110,22 @@ private:
     bool m_isValid { false };
 };
 
+enum class ElementType : int {
+    SINK,
+    DECODER,
+    ELEMENT_COUNT
+};
+
+enum class MediaType : int {
+    AUDIO,
+    VIDEO,
+    MEDIA_COUNT
+};
+
 bool gstRegistryHasElementForMediaType(GList* elementFactories, const char* capsString);
 void connectSimpleBusMessageCallback(GstElement *pipeline);
 void disconnectSimpleBusMessageCallback(GstElement *pipeline);
+GstElement* getElement(GstElement* container, ElementType, MediaType);
 
 }
 

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -164,7 +164,7 @@ MediaPlayerPrivateGStreamer::MediaPlayerPrivateGStreamer(MediaPlayer* player)
     , m_hasVideo(false)
     , m_hasAudio(false)
     , m_readyTimerHandler(RunLoop::main(), this, &MediaPlayerPrivateGStreamer::readyTimerFired)
-    , m_totalBytes(0)
+    , m_totalBytes(-1)
     , m_preservesPitch(false)
 {
 #if USE(GLIB)
@@ -1843,12 +1843,12 @@ bool MediaPlayerPrivateGStreamer::didLoadingProgress() const
     return didLoadingProgress;
 }
 
-unsigned long long MediaPlayerPrivateGStreamer::totalBytes() const
+long long MediaPlayerPrivateGStreamer::determineTotalBytes() const
 {
     if (m_errorOccured)
         return 0;
 
-    if (m_totalBytes)
+    if (m_totalBytes != -1)
         return m_totalBytes;
 
     if (!m_source)
@@ -1858,10 +1858,10 @@ unsigned long long MediaPlayerPrivateGStreamer::totalBytes() const
         return 0;
 
     GstFormat fmt = GST_FORMAT_BYTES;
-    gint64 length = 0;
+    gint64 length = -1;
     if (gst_element_query_duration(m_source.get(), fmt, &length)) {
-        GST_INFO("totalBytes %" G_GINT64_FORMAT, length);
         m_totalBytes = static_cast<unsigned long long>(length);
+        GST_INFO("totalBytes %" G_GINT64_FORMAT, m_totalBytes);
         m_isStreaming = !length;
         return m_totalBytes;
     }
@@ -1895,10 +1895,16 @@ unsigned long long MediaPlayerPrivateGStreamer::totalBytes() const
 
     gst_iterator_free(iter);
 
-    GST_INFO("totalBytes %" G_GINT64_FORMAT, length);
     m_totalBytes = static_cast<unsigned long long>(length);
+    GST_INFO("totalBytes %" G_GINT64_FORMAT, m_totalBytes);
     m_isStreaming = !length;
     return m_totalBytes;
+}
+
+unsigned long long MediaPlayerPrivateGStreamer::totalBytes() const
+{
+    determineTotalBytes();
+    return m_totalBytes >= 0 ? static_cast<unsigned long long>(m_totalBytes) : 0;
 }
 
 void MediaPlayerPrivateGStreamer::sourceSetupCallback(MediaPlayerPrivateGStreamer* player, GstElement* sourceElement)
@@ -2596,7 +2602,10 @@ void MediaPlayerPrivateGStreamer::setDownloadBuffering()
     if (flags & flagDownload && m_readyState > MediaPlayer::HaveNothing && !m_resetPipeline && !isLiveStream())
         return;
 
-    bool shouldDownload = !isLiveStream() && m_preload == MediaPlayer::Auto && !isMediaDiskCacheDisabled();
+    // determineTotalBytes() is equivalent to isLiveStream() once this is determined or makes sure isLiveStream()
+    // checked later base its decision on updted data.
+    const bool downloadProhibited = determineTotalBytes() != -1 && isLiveStream();
+    bool shouldDownload = !downloadProhibited && m_preload == MediaPlayer::Auto && !isMediaDiskCacheDisabled();
     if (shouldDownload) {
         GST_INFO("Enabling on-disk buffering");
         g_object_set(m_pipeline.get(), "flags", flags | flagDownload, nullptr);

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -185,6 +185,8 @@ private:
     void clearTracks();
 #endif
 
+    long long determineTotalBytes() const;
+
 protected:
     bool m_buffering;
     int m_bufferingPercentage;
@@ -255,7 +257,7 @@ private:
     bool m_hasVideo;
     bool m_hasAudio;
     RunLoop::Timer<MediaPlayerPrivateGStreamer> m_readyTimerHandler;
-    mutable unsigned long long m_totalBytes;
+    mutable long long m_totalBytes;
     URL m_url;
     bool m_preservesPitch;
     mutable std::optional<Seconds> m_lastQueryTime;


### PR DESCRIPTION
This is a work I did towards removing BCM_NEXUS defines from Webkit and moving them to GST. It turned out not that many may be removed that way without changing the philosophy behind BRCM's plugins (vid/aud filter saying they accept all caps) but this is a part of it which allowed to remove some of the defines on Webkit side. There are still more which could be removed on Webkit side (asking GST factory about decoders vs parsers) but I didn't invest in them. The biggest one is to rely on generic query_position() without doing decoders lookup and jumping between them but this one requires GST change which is not yet official so I split this out.