### PR TITLE
Improve waylandsink video sink support

### DIFF
--- a/Source/JavaScriptCore/assembler/ARM64Assembler.h
+++ b/Source/JavaScriptCore/assembler/ARM64Assembler.h
@@ -452,11 +452,11 @@ public:
             struct RealTypes {
                 intptr_t m_from : 48;
                 intptr_t m_to : 48;
+		RegisterID m_compareRegister;
                 JumpType m_type : 8;
                 JumpLinkType m_linkType : 8;
                 Condition m_condition : 4;
                 unsigned m_bitNumber : 6;
-                RegisterID m_compareRegister : 6;
                 bool m_is64Bit : 1;
             } realTypes;
             struct CopyTypes {

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -83,6 +83,14 @@
 #include "AudioSourceProviderGStreamer.h"
 #endif
 
+#if USE(WAYLAND_SINK)
+#include "PlatformDisplayWPE.h"
+#include <wpe-rdk-1.0/wpe/compositorclient-get-surface.h>
+#include <wpe/wpe-egl.h>
+#include <gst/video/videooverlay.h>
+
+#endif
+
 GST_DEBUG_CATEGORY_EXTERN(webkit_media_player_debug);
 #define GST_CAT_DEFAULT webkit_media_player_debug
 
@@ -169,6 +177,17 @@ MediaPlayerPrivateGStreamer::MediaPlayerPrivateGStreamer(MediaPlayer* player)
 {
 #if USE(GLIB)
     m_readyTimerHandler.setPriority(G_PRIORITY_DEFAULT_IDLE);
+#endif
+
+#if USE(WAYLAND_SINK)
+    //Used to receive parent wayland surface
+    auto& sharedDisplay = PlatformDisplay::sharedDisplay();
+    if (is<PlatformDisplayWPE>(sharedDisplay)) {
+        m_parentSurface = wpe_compositorclient_get_parent_surface(downcast<PlatformDisplayWPE>(sharedDisplay).backend());
+        GST_DEBUG("wayland-sink: m_parentSurface = %p", m_parentSurface);
+        m_nativeDisplayHandle = wpe_renderer_backend_egl_get_native_display(downcast<PlatformDisplayWPE>(sharedDisplay).backend());
+        GST_DEBUG("wayland-sink: m_nativeDisplay = %p", m_nativeDisplayHandle);
+    }
 #endif
 }
 

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerBase.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerBase.cpp
@@ -1304,6 +1304,15 @@ GstElement* MediaPlayerPrivateGStreamerBase::createHolePunchVideoSink()
     return videoSink;
 #endif
 
+#if USE(WAYLAND_SINK)
+    GST_INFO("wayland-sink: Creating waylandsink videoSink");
+    GRefPtr<GstElementFactory> waylandsinkfactory = adoptGRef(gst_element_factory_find("waylandsink"));
+    GstElement* videoSink = gst_element_factory_create(waylandsinkfactory.get(), "waylandsink");
+    //set alpha so GUI is visible (NOTE alpha is a NXP specific waylandsink property)
+    g_object_set(G_OBJECT(videoSink), "alpha", 0.5f, nullptr);
+    return videoSink;
+#endif
+
     // Returning nullptr means relying on autovideosink.
     return nullptr;
 }
@@ -1346,9 +1355,7 @@ GstElement* MediaPlayerPrivateGStreamerBase::createVideoSink()
     m_videoSink = gst_element_factory_make( "brcmvideosink", nullptr);
 #endif
 
-#if USE(WAYLAND_SINK)
-    m_videoSink = gst_element_factory_make( "waylandsink", nullptr);
-#elif USE(GSTREAMER_GL)
+#if USE(GSTREAMER_GL)
     if (m_renderingCanBeAccelerated)
         m_videoSink = createVideoSinkGL();
 #endif

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerBase.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerBase.h
@@ -290,6 +290,11 @@ protected:
 
     ImageOrientation m_videoSourceOrientation;
 
+#if USE(WAYLAND_SINK)
+    void *m_nativeDisplayHandle;
+    void *m_parentSurface;
+#endif
+
 #if ENABLE(ENCRYPTED_MEDIA)
     RefPtr<const CDMInstance> m_cdmInstance;
 #endif

--- a/Source/WebKit/wpe/wpe-webkit-deprecated.pc.in
+++ b/Source/WebKit/wpe/wpe-webkit-deprecated.pc.in
@@ -7,6 +7,6 @@ Name: WPE WebKit -- DEPRECATED API
 Description: Embeddable Web content engine -- DEPRECATED API
 URL: https://wpewebkit.org
 Version: @PROJECT_VERSION@
-Requires: glib-2.0 libsoup-2.4 wpe-0.2
+Requires: glib-2.0 libsoup-2.4 wpe-1.0
 Libs: -L${libdir} -lWPEWebKit-@WPE_API_VERSION@
 Cflags: -I${includedir}/wpe-webkit-deprecated-@WPE_API_VERSION@

--- a/Source/cmake/FindWPE.cmake
+++ b/Source/cmake/FindWPE.cmake
@@ -29,7 +29,7 @@
 # ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 find_package(PkgConfig)
-pkg_check_modules(PC_WPE QUIET wpe-0.2)
+pkg_check_modules(PC_WPE QUIET wpe-1.0)
 
 find_path(WPE_INCLUDE_DIRS
     NAMES wpe/wpe.h
@@ -37,7 +37,7 @@ find_path(WPE_INCLUDE_DIRS
 )
 
 find_library(WPE_LIBRARIES
-    NAMES wpe-0.2
+    NAMES wpe-1.0
     HINTS ${PC_WPE_LIBDIR} ${PC_WPE_LIBRARY_DIRS}
 )
 

--- a/Source/cmake/FindWPEBackend-rdk.cmake
+++ b/Source/cmake/FindWPEBackend-rdk.cmake
@@ -1,0 +1,47 @@
+# - Try to find WPEBackend-rdk.
+# Once done, this will define
+#
+#  WPEBACKEND_RDK_FOUND - system has WPEBackend-rdk.
+#  WPEBACKEND_RDK_INCLUDE_DIRS - the WPEBackend-rdk include directories
+#  WPEBACKEND_RDK_LIBRARIES - link these to use WPEBackend-rdk.
+#
+# Copyright (C) 2020 Linaro
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER AND ITS CONTRIBUTORS ``AS
+# IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR ITS
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+find_package(PkgConfig)
+pkg_check_modules(PC_WPEBACKEND_RDK QUIET wpebackend-rdk-1.0)
+
+find_path(WPEBACKEND_RDK_INCLUDE_DIRS
+    NAMES wpe/compositorclient-get-surface.h
+    HINTS ${PC_WPEBACKEND_RDK_INCLUDEDIR} ${PC_WPEBACKEND_RDK_INCLUDE_DIRS}
+)
+
+find_library(WPEBACKEND_RDK_LIBRARIES
+    NAMES WPEBackend-rdk
+    HINTS ${PC_WPEBACKEND_RDK_LIBDIR} ${PC_WPEBACKEND_RDK_LIBRARY_DIRS}
+)
+
+mark_as_advanced(WPEBACKEND_RDK_INCLUDE_DIRS WPEBACKEND_RDK_LIBRARIES)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(WPEBackend-rdk REQUIRED_VARS WPEBACKEND_RDK_INCLUDE_DIRS WPEBACKEND_RDK_LIBRARIES)

--- a/Source/cmake/OptionsWPE.cmake
+++ b/Source/cmake/OptionsWPE.cmake
@@ -136,6 +136,10 @@ if (USE_WPEWEBKIT_BACKEND_BCM_NEXUS_WAYLAND)
     find_package(Wayland REQUIRED)
 endif(USE_WPEWEBKIT_BACKEND_BCM_NEXUS_WAYLAND)
 
+if (USE_WAYLAND_SINK)
+    find_package(WPEBackend-rdk REQUIRED)
+endif(USE_WAYLAND_SINK)
+
 if (ENABLE_ACCELERATED_2D_CANVAS)
     find_package(CairoGL 1.10.2 REQUIRED COMPONENTS cairo-egl)
 endif ()


### PR DESCRIPTION
This pull request improves the waylandsink video sink support that can be used in conjunction with the hole punch mechanism. It does this in a couple of ways.
- It updates libwpe to a newer version enabling us to. Specifically we want a version of libwpe that includes this commit https://github.com/WebPlatformForEmbedded/libwpe/commit/67ccb407efb295c727553145080937e8bb3a3211
- It adds a CMake file for finding WPEBackend-rdk to pick up public headers
- Adds support for the wpe_compositorclient_get_parent_surface() api added in this pull request https://github.com/WebPlatformForEmbedded/WPEBackend-rdk/pull/55 to wpebackend-rdk to enable gstreamer backend to get the parent surface created by Thunder compositorclient.
- Adds support in gstreamer backend to set the wayland display handle and the external surface to waylandsink. This allows the video surface to correctly be a sub-surface of the browser.
- Updates the GStreamer holePunchClient so that it can set the render rectangle on the GstVideoOverlay of waylandsink.

Before this pull request, when using waylandsink as the video sink in wpewebkit the video was always played full screen. With this pull request applied the video surface is correctly placed at the right coordinates, and the video surface is created as a subsurface of the browser surface.

This pull request is dependent on corresponding new api in wpebackend-rdk https://github.com/WebPlatformForEmbedded/WPEBackend-rdk/pull/55 and a new GetNativeSurface hook in Thunder here https://github.com/rdkcentral/ThunderClientLibraries/pull/7

The following video demonstrates the waylandsink video sink integration work described here. This is running Weston compositor with Thunder, OpenCDM & Widevine and using waylandsink as the video sink https://photos.app.goo.gl/DEKhcYmWfxRsFDxw7