### PR TITLE
Adding encoded stream format support from camera input

### DIFF
--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp
@@ -47,8 +47,8 @@ GstElement* GStreamerVideoCapturer::createConverter()
 
     if (strcmp (codec, "video/x-raw") == 0)
     {
-        GRefPtr<GstElementFactory> h264encoder = getEncoder ("video/x-h264");
-        GRefPtr<GstElementFactory> h264parser = getParser ("video/x-h264");
+        GRefPtr<GstElementFactory> h264encoder = adoptGRef(getEncoder ("video/x-h264"));
+        GRefPtr<GstElementFactory> h264parser = adoptGRef(getParser ("video/x-h264"));
 
         if (h264encoder && h264parser)
         {
@@ -112,6 +112,7 @@ GstElementFactory* GStreamerVideoCapturer::getEncoder (const char* format)
     }
     encoder_factory = GST_ELEMENT_FACTORY (g_list_first(encoders)->data);
     GST_INFO("Found H264 encoder : %s ", GST_ELEMENT_NAME(encoder_factory));
+    gst_object_ref(encoder_factory);
 
     gst_plugin_feature_list_free (encoder_list);
     gst_plugin_feature_list_free (encoders);
@@ -137,6 +138,7 @@ GstElementFactory* GStreamerVideoCapturer::getParser (const char* format)
     }
     parser_factory = GST_ELEMENT_FACTORY (g_list_first(parsers)->data);
     GST_INFO("Found H264 parser : %s ", GST_ELEMENT_NAME(parser_factory));
+    gst_object_ref(parser_factory);
 
     gst_plugin_feature_list_free (parser_list);
     gst_plugin_feature_list_free (parsers);

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp
@@ -50,9 +50,12 @@ GstElement* GStreamerVideoCapturer::createConverter()
         GstElementFactory *h264encoder = getEncoder ("video/x-h264");
         GstElementFactory *h264parser = getParser ("video/x-h264");
 
-        char *videoInput = g_strdup_printf ("videoscale ! videoconvert ! videorate ! %s ! %s", GST_ELEMENT_NAME(h264encoder), GST_ELEMENT_NAME(h264parser));
-        converter = gst_parse_bin_from_description(videoInput, TRUE, nullptr);
-        m_caps = adoptGRef(gst_caps_new_empty_simple("video/x-h264"));
+        if (h264encoder && h264parser)
+        {
+            char *videoInput = g_strdup_printf ("videoscale ! videoconvert ! videorate ! %s ! %s", GST_ELEMENT_NAME(h264encoder), GST_ELEMENT_NAME(h264parser));
+            converter = gst_parse_bin_from_description(videoInput, TRUE, nullptr);
+            m_caps = adoptGRef(gst_caps_new_empty_simple("video/x-h264"));
+        }
     }
     else
     {

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp
@@ -39,10 +39,108 @@ GStreamerVideoCapturer::GStreamerVideoCapturer(const char* sourceFactory)
 GstElement* GStreamerVideoCapturer::createConverter()
 {
     auto converter = gst_parse_bin_from_description("videoscale ! videoconvert ! videorate", TRUE, nullptr);
+#if USE(WESTEROS_SINK)
+// If camera supports only x-raw, westerossink expects encoded form. So pass through an h264 encoder and parser after probing platform.
+// If camera supports encoded formats, use a dummy identity element to skip converting to x-raw.
+    const char* codec = getPreferredCodec().c_str();
+    GST_INFO_OBJECT(m_pipeline.get(), "Preferred codec is %s ", codec);
+
+    if (strcmp (codec, "video/x-raw") == 0)
+    {
+        GstElementFactory *h264encoder = getEncoder ("video/x-h264");
+        GstElementFactory *h264parser = getParser ("video/x-h264");
+
+        char *videoInput = g_strdup_printf ("videoscale ! videoconvert ! videorate ! %s ! %s", GST_ELEMENT_NAME(h264encoder), GST_ELEMENT_NAME(h264parser));
+        converter = gst_parse_bin_from_description(videoInput, TRUE, nullptr);
+        m_caps = adoptGRef(gst_caps_new_empty_simple("video/x-h264"));
+    }
+    else
+    {
+        converter = gst_parse_bin_from_description("identity", TRUE, nullptr);
+        m_caps = adoptGRef(gst_caps_new_empty_simple(codec));
+    }
+#endif
 
     ASSERT(converter);
 
     return converter;
+}
+
+std::string GStreamerVideoCapturer::getPreferredCodec()
+{
+    GstCaps* caps = gst_device_get_caps(m_device.get());
+    const std::string videoCaps = gst_caps_to_string(caps);
+
+    if( videoCaps.find("video/x-av1") != std::string::npos )
+        return "video/x-av1";
+    else if( videoCaps.find("video/x-vp9") != std::string::npos )
+        return "video/x-vp9";
+    else if( videoCaps.find("video/x-vp8") != std::string::npos )
+        return "video/x-vp8";
+    else if( videoCaps.find("video/x-h265") != std::string::npos )
+        return "video/x-h265";
+    else if( videoCaps.find("video/x-h264") != std::string::npos )
+        return "video/x-h264";
+    else if( videoCaps.find("video/x-mpeg") != std::string::npos )
+        return "video/x-mpeg";
+    else if( videoCaps.find("video/x-raw") != std::string::npos )
+        return "video/x-raw";
+
+    return " ";
+}
+
+GstElementFactory* GStreamerVideoCapturer::getEncoder (const char* format)
+{
+    GList *encoder_list, *encoders;
+    GstCaps *caps_str;
+    GstElementFactory *encoder_factory;
+    caps_str = gst_caps_from_string (format);
+
+    encoder_list = gst_element_factory_list_get_elements (GST_ELEMENT_FACTORY_TYPE_ENCODER, GST_RANK_MARGINAL);
+    encoders = gst_element_factory_list_filter(encoder_list, caps_str, GST_PAD_SRC, false);
+
+    if (!(g_list_length(encoders)))
+    {
+        gst_plugin_feature_list_free (encoder_list);
+        gst_plugin_feature_list_free (encoders);
+        GST_ERROR("Couldnt find h264 encoder ");
+        return NULL;
+    }
+    encoder_factory = GST_ELEMENT_FACTORY (g_list_first(encoders)->data);
+    GST_INFO("Found H264 encoder : %s ", GST_ELEMENT_NAME(encoder_factory));
+
+    gst_caps_unref (caps_str);
+    gst_plugin_feature_list_free (encoder_list);
+    gst_plugin_feature_list_free (encoders);
+
+    return encoder_factory;
+}
+
+GstElementFactory* GStreamerVideoCapturer::getParser (const char* format)
+{
+    GList *parser_list, *parsers;
+    GstCaps *caps_str;
+    GstElementFactory *parser_factory;
+    caps_str = gst_caps_from_string (format);
+
+    parser_list = gst_element_factory_list_get_elements (GST_ELEMENT_FACTORY_TYPE_PARSER, GST_RANK_MARGINAL);
+    parsers = gst_element_factory_list_filter(parser_list, caps_str, GST_PAD_SINK, false);
+
+    if (!(g_list_length(parsers)))
+    {
+        gst_plugin_feature_list_free (parser_list);
+        gst_plugin_feature_list_free (parsers);
+        GST_ERROR("Couldnt find h264 parser ");
+        return NULL;
+    }
+    parser_factory = GST_ELEMENT_FACTORY (g_list_first(parsers)->data);
+    GST_INFO("Found H264 parser : %s ", GST_ELEMENT_NAME(parser_factory));
+
+    gst_caps_unref (caps_str);
+    gst_plugin_feature_list_free (parser_list);
+    gst_plugin_feature_list_free (parsers);
+
+    return parser_factory;
 }
 
 GstVideoInfo GStreamerVideoCapturer::getBestFormat()

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.h
@@ -40,6 +40,9 @@ public:
     bool setSize(int width, int height);
     bool setFrameRate(double);
     GstVideoInfo getBestFormat();
+    std::string getPreferredCodec();
+    GstElementFactory* getEncoder (const char* format);
+    GstElementFactory* getParser (const char* format);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.h
@@ -40,7 +40,7 @@ public:
     bool setSize(int width, int height);
     bool setFrameRate(double);
     GstVideoInfo getBestFormat();
-    std::string getPreferredCodec();
+    const char * getPreferredCodec();
     GstElementFactory* getEncoder (const char* format);
     GstElementFactory* getParser (const char* format);
 };


### PR DESCRIPTION
Westeros sink supports encoded video formats.
If camera supports encoded stream formats, make use of westerossink capability by passing them directly to westerossink instead of formatting to x-raw.
Change added to meet the use case in RDK builds using westerossink.