### PR TITLE
[GSTUTILS] getElement() leak fix.

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -153,8 +153,7 @@ GstElement* findElement(GstElement* container, ElementType type, MediaType media
             g_free(name);
         }
     }
-    if (re)
-        g_object_ref(re);
+
     return re;
 }
 

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -489,27 +489,20 @@ void connectSimpleBusMessageCallback(GstElement* pipeline)
 
 GRefPtr<GstElement> getElement(GstElement* container, ElementType type, MediaType media)
 {
-    GRefPtr<GstElement> ret;
+    GRefPtr<GstElement> result;
     if (GST_IS_PIPELINE(container)) {
         if (type == ElementType::SINK) {
             if (media == MediaType::AUDIO)
-                g_object_get(container, "audio-sink", &ret.outPtr(), nullptr);
+                g_object_get(container, "audio-sink", &result.outPtr(), nullptr);
             else
-                g_object_get(container, "video-sink", &ret.outPtr(), nullptr);
+                g_object_get(container, "video-sink", &result.outPtr(), nullptr);
         }
     }
 
-    if (!ret) {
-        auto element = findElement(container, type, media);
-        if (element) {
-            // findElement() does not copy/transfer ownership but due to
-            // the fact GRefPtr is returned ref element before assigning.
-            g_object_ref(element);
-            ret.outPtr() = element;
-        }
-    }
+    if (!result)
+        result = findElement(container, type, media);
 
-    return ret;
+    return result;
 }
 
 }

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -125,7 +125,7 @@ enum class MediaType : int {
 bool gstRegistryHasElementForMediaType(GList* elementFactories, const char* capsString);
 void connectSimpleBusMessageCallback(GstElement *pipeline);
 void disconnectSimpleBusMessageCallback(GstElement *pipeline);
-GstElement* getElement(GstElement* container, ElementType, MediaType);
+GRefPtr<GstElement> getElement(GstElement* container, ElementType, MediaType);
 
 }
 

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerBase.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerBase.cpp
@@ -1375,9 +1375,15 @@ unsigned MediaPlayerPrivateGStreamerBase::decodedFrameCount() const
 {
     guint64 decodedFrames = 0;
     GstElement* sink = m_fpsSink.get();
+    GRefPtr<GstElement> scopedSink;
 
     if (!sink)
-        sink = m_videoSink ? m_videoSink.get() : getElement(m_pipeline.get(), ElementType::SINK, MediaType::VIDEO);
+        sink = m_videoSink ? m_videoSink.get() : nullptr;
+
+    if (!sink) {
+        scopedSink = getElement(m_pipeline.get(), ElementType::SINK, MediaType::VIDEO);
+        sink = scopedSink.get();
+    }
 
     if (sink && g_object_class_find_property(G_OBJECT_GET_CLASS(sink), "frames-rendered")) {
         g_object_get(sink, "frames-rendered", &decodedFrames, nullptr);

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerBase.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerBase.cpp
@@ -1374,19 +1374,13 @@ void MediaPlayerPrivateGStreamerBase::setStreamVolumeElement(GstStreamVolume* vo
 unsigned MediaPlayerPrivateGStreamerBase::decodedFrameCount() const
 {
     guint64 decodedFrames = 0;
-    GstElement* sink = m_fpsSink.get();
-    GRefPtr<GstElement> scopedSink;
+    GRefPtr<GstElement> sink = m_fpsSink;
 
     if (!sink)
-        sink = m_videoSink ? m_videoSink.get() : nullptr;
+        sink = m_videoSink ? m_videoSink : getElement(m_pipeline.get(), ElementType::SINK, MediaType::VIDEO);
 
-    if (!sink) {
-        scopedSink = getElement(m_pipeline.get(), ElementType::SINK, MediaType::VIDEO);
-        sink = scopedSink.get();
-    }
-
-    if (sink && g_object_class_find_property(G_OBJECT_GET_CLASS(sink), "frames-rendered")) {
-        g_object_get(sink, "frames-rendered", &decodedFrames, nullptr);
+    if (sink && g_object_class_find_property(G_OBJECT_GET_CLASS(sink.get()), "frames-rendered")) {
+        g_object_get(sink.get(), "frames-rendered", &decodedFrames, nullptr);
         GST_DEBUG("frames decoded: %llu",  decodedFrames);
     }
     return static_cast<unsigned>(decodedFrames);


### PR DESCRIPTION
In one code path (gtting sinks from playbin) the caller is
responsible for freeing the returned element and on the other one
(findElement()) does not copy thus no free is needed. In order
to hide that and properly act no matter the path GRefPtr is now
returned from the function and for the case which does not copy
ref cnt is increased.