### PR TITLE
Leak of VectorBufferBase.m_buffer (16-64 bytes) under JSC::CompactVar…

### DIFF
--- a/Source/JavaScriptCore/ChangeLog
+++ b/Source/JavaScriptCore/ChangeLog
@@ -1,3 +1,19 @@
+2019-01-08  David Kilzer  <ddkilzer@apple.com>
+
+        Leak of VectorBufferBase.m_buffer (16-64 bytes) under JSC::CompactVariableEnvironment in com.apple.WebKit.WebContent running layout tests
+        <https://webkit.org/b/193264>
+        <rdar://problem/46651026>
+
+        Reviewed by Yusuke Suzuki.
+
+        * parser/VariableEnvironment.cpp:
+        (JSC::CompactVariableMap::Handle::~Handle): Call delete on
+        m_environment instead of fastFree() to make sure the destructors
+        for the Vector instance variables are run.  This fixes the leaks
+        because calling fastFree() would only free the
+        CompactVariableEnvironment object, but not the heap-based
+        buffers allocated for the Vector instance variables.
+
 2020-08-14  Caio Lima  <ticaiolima@gmail.com>
 
         [ARMv7][JSC] Conservative GC is not considering `r7` as a root

--- a/Source/JavaScriptCore/parser/VariableEnvironment.cpp
+++ b/Source/JavaScriptCore/parser/VariableEnvironment.cpp
@@ -179,7 +179,7 @@ CompactVariableMap::Handle::~Handle()
     if (!iter->value) {
         ASSERT(m_environment == &iter->key.environment());
         m_map->m_map.remove(iter);
-        fastFree(m_environment);
+        delete m_environment;
     }
 }
 


### PR DESCRIPTION
…iableEnvironment in com.apple.WebKit.WebContent running layout tests

<https://webkit.org/b/193264>
<rdar://problem/46651026>

Reviewed by Yusuke Suzuki.

* parser/VariableEnvironment.cpp:
(JSC::CompactVariableMap::Handle::~Handle): Call delete on
m_environment instead of fastFree() to make sure the destructors
for the Vector instance variables are run.  This fixes the leaks
because calling fastFree() would only free the
CompactVariableEnvironment object, but not the heap-based
buffers allocated for the Vector instance variables.

git-svn-id: http://svn.webkit.org/repository/webkit/trunk@239755 268f45cc-cd09-0410-ab3c-d52691b4dbfc