### PR TITLE
Do not convert language strings to lowercase

### DIFF
--- a/Source/WebKit/UIProcess/API/C/soup/WKSoupSession.cpp
+++ b/Source/WebKit/UIProcess/API/C/soup/WKSoupSession.cpp
@@ -34,7 +34,7 @@ void WKSoupSessionSetPreferredLanguages(WKContextRef context, WKArrayRef languag
         if (equalIgnoringASCIICase(string, "C") || equalIgnoringASCIICase(string, "POSIX"))
             languagesVector.uncheckedAppend("en-us"_s);
         else
-            languagesVector.uncheckedAppend(string.convertToASCIILowercase().replace("_", "-"));
+            languagesVector.uncheckedAppend(string.replace("_", "-"));
     }
 
     overrideUserPreferredLanguages(languagesVector);


### PR DESCRIPTION
Those values are used for HTTP Accept-Language header, which usually has country part in uppercase. e.g:
Accept-Language: de-CH
Accept-Language: en-US,en;q=0.5
There's no point in converting to lowercase, it should be left as is