### PR TITLE
[EME][CDM] rename enqueueMessage to solve recursive function calls due to overloading

### DIFF
--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
@@ -609,7 +609,7 @@ void MediaKeySession::enqueueMessage(MediaKeyMessageType messageType, const Shar
     m_eventQueue.enqueueEvent(WTFMove(messageEvent));
 }
 
-void MediaKeySession::enqueueMessageFromCDM(CDMInstanceClient::MessageType type, Ref<SharedBuffer>&& message)
+void MediaKeySession::issueMessage(CDMInstanceClient::MessageType type, Ref<SharedBuffer>&& message)
 {
     m_taskQueue.enqueueTask([this, type, message = WTFMove(message)] () mutable {
         MediaKeyMessageType messageType;

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
@@ -609,7 +609,7 @@ void MediaKeySession::enqueueMessage(MediaKeyMessageType messageType, const Shar
     m_eventQueue.enqueueEvent(WTFMove(messageEvent));
 }
 
-void MediaKeySession::enqueueMessage(CDMInstanceClient::MessageType type, Ref<SharedBuffer>&& message)
+void MediaKeySession::enqueueMessageFromCDM(CDMInstanceClient::MessageType type, Ref<SharedBuffer>&& message)
 {
     m_taskQueue.enqueueTask([this, type, message = WTFMove(message)] () mutable {
         MediaKeyMessageType messageType;

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySession.h
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySession.h
@@ -81,7 +81,7 @@ private:
     MediaKeySession(ScriptExecutionContext&, WeakPtr<MediaKeys>&&, MediaKeySessionType, bool useDistinctiveIdentifier, Ref<CDM>&&, Ref<CDMInstance>&&);
     void enqueueMessage(MediaKeyMessageType, const SharedBuffer&);
     void updateKeyStatuses(CDMInstance::KeyStatusVector&&) override;
-    void enqueueMessage(MessageType, Ref<SharedBuffer>&&) override;
+    void enqueueMessageFromCDM(MessageType, Ref<SharedBuffer>&&) override;
     void updateExpiration(double);
     void sessionClosed();
 

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySession.h
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySession.h
@@ -81,7 +81,7 @@ private:
     MediaKeySession(ScriptExecutionContext&, WeakPtr<MediaKeys>&&, MediaKeySessionType, bool useDistinctiveIdentifier, Ref<CDM>&&, Ref<CDMInstance>&&);
     void enqueueMessage(MediaKeyMessageType, const SharedBuffer&);
     void updateKeyStatuses(CDMInstance::KeyStatusVector&&) override;
-    void enqueueMessageFromCDM(MessageType, Ref<SharedBuffer>&&) override;
+    void issueMessage(MessageType, Ref<SharedBuffer>&&) override;
     void updateExpiration(double);
     void sessionClosed();
 

--- a/Source/WebCore/platform/encryptedmedia/CDMInstance.h
+++ b/Source/WebCore/platform/encryptedmedia/CDMInstance.h
@@ -51,7 +51,7 @@ public:
     using MessageType = CDMMessageType;
     using KeyStatusVector = Vector<std::pair<Ref<SharedBuffer>, KeyStatus>>;
     virtual void updateKeyStatuses(KeyStatusVector&&) = 0;
-    virtual void enqueueMessageFromCDM(MessageType, Ref<SharedBuffer>&&) = 0;
+    virtual void issueMessage(MessageType, Ref<SharedBuffer>&&) = 0;
 };
 
 class CDMInstance : public RefCounted<CDMInstance> {

--- a/Source/WebCore/platform/encryptedmedia/CDMInstance.h
+++ b/Source/WebCore/platform/encryptedmedia/CDMInstance.h
@@ -51,7 +51,7 @@ public:
     using MessageType = CDMMessageType;
     using KeyStatusVector = Vector<std::pair<Ref<SharedBuffer>, KeyStatus>>;
     virtual void updateKeyStatuses(KeyStatusVector&&) = 0;
-    virtual void enqueueMessage(MessageType, Ref<SharedBuffer>&&) = 0;
+    virtual void enqueueMessageFromCDM(MessageType, Ref<SharedBuffer>&&) = 0;
 };
 
 class CDMInstance : public RefCounted<CDMInstance> {

--- a/Source/WebCore/platform/graphics/gstreamer/eme/CDMOpenCDM.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/CDMOpenCDM.cpp
@@ -385,7 +385,7 @@ void CDMInstanceOpenCDM::Session::challengeGeneratedCallback(RefPtr<SharedBuffer
         m_sessionChangedCallbacks.clear();
     } else {
         if (m_parent->client() && requestType.has_value())
-            m_parent->client()->enqueueMessage(static_cast<CDMInstanceClient::MessageType>(requestType.value()), message.releaseNonNull());
+            m_parent->client()->enqueueMessageFromCDM(static_cast<CDMInstanceClient::MessageType>(requestType.value()), message.releaseNonNull());
     }
 }
 

--- a/Source/WebCore/platform/graphics/gstreamer/eme/CDMOpenCDM.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/CDMOpenCDM.cpp
@@ -385,7 +385,7 @@ void CDMInstanceOpenCDM::Session::challengeGeneratedCallback(RefPtr<SharedBuffer
         m_sessionChangedCallbacks.clear();
     } else {
         if (m_parent->client() && requestType.has_value())
-            m_parent->client()->enqueueMessageFromCDM(static_cast<CDMInstanceClient::MessageType>(requestType.value()), message.releaseNonNull());
+            m_parent->client()->issueMessage(static_cast<CDMInstanceClient::MessageType>(requestType.value()), message.releaseNonNull());
     }
 }
 


### PR DESCRIPTION
MediaKeySession::engqueueMessage(CDMInstanceClient::MessageType type, Ref<SharedBuffer>&& message)is  calling itself recursively instead of calling 
MediaKeySession::enqueueMessage(MediaKeyMessageType messageType, const SharedBuffer& message)

I think the prototype amount to the same thing. Renaming it to enqueueMessageFromCDM() solves the problem

```
void MediaKeySession::enqueueMessage(CDMInstanceClient::MessageType type, Ref<SharedBuffer>&& message)
{
    m_taskQueue.enqueueTask([this, type, message = WTFMove(message)] () mutable {
        MediaKeyMessageType messageType;
        switch (type) {
        case CDMInstance::MessageType::LicenseRequest:
            messageType = MediaKeyMessageType::LicenseRequest;
            break;
        case CDMInstance::MessageType::LicenseRenewal:
            messageType = MediaKeyMessageType::LicenseRenewal;
            break;
        case CDMInstance::MessageType::LicenseRelease:
            messageType = MediaKeyMessageType::LicenseRelease;
            break;
        case CDMInstance::MessageType::IndividualizationRequest:
            messageType = MediaKeyMessageType::IndividualizationRequest;
            break;
        }

        enqueueMessage(messageType, WTFMove(message));
    });
}
```