### PR TITLE
[WPE-511][MSE] Update |m_playbackRatePause| also in MSE path.

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -199,6 +199,7 @@ protected:
     mutable MediaTime m_durationAtEOS;
     bool m_paused;
     float m_playbackRate;
+    bool m_playbackRatePause;
     GstState m_currentState;
     GstState m_oldState;
     GstState m_requestedState;
@@ -245,7 +246,6 @@ private:
 #endif
     GstStructure* m_mediaLocations;
     int m_mediaLocationCurrentIndex;
-    bool m_playbackRatePause;
     MediaTime m_timeOfOverlappingSeek;
     float m_lastPlaybackRate;
     Timer m_fillTimer;

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -406,8 +406,6 @@ bool MediaPlayerPrivateGStreamerMSE::doSeek()
         return false;
     }
 
-    m_playbackRatePause = !m_playbackRate;
-
     // The samples will be enqueued in notifySeekNeedsData().
     GST_DEBUG("doSeek(): gst_element_seek() succeeded, returning true");
     return true;
@@ -451,6 +449,15 @@ void MediaPlayerPrivateGStreamerMSE::maybeFinishSeek()
 
 void MediaPlayerPrivateGStreamerMSE::updatePlaybackRate()
 {
+    if (m_playbackRatePause) {
+        GstState state;
+        GstState pending;
+
+        gst_element_get_state(m_pipeline.get(), &state, &pending, 0);
+        if (state != GST_STATE_PLAYING && pending != GST_STATE_PLAYING)
+            changePipelineState(GST_STATE_PLAYING);
+        m_playbackRatePause = false;
+    }
 }
 
 bool MediaPlayerPrivateGStreamerMSE::seeking() const

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -406,6 +406,8 @@ bool MediaPlayerPrivateGStreamerMSE::doSeek()
         return false;
     }
 
+    m_playbackRatePause = !m_playbackRate;
+
     // The samples will be enqueued in notifySeekNeedsData().
     GST_DEBUG("doSeek(): gst_element_seek() succeeded, returning true");
     return true;


### PR DESCRIPTION
Otherwise in MSE case the following calls do not make playback to
start as expected:

mediaElement.setRate(0);
mediaElement.play();
mediaElement.setRate(1);