### PR TITLE
DFG's StrengthReduction phase should not reduce Construct into Direct…

### DIFF
--- a/JSTests/ChangeLog
+++ b/JSTests/ChangeLog
@@ -1,3 +1,13 @@
+2018-12-04  Mark Lam  <mark.lam@apple.com>
+
+        DFG's StrengthReduction phase should not reduce Construct into DirectContruct when the executable does not have constructAbility.
+        https://bugs.webkit.org/show_bug.cgi?id=192386
+        <rdar://problem/46445516>
+
+        Reviewed by Saam Barati.
+
+        * stress/regress-192386.js: Added.
+
 2019-02-26  Guillaume Emont  <guijemont@igalia.com>
 
         [JSC] Repeat string created from Array.prototype.join() take too much memory

--- a/JSTests/stress/regress-192386.js
+++ b/JSTests/stress/regress-192386.js
@@ -1,0 +1,12 @@
+//@ requireOptions("--jitPolicyScale=0")
+
+function foo(x) {
+    try {
+        new x();
+    } catch {
+    }
+}
+
+foo(function() {});
+for (let i = 0; i < 10000; ++i)
+    foo(() => undefined);

--- a/Source/JavaScriptCore/ChangeLog
+++ b/Source/JavaScriptCore/ChangeLog
@@ -1,3 +1,16 @@
+2018-12-04  Mark Lam  <mark.lam@apple.com>
+
+        DFG's StrengthReduction phase should not reduce Construct into DirectContruct when the executable does not have constructAbility.
+        https://bugs.webkit.org/show_bug.cgi?id=192386
+        <rdar://problem/46445516>
+
+        Reviewed by Saam Barati.
+
+        This violates an invariant documented by a RELEASE_ASSERT in operationLinkDirectCall().
+
+        * dfg/DFGStrengthReductionPhase.cpp:
+        (JSC::DFG::StrengthReductionPhase::handleNode):
+
 2018-08-27  Keith Rollin  <krollin@apple.com>
 
         Unreviewed build fix -- disable LTO for production builds

--- a/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
@@ -911,6 +911,9 @@ private:
                 break;
             
             if (FunctionExecutable* functionExecutable = jsDynamicCast<FunctionExecutable*>(vm(), executable)) {
+                if (m_node->op() == Construct && functionExecutable->constructAbility() == ConstructAbility::CannotConstruct)
+                    break;
+
                 // We need to update m_parameterSlots before we get to the backend, but we don't
                 // want to do too much of this.
                 unsigned numAllocatedArgs =


### PR DESCRIPTION
…Contruct when the executable does not have constructAbility.

https://bugs.webkit.org/show_bug.cgi?id=192386
<rdar://problem/46445516>

Reviewed by Saam Barati.

JSTests:

* stress/regress-192386.js: Added.

Source/JavaScriptCore:

This violates an invariant documented by a RELEASE_ASSERT in operationLinkDirectCall().

* dfg/DFGStrengthReductionPhase.cpp:
(JSC::DFG::StrengthReductionPhase::handleNode):

git-svn-id: http://svn.webkit.org/repository/webkit/trunk@238884 268f45cc-cd09-0410-ab3c-d52691b4dbfc