### PR TITLE
fix crash in webkitMediaOpenCDMDecryptorResetSessionFromKeyIdIfNeeded()

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/eme/WebKitOpenCDMDecryptorGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/WebKitOpenCDMDecryptorGStreamer.cpp
@@ -153,7 +153,7 @@ static SessionResult webKitMediaOpenCDMDecryptorResetSessionFromKeyIdIfNeeded(We
     LockHolder locker(priv->m_mutex);
     RefPtr<WebCore::CDMInstance> cdmInstance = webKitMediaCommonEncryptionDecryptCDMInstance(self);
 
-    if( !cdmInstance || !is<WebCore::CDMInstanceOpenCDM>(*cdmInstance) )
+    if( !cdmInstance || !is<WebCore::CDMInstanceOpenCDM>(*cdmInstance) ) {
         GST_WARNING_OBJECT(self, "CDM instance is not available yet!");
         ASSERT_NOT_REACHED();
         return InvalidSession;

--- a/Source/WebCore/platform/graphics/gstreamer/eme/WebKitOpenCDMDecryptorGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/WebKitOpenCDMDecryptorGStreamer.cpp
@@ -152,7 +152,13 @@ static SessionResult webKitMediaOpenCDMDecryptorResetSessionFromKeyIdIfNeeded(We
 
     LockHolder locker(priv->m_mutex);
     RefPtr<WebCore::CDMInstance> cdmInstance = webKitMediaCommonEncryptionDecryptCDMInstance(self);
-    ASSERT(cdmInstance && is<WebCore::CDMInstanceOpenCDM>(*cdmInstance));
+
+    if( !cdmInstance || !is<WebCore::CDMInstanceOpenCDM>(*cdmInstance) )
+        GST_WARNING_OBJECT(self, "CDM instance is not available yet!");
+        ASSERT_NOT_REACHED();
+        return InvalidSession;
+    }
+
     auto& cdmInstanceOpenCDM = downcast<WebCore::CDMInstanceOpenCDM>(*cdmInstance);
 
     SessionResult returnValue = InvalidSession;


### PR DESCRIPTION
cdmInstance may not be available when webKitMediaOpenCDMDecryptorResetSessionFromKeyIdIfNeeded() is called

This prevents a crash seen when playing content in http://www.gurdal-lab.net/dash.js/samples/playreadyMS.html