### PR TITLE
Extend supportsType to reject invalid channels and features

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -978,8 +978,12 @@ MediaPlayer::SupportsType MediaPlayerPrivateGStreamerMSE::supportsType(const Med
     }
 
     bool ok;
-    unsigned channels = parameters.type.parameter("channels"_s).toUInt(&ok);
-    if (ok && channels > MEDIA_MAX_AAC_CHANNELS)
+    int channels = parameters.type.parameter("channels"_s).toInt(&ok);
+    if (ok && (channels > MEDIA_MAX_AAC_CHANNELS || channels <= 0))
+        return result;
+
+    String features = parameters.type.parameter("features"_s);
+    if (!features.isEmpty() && !supportsFeatures(features))
         return result;
 
     float width = parameters.type.parameter("width"_s).toFloat(&ok);
@@ -1007,6 +1011,16 @@ MediaPlayer::SupportsType MediaPlayerPrivateGStreamerMSE::supportsType(const Med
     }
 
     return extendedSupportsType(parameters, result);
+}
+
+bool MediaPlayerPrivateGStreamerMSE::supportsFeatures(const String& features)
+{
+    // Apple TV requires this one for DD+
+    constexpr auto dolbyDigitalPlusJOC = "joc";
+    if (features == dolbyDigitalPlusJOC)
+        return true;
+
+    return false;
 }
 
 void MediaPlayerPrivateGStreamerMSE::markEndOfStream(MediaSourcePrivate::EndOfStreamStatus status)

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
@@ -105,6 +105,7 @@ public:
 private:
     static void getSupportedTypes(HashSet<String, ASCIICaseInsensitiveHash>&);
     static MediaPlayer::SupportsType supportsType(const MediaEngineSupportParameters&);
+    static bool supportsFeatures(const String&);
     static bool initializeGStreamer();
     static void ensureWebKitGStreamerElements();
     static HashSet<String, ASCIICaseInsensitiveHash>& mimeTypeCache();


### PR DESCRIPTION
`MediaPlayerPrivateGStreamerMSE::supportsType` should not accept `channels<=0` as well as features other than `joc` (dolby atmos aka dolby digital+ JOC) if present - this is needed by AppleTV+ as they have checks like:



`audio/mp4; codecs="mp4a.40.2"; channels="-1"`, `expectSupported: false`
`audio/mp4; codecs="mp4a.40.2"; channels="16"`, `expectSupported: true`
`audio/mp4; codecs="mp4a.40.2"; features="INVALID"`, `expectSupported: false`
`audio/mp4; codecs="mp4a.40.2"; features="JOC"`, `expectSupported: true`
`audio/mp4; codecs="mp4a.40.2"; channels="-1"; features="INVALID"`, `expectSupported: false`
