### PR TITLE
Use generic gstreamers position also on BRCM

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -426,36 +426,6 @@ MediaTime MediaPlayerPrivateGStreamer::playbackPosition() const
             return MediaTime::zeroTime();
         }
     }
-#elif PLATFORM(BCM_NEXUS)
-    // Implement getting pts time from broadcom decoder directly for seek functionality.
-    // In some cases one stream (audio or video) is shorter than the other and its position doesn't
-    // increase anymore. We need to query both decoders (if available) and choose the highest position.
-    GstElement* videoDecoder = nullptr;
-    GstElement* audioDecoder = nullptr;
-    GstClockTime videoPosition = GST_CLOCK_TIME_NONE;
-    GstClockTime audioPosition = GST_CLOCK_TIME_NONE;
-
-    findDecoders(m_pipeline.get(), &videoDecoder, &audioDecoder);
-
-    GST_TRACE("videoDecoder: %s, audioDecoder: %s", videoDecoder ? GST_ELEMENT_NAME(videoDecoder) : "null", audioDecoder ? GST_ELEMENT_NAME(audioDecoder) : "null");
-
-    if (!(videoDecoder || audioDecoder))
-        return MediaTime::zeroTime();
-    if (videoDecoder && gst_element_query(videoDecoder, query))
-        gst_query_parse_position(query, 0, (gint64*)&videoPosition);
-    if (audioDecoder) {
-        g_object_set(audioDecoder, "use-audio-position", true, nullptr);
-        if (gst_element_query(audioDecoder, query))
-            gst_query_parse_position(query, 0, (gint64*)&audioPosition);
-    }
-    if (videoPosition == GST_CLOCK_TIME_NONE)
-        videoPosition = 0;
-    if (audioPosition == GST_CLOCK_TIME_NONE)
-        audioPosition = 0;
-
-    GST_TRACE("videoPosition: %" GST_TIME_FORMAT ", audioPosition: %" GST_TIME_FORMAT, GST_TIME_ARGS(videoPosition), GST_TIME_ARGS(audioPosition));
-
-    position = max(videoPosition, audioPosition);
 #else
     positionElement = m_pipeline.get();
 #endif

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -349,47 +349,6 @@ void MediaPlayerPrivateGStreamer::commitLoad()
     updateStates();
 }
 
-#if PLATFORM(BCM_NEXUS)
-// utility function for bcm nexus seek functionality
-static void findDecoders(GstElement *element, GstElement **videoDecoder, GstElement **audioDecoder)
-{
-    if (!(videoDecoder || audioDecoder))
-        return;
-
-    if (GST_IS_BIN(element)) {
-        GstIterator* it = gst_bin_iterate_elements(GST_BIN(element));
-        GValue item = G_VALUE_INIT;
-        bool done = false;
-        while (!done) {
-            switch (gst_iterator_next(it, &item)) {
-                case GST_ITERATOR_OK:
-                {
-                    GstElement *next = GST_ELEMENT(g_value_get_object(&item));
-                    findDecoders(next, videoDecoder, audioDecoder);
-                    done = (!((videoDecoder && !*videoDecoder) || (audioDecoder && !*audioDecoder)));
-                    g_value_reset (&item);
-                    break;
-                }
-                case GST_ITERATOR_RESYNC:
-                    gst_iterator_resync (it);
-                    break;
-                case GST_ITERATOR_ERROR:
-                case GST_ITERATOR_DONE:
-                    done = true;
-                    break;
-            }
-        }
-        g_value_unset (&item);
-        gst_iterator_free(it);
-    } else if (videoDecoder && (GST_IS_VIDEO_DECODER(element) || g_str_has_suffix(G_OBJECT_TYPE_NAME(G_OBJECT(element)), "VideoDecoder")))
-        *videoDecoder = element;
-    else if (audioDecoder && (GST_IS_AUDIO_DECODER(element) || g_str_has_suffix(G_OBJECT_TYPE_NAME(G_OBJECT(element)), "AudioDecoder")))
-        *audioDecoder = element;
-    return;
-}
-#endif
-
-
 MediaTime MediaPlayerPrivateGStreamer::playbackPosition() const
 {
 


### PR DESCRIPTION
This is a part of getting rid of BCM_NEXUS from WK. Thie idea is to make fixes in BCM plugins instead - i..e where they belong to. This has to go with changed/unified plugins which now live at https://github.com/Metrological/bcm-gstreamer. The fixes to make this one particular change possible  are here: https://github.com/Metrological/bcm-gstreamer/commit/5eb74f10e9811f15942e55a661ca15db3c462111