### PR TITLE
[EME openCDM]: clearkey's initdata type is added

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/eme/CDMOpenCDM.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/CDMOpenCDM.cpp
@@ -61,7 +61,7 @@ public:
     virtual ~CDMPrivateOpenCDM() = default;
 
 public:
-    bool supportsInitDataType(const AtomicString& initDataType) const final { return equalLettersIgnoringASCIICase(initDataType, "cenc") || equalLettersIgnoringASCIICase(initDataType, "webm"); }
+    bool supportsInitDataType(const AtomicString& initDataType) const final { return equalLettersIgnoringASCIICase(initDataType, "cenc") || equalLettersIgnoringASCIICase(initDataType, "webm") || equalLettersIgnoringASCIICase(initDataType, "keyids"); }
     bool supportsConfiguration(const MediaKeySystemConfiguration& config) const final;
     bool supportsConfigurationWithRestrictions(const MediaKeySystemConfiguration& config, const MediaKeysRestrictions&) const final { return supportsConfiguration(config); }
     bool supportsSessionTypeWithConfiguration(MediaKeySessionType&, const MediaKeySystemConfiguration& config) const final { return supportsConfiguration(config); }


### PR DESCRIPTION
  - 'keyids' initdata type support is added as
    clearkey uses this instead of 'cenc'

Signed-off-by: Moorthy Baskar <moorthy.baskaravenkatraman-sambamoorthy@linaro.org>