### PR TITLE
Introduce WKNavigationResponseCopyURLResponse

### DIFF
--- a/Source/WebKit/UIProcess/API/C/WKNavigationResponseRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKNavigationResponseRef.cpp
@@ -46,6 +46,11 @@ WKURLResponseRef WKNavigationResponseGetURLResponse(WKNavigationResponseRef resp
     return toAPI(toImpl(response)->response());
 }
 
+WKURLResponseRef WKNavigationResponseCopyURLResponse(WKNavigationResponseRef response)
+{
+    return toAPI(&API::URLResponse::create(toImpl(response)->response()).leakRef());
+}
+
 bool WKNavigationResponseIsMainFrame(WKNavigationResponseRef response)
 {
     return toImpl(response)->frame().isMainFrame();

--- a/Source/WebKit/UIProcess/API/C/WKNavigationResponseRef.h
+++ b/Source/WebKit/UIProcess/API/C/WKNavigationResponseRef.h
@@ -36,7 +36,10 @@ WK_EXPORT WKTypeID WKNavigationResponseGetTypeID();
     
 WK_EXPORT bool WKNavigationResponseCanShowMIMEType(WKNavigationResponseRef);
 
+WK_C_DEPRECATED("use WKNavigationResponseCopyURLResponse")
 WK_EXPORT WKURLResponseRef WKNavigationResponseGetURLResponse(WKNavigationResponseRef response);
+
+WK_EXPORT WKURLResponseRef WKNavigationResponseCopyURLResponse(WKNavigationResponseRef response);
 
 WK_EXPORT bool WKNavigationResponseIsMainFrame(WKNavigationResponseRef response);
 


### PR DESCRIPTION
And deprecate WKNavigationResponseGetURLResponse that returns pointer
to a dead object.