### PR TITLE
[ARMv7][JSC] Conservative GC is not considering `r7` as a root

### DIFF
--- a/Source/JavaScriptCore/ChangeLog
+++ b/Source/JavaScriptCore/ChangeLog
@@ -1,3 +1,22 @@
+2020-08-14  Caio Lima  <ticaiolima@gmail.com>
+
+        [ARMv7][JSC] Conservative GC is not considering `r7` as a root
+        https://bugs.webkit.org/show_bug.cgi?id=215512
+
+        Reviewed by Yusuke Suzuki.
+
+        Since `r7` is a callee-saved register on ARMv7
+        we need to consider it as a conservative root.
+
+        See the statement "A subroutine must preserve
+        the contents of the registers r4-r8, r10, r11
+        and SP (and r9 in PCS variants that designate
+        r9 as v6) form page 15 of
+        https://developer.arm.com/documentation/ihi0042/f/.
+
+        * heap/RegisterState.h:
+
+
 2020-01-27  Stephan Szabo  <stephan.szabo@sony.com>
 
         Python 3: generate-js-builtins hits SyntaxWarning for "is 0"

--- a/Source/JavaScriptCore/heap/RegisterState.h
+++ b/Source/JavaScriptCore/heap/RegisterState.h
@@ -78,6 +78,7 @@ struct RegisterState {
     uint32_t r4;
     uint32_t r5;
     uint32_t r6;
+    uint32_t r7;
     uint32_t r8;
     uint32_t r9;
     uint32_t r10;
@@ -92,6 +93,7 @@ struct RegisterState {
     SAVE_REG(r4, registers.r4); \
     SAVE_REG(r5, registers.r5); \
     SAVE_REG(r6, registers.r6); \
+    SAVE_REG(r7, registers.r7); \
     SAVE_REG(r8, registers.r8); \
     SAVE_REG(r9, registers.r9); \
     SAVE_REG(r10, registers.r10); \


### PR DESCRIPTION
Cherry pick from: https://bugs.webkit.org/show_bug.cgi?id=215512

cc: @guijemont 

It is related with #655