### PR TITLE
Crash when calling XMLHttpRequest.setRequestHeader() in a worker

### DIFF
--- a/LayoutTests/ChangeLog
+++ b/LayoutTests/ChangeLog
@@ -9,6 +9,20 @@
         * compositing/video/video-update-rendering-expected.txt: Added.
         * compositing/video/video-update-rendering.html: Added.
 
+2019-06-04  Chris Dumez  <cdumez@apple.com>
+
+        Crash when calling XMLHttpRequest.setRequestHeader() in a worker
+        https://bugs.webkit.org/show_bug.cgi?id=198534
+        <rdar://problem/51393912>
+
+        Reviewed by Alex Christensen.
+
+        Add layout test coverage.
+
+        * fast/workers/resources/worker-xhr-setRequestHeader.js: Added.
+        * fast/workers/worker-xhr-setRequestHeader-expected.txt: Added.
+        * fast/workers/worker-xhr-setRequestHeader.html: Added.
+
 2018-10-18  Jer Noble  <jer.noble@apple.com>
 
         Safari is not able to adapt between H264 streams with EditList and without EditList

--- a/LayoutTests/fast/workers/resources/worker-xhr-setRequestHeader.js
+++ b/LayoutTests/fast/workers/resources/worker-xhr-setRequestHeader.js
@@ -1,0 +1,14 @@
+importScripts('../../../resources/js-test-pre.js');
+
+var global = this;
+global.jsTestIsAsync = true;
+
+description("Tests XMLHttpRequest.setRequestHeader() in workers");
+
+var xhr = new XMLHttpRequest;
+xhr.open("GET", "empty-worker.js", false);
+xhr.setRequestHeader("Accept", "*/*");
+xhr.send(null);
+
+finishJSTest();
+

--- a/LayoutTests/fast/workers/worker-xhr-setRequestHeader-expected.txt
+++ b/LayoutTests/fast/workers/worker-xhr-setRequestHeader-expected.txt
@@ -1,0 +1,10 @@
+[Worker] Tests XMLHttpRequest.setRequestHeader() in workers
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Starting worker: resources/worker-xhr-setRequestHeader.js
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/workers/worker-xhr-setRequestHeader.html
+++ b/LayoutTests/fast/workers/worker-xhr-setRequestHeader.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+</head>
+<body>
+<script>
+worker = startWorker('resources/worker-xhr-setRequestHeader.js');
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/Source/WebCore/ChangeLog
+++ b/Source/WebCore/ChangeLog
@@ -11,6 +11,22 @@
         * rendering/RenderLayerBacking.cpp:
         (WebCore::RenderLayerBacking::contentChanged):
 
+2019-06-04  Chris Dumez  <cdumez@apple.com>
+
+        Crash when calling XMLHttpRequest.setRequestHeader() in a worker
+        https://bugs.webkit.org/show_bug.cgi?id=198534
+        <rdar://problem/51393912>
+
+        Reviewed by Alex Christensen.
+
+        Make sure the script execution context is a Document because calling document()
+        to get the settings.
+
+        Test: fast/workers/worker-xhr-setRequestHeader.html
+
+        * xml/XMLHttpRequest.cpp:
+        (WebCore::XMLHttpRequest::setRequestHeader):
+
 2018-09-21  Mike Gorse  <mgorse@suse.com>
 
         Build tools should work when the /usr/bin/python is python3

--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -822,7 +822,9 @@ ExceptionOr<void> XMLHttpRequest::setRequestHeader(const String& name, const Str
 #if ENABLE(DASHBOARD_SUPPORT)
     allowUnsafeHeaderField = usesDashboardBackwardCompatibilityMode();
 #endif
-    if (securityOrigin()->canLoadLocalResources() && document()->settings().allowSettingAnyXHRHeaderFromFileURLs())
+
+    // FIXME: The allowSettingAnyXHRHeaderFromFileURLs setting currently only applies to Documents, not workers.
+    if (securityOrigin()->canLoadLocalResources() && scriptExecutionContext()->isDocument() && document()->settings().allowSettingAnyXHRHeaderFromFileURLs())
         allowUnsafeHeaderField = true;
     if (!allowUnsafeHeaderField && isForbiddenHeaderName(name)) {
         logConsoleError(scriptExecutionContext(), "Refused to set unsafe header \"" + name + "\"");


### PR DESCRIPTION
This is a commit from Webkit ustream https://github.com/WebKit/webkit/commit/673841f96982b745e2a6cab7779d0d3ab7732950, fixing a WPEWebProcess crash after calling XMLHttpRequest.setRequestHeader() in a worker.