### PR TITLE
[JSC] Identifier validity should be based on ID_Start / ID_Continue properties

### DIFF
--- a/JSTests/ChangeLog
+++ b/JSTests/ChangeLog
@@ -1,3 +1,14 @@
+2018-12-30  Ross Kirsling  <ross.kirsling@sony.com>
+
+        [JSC] Identifier validity should be based on ID_Start / ID_Continue properties
+        https://bugs.webkit.org/show_bug.cgi?id=193050
+
+        Reviewed by Yusuke Suzuki.
+
+        * test262.yaml:
+        * test262/expectations.yaml:
+        Mark 16 tests as passing.
+
 2019-04-04  Saam Barati  <sbarati@apple.com>
 
         Unreviewed. Make the test from r243906 catch the thrown exceptions.

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -2818,33 +2818,9 @@ test/language/global-code/script-decl-func-err-non-extensible.js:
 test/language/global-code/script-decl-var-err.js:
   default: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'
-test/language/identifiers/other_id_continue-escaped.js:
-  default: "SyntaxError: Invalid unicode escape in identifier: 'a\\u2118'"
-  strict mode: "SyntaxError: Invalid unicode escape in identifier: 'a\\u2118'"
-test/language/identifiers/other_id_continue.js:
-  default: "SyntaxError: Invalid character '\\u2118'"
-  strict mode: "SyntaxError: Invalid character '\\u2118'"
-test/language/identifiers/other_id_start-escaped.js:
-  default: "SyntaxError: Invalid unicode escape in identifier: '\\u2118'"
-  strict mode: "SyntaxError: Invalid unicode escape in identifier: '\\u2118'"
-test/language/identifiers/other_id_start.js:
-  default: "SyntaxError: Invalid character '\\u2118'"
-  strict mode: "SyntaxError: Invalid character '\\u2118'"
 test/language/identifiers/val-yield-strict.js:
   default: 'Test262: This statement should not be evaluated.'
   strict mode: "SyntaxError: Cannot use 'yield' as a variable name in strict mode."
-test/language/identifiers/vertical-tilde-continue-escaped.js:
-  default: 'Test262: This statement should not be evaluated.'
-  strict mode: 'Test262: This statement should not be evaluated.'
-test/language/identifiers/vertical-tilde-continue.js:
-  default: 'Test262: This statement should not be evaluated.'
-  strict mode: 'Test262: This statement should not be evaluated.'
-test/language/identifiers/vertical-tilde-start-escaped.js:
-  default: 'Test262: This statement should not be evaluated.'
-  strict mode: 'Test262: This statement should not be evaluated.'
-test/language/identifiers/vertical-tilde-start.js:
-  default: 'Test262: This statement should not be evaluated.'
-  strict mode: 'Test262: This statement should not be evaluated.'
 test/language/literals/numeric/numeric-separator-literal-bil-bd-nsl-bd.js:
   default: 'SyntaxError: No space between binary literal and identifier'
   strict mode: 'SyntaxError: No space between binary literal and identifier'

--- a/LayoutTests/ChangeLog
+++ b/LayoutTests/ChangeLog
@@ -1,3 +1,39 @@
+2018-12-30  Ross Kirsling  <ross.kirsling@sony.com>
+
+        [JSC] Identifier validity should be based on ID_Start / ID_Continue properties
+        https://bugs.webkit.org/show_bug.cgi?id=193050
+
+        Reviewed by Yusuke Suzuki.
+
+        * sputnik/Unicode/Unicode_218/S7.6_A1.1_T2-expected.txt:
+        * sputnik/Unicode/Unicode_218/S7.6_A1.1_T6-expected.txt:
+        * sputnik/Unicode/Unicode_218/S7.6_A5.2_T2-expected.txt:
+        * sputnik/Unicode/Unicode_218/S7.6_A5.2_T6-expected.txt:
+        * sputnik/Unicode/Unicode_218/S7.6_A5.3_T1-expected.txt:
+        * sputnik/Unicode/Unicode_218/S7.6_A5.3_T2-expected.txt:
+        * sputnik/Unicode/Unicode_320/S7.6_A1.1_T6-expected.txt:
+        * sputnik/Unicode/Unicode_320/S7.6_A2.3-expected.txt:
+        * sputnik/Unicode/Unicode_320/S7.6_A3.1-expected.txt:
+        * sputnik/Unicode/Unicode_320/S7.6_A5.2_T6-expected.txt:
+        * sputnik/Unicode/Unicode_320/S7.6_A5.2_T9-expected.txt:
+        * sputnik/Unicode/Unicode_320/S7.6_A5.3_T1-expected.txt:
+        * sputnik/Unicode/Unicode_320/S7.6_A5.3_T2-expected.txt:
+        * sputnik/Unicode/Unicode_410/S7.6_A1.1_T6-expected.txt:
+        * sputnik/Unicode/Unicode_410/S7.6_A3.1-expected.txt:
+        * sputnik/Unicode/Unicode_410/S7.6_A5.2_T6-expected.txt:
+        * sputnik/Unicode/Unicode_410/S7.6_A5.3_T1-expected.txt:
+        * sputnik/Unicode/Unicode_410/S7.6_A5.3_T2-expected.txt:
+        * sputnik/Unicode/Unicode_500/S7.6_A1.1_T6-expected.txt:
+        * sputnik/Unicode/Unicode_500/S7.6_A3.1-expected.txt:
+        * sputnik/Unicode/Unicode_500/S7.6_A5.2_T6-expected.txt:
+        * sputnik/Unicode/Unicode_500/S7.6_A5.3_T1-expected.txt:
+        * sputnik/Unicode/Unicode_500/S7.6_A5.3_T2-expected.txt:
+        * sputnik/Unicode/Unicode_510/S7.6_A1.1_T4-expected.txt:
+        * sputnik/Unicode/Unicode_510/S7.6_A1.1_T6-expected.txt:
+        * sputnik/Unicode/Unicode_510/S7.6_A5.2_T4-expected.txt:
+        * sputnik/Unicode/Unicode_510/S7.6_A5.2_T6-expected.txt:
+        Update expectations for outdated tests.
+
 2020-02-28  Chris Dumez  <cdumez@apple.com>
 
         Garbage collection prevents FontFace.loaded promise from getting resolved

--- a/LayoutTests/sputnik/Unicode/Unicode_218/S7.6_A1.1_T2-expected.txt
+++ b/LayoutTests/sputnik/Unicode/Unicode_218/S7.6_A1.1_T2-expected.txt
@@ -1,6 +1,6 @@
 S7.6_A1.1_T2
 
-FAIL SputnikError: #2118 
+PASS 
 
 TEST COMPLETE
 

--- a/LayoutTests/sputnik/Unicode/Unicode_218/S7.6_A1.1_T6-expected.txt
+++ b/LayoutTests/sputnik/Unicode/Unicode_218/S7.6_A1.1_T6-expected.txt
@@ -1,6 +1,6 @@
 S7.6_A1.1_T6
 
-FAIL SputnikError: #2160 
+PASS 
 
 TEST COMPLETE
 

--- a/LayoutTests/sputnik/Unicode/Unicode_218/S7.6_A5.2_T2-expected.txt
+++ b/LayoutTests/sputnik/Unicode/Unicode_218/S7.6_A5.2_T2-expected.txt
@@ -1,6 +1,6 @@
 S7.6_A5.2_T2
 
-FAIL SputnikError: #2118 
+PASS 
 
 TEST COMPLETE
 

--- a/LayoutTests/sputnik/Unicode/Unicode_218/S7.6_A5.2_T6-expected.txt
+++ b/LayoutTests/sputnik/Unicode/Unicode_218/S7.6_A5.2_T6-expected.txt
@@ -1,6 +1,6 @@
 S7.6_A5.2_T6
 
-FAIL SputnikError: #2160 
+PASS 
 
 TEST COMPLETE
 

--- a/LayoutTests/sputnik/Unicode/Unicode_218/S7.6_A5.3_T1-expected.txt
+++ b/LayoutTests/sputnik/Unicode/Unicode_218/S7.6_A5.3_T1-expected.txt
@@ -1,6 +1,6 @@
 S7.6_A5.3_T1
 
-FAIL SputnikError: #01F6-01F9 
+FAIL SputnikError: #00B7 
 
 TEST COMPLETE
 

--- a/LayoutTests/sputnik/Unicode/Unicode_218/S7.6_A5.3_T2-expected.txt
+++ b/LayoutTests/sputnik/Unicode/Unicode_218/S7.6_A5.3_T2-expected.txt
@@ -1,6 +1,6 @@
 S7.6_A5.3_T2
 
-FAIL SputnikError: #01F6-01F9 
+FAIL SputnikError: #00B7 
 
 TEST COMPLETE
 

--- a/LayoutTests/sputnik/Unicode/Unicode_320/S7.6_A1.1_T6-expected.txt
+++ b/LayoutTests/sputnik/Unicode/Unicode_320/S7.6_A1.1_T6-expected.txt
@@ -1,6 +1,6 @@
 S7.6_A1.1_T6
 
-FAIL SputnikError: #16EE 
+PASS 
 
 TEST COMPLETE
 

--- a/LayoutTests/sputnik/Unicode/Unicode_320/S7.6_A2.3-expected.txt
+++ b/LayoutTests/sputnik/Unicode/Unicode_320/S7.6_A2.3-expected.txt
@@ -1,6 +1,6 @@
 S7.6_A2.3
 
-FAIL SputnikError: #1369 
+PASS 
 
 TEST COMPLETE
 

--- a/LayoutTests/sputnik/Unicode/Unicode_320/S7.6_A3.1-expected.txt
+++ b/LayoutTests/sputnik/Unicode/Unicode_320/S7.6_A3.1-expected.txt
@@ -1,6 +1,6 @@
 S7.6_A3.1
 
-FAIL SputnikError: #0221 
+FAIL SputnikError: #00B7 
 
 TEST COMPLETE
 

--- a/LayoutTests/sputnik/Unicode/Unicode_320/S7.6_A5.2_T6-expected.txt
+++ b/LayoutTests/sputnik/Unicode/Unicode_320/S7.6_A5.2_T6-expected.txt
@@ -1,6 +1,6 @@
 S7.6_A5.2_T6
 
-FAIL SputnikError: #16EE 
+PASS 
 
 TEST COMPLETE
 

--- a/LayoutTests/sputnik/Unicode/Unicode_320/S7.6_A5.2_T9-expected.txt
+++ b/LayoutTests/sputnik/Unicode/Unicode_320/S7.6_A5.2_T9-expected.txt
@@ -1,6 +1,6 @@
 S7.6_A5.2_T9
 
-FAIL SputnikError: #1369 
+PASS 
 
 TEST COMPLETE
 

--- a/LayoutTests/sputnik/Unicode/Unicode_320/S7.6_A5.3_T1-expected.txt
+++ b/LayoutTests/sputnik/Unicode/Unicode_320/S7.6_A5.3_T1-expected.txt
@@ -1,6 +1,6 @@
 S7.6_A5.3_T1
 
-FAIL SputnikError: #0221 
+FAIL SputnikError: #00B7 
 
 TEST COMPLETE
 

--- a/LayoutTests/sputnik/Unicode/Unicode_320/S7.6_A5.3_T2-expected.txt
+++ b/LayoutTests/sputnik/Unicode/Unicode_320/S7.6_A5.3_T2-expected.txt
@@ -1,6 +1,6 @@
 S7.6_A5.3_T2
 
-FAIL SputnikError: #0221 
+FAIL SputnikError: #00B7 
 
 TEST COMPLETE
 

--- a/LayoutTests/sputnik/Unicode/Unicode_410/S7.6_A1.1_T6-expected.txt
+++ b/LayoutTests/sputnik/Unicode/Unicode_410/S7.6_A1.1_T6-expected.txt
@@ -1,6 +1,6 @@
 S7.6_A1.1_T6
 
-FAIL SputnikError: #16EE 
+PASS 
 
 TEST COMPLETE
 

--- a/LayoutTests/sputnik/Unicode/Unicode_410/S7.6_A3.1-expected.txt
+++ b/LayoutTests/sputnik/Unicode/Unicode_410/S7.6_A3.1-expected.txt
@@ -1,6 +1,6 @@
 S7.6_A3.1
 
-FAIL SputnikError: #0242-024F 
+FAIL SputnikError: #00B7 
 
 TEST COMPLETE
 

--- a/LayoutTests/sputnik/Unicode/Unicode_410/S7.6_A5.2_T6-expected.txt
+++ b/LayoutTests/sputnik/Unicode/Unicode_410/S7.6_A5.2_T6-expected.txt
@@ -1,6 +1,6 @@
 S7.6_A5.2_T6
 
-FAIL SputnikError: #16EE 
+PASS 
 
 TEST COMPLETE
 

--- a/LayoutTests/sputnik/Unicode/Unicode_410/S7.6_A5.3_T1-expected.txt
+++ b/LayoutTests/sputnik/Unicode/Unicode_410/S7.6_A5.3_T1-expected.txt
@@ -1,6 +1,6 @@
 S7.6_A5.3_T1
 
-FAIL SputnikError: #0242-024F 
+FAIL SputnikError: #00B7 
 
 TEST COMPLETE
 

--- a/LayoutTests/sputnik/Unicode/Unicode_410/S7.6_A5.3_T2-expected.txt
+++ b/LayoutTests/sputnik/Unicode/Unicode_410/S7.6_A5.3_T2-expected.txt
@@ -1,6 +1,6 @@
 S7.6_A5.3_T2
 
-FAIL SputnikError: #0242-024F 
+FAIL SputnikError: #00B7 
 
 TEST COMPLETE
 

--- a/LayoutTests/sputnik/Unicode/Unicode_500/S7.6_A1.1_T6-expected.txt
+++ b/LayoutTests/sputnik/Unicode/Unicode_500/S7.6_A1.1_T6-expected.txt
@@ -1,6 +1,6 @@
 S7.6_A1.1_T6
 
-FAIL SputnikError: #16EE 
+PASS 
 
 TEST COMPLETE
 

--- a/LayoutTests/sputnik/Unicode/Unicode_500/S7.6_A3.1-expected.txt
+++ b/LayoutTests/sputnik/Unicode/Unicode_500/S7.6_A3.1-expected.txt
@@ -1,6 +1,6 @@
 S7.6_A3.1
 
-FAIL SputnikError: #02EC 
+FAIL SputnikError: #00B7 
 
 TEST COMPLETE
 

--- a/LayoutTests/sputnik/Unicode/Unicode_500/S7.6_A5.2_T6-expected.txt
+++ b/LayoutTests/sputnik/Unicode/Unicode_500/S7.6_A5.2_T6-expected.txt
@@ -1,6 +1,6 @@
 S7.6_A5.2_T6
 
-FAIL SputnikError: #16EE 
+PASS 
 
 TEST COMPLETE
 

--- a/LayoutTests/sputnik/Unicode/Unicode_500/S7.6_A5.3_T1-expected.txt
+++ b/LayoutTests/sputnik/Unicode/Unicode_500/S7.6_A5.3_T1-expected.txt
@@ -1,6 +1,6 @@
 S7.6_A5.3_T1
 
-FAIL SputnikError: #02EC 
+FAIL SputnikError: #00B7 
 
 TEST COMPLETE
 

--- a/LayoutTests/sputnik/Unicode/Unicode_500/S7.6_A5.3_T2-expected.txt
+++ b/LayoutTests/sputnik/Unicode/Unicode_500/S7.6_A5.3_T2-expected.txt
@@ -1,6 +1,6 @@
 S7.6_A5.3_T2
 
-FAIL SputnikError: #02EC 
+FAIL SputnikError: #00B7 
 
 TEST COMPLETE
 

--- a/LayoutTests/sputnik/Unicode/Unicode_510/S7.6_A1.1_T4-expected.txt
+++ b/LayoutTests/sputnik/Unicode/Unicode_510/S7.6_A1.1_T4-expected.txt
@@ -1,6 +1,6 @@
 S7.6_A1.1_T4
 
-PASS 
+FAIL SputnikError: #2E2F 
 
 TEST COMPLETE
 

--- a/LayoutTests/sputnik/Unicode/Unicode_510/S7.6_A1.1_T6-expected.txt
+++ b/LayoutTests/sputnik/Unicode/Unicode_510/S7.6_A1.1_T6-expected.txt
@@ -1,6 +1,6 @@
 S7.6_A1.1_T6
 
-FAIL SputnikError: #16EE 
+PASS 
 
 TEST COMPLETE
 

--- a/LayoutTests/sputnik/Unicode/Unicode_510/S7.6_A5.2_T4-expected.txt
+++ b/LayoutTests/sputnik/Unicode/Unicode_510/S7.6_A5.2_T4-expected.txt
@@ -1,6 +1,6 @@
 S7.6_A5.2_T4
 
-PASS 
+FAIL SputnikError: #2E2F 
 
 TEST COMPLETE
 

--- a/LayoutTests/sputnik/Unicode/Unicode_510/S7.6_A5.2_T6-expected.txt
+++ b/LayoutTests/sputnik/Unicode/Unicode_510/S7.6_A5.2_T6-expected.txt
@@ -1,6 +1,6 @@
 S7.6_A5.2_T6
 
-FAIL SputnikError: #16EE 
+PASS 
 
 TEST COMPLETE
 

--- a/Source/JavaScriptCore/ChangeLog
+++ b/Source/JavaScriptCore/ChangeLog
@@ -1,3 +1,25 @@
+2018-12-30  Ross Kirsling  <ross.kirsling@sony.com>
+
+        [JSC] Identifier validity should be based on ID_Start / ID_Continue properties
+        https://bugs.webkit.org/show_bug.cgi?id=193050
+
+        Reviewed by Yusuke Suzuki.
+
+        From https://tc39.github.io/ecma262/#sec-names-and-keywords:
+            UnicodeIDStart::
+                any Unicode code point with the Unicode property "ID_Start"
+            UnicodeIDContinue::
+                any Unicode code point with the Unicode property "ID_Continue"
+
+        * parser/Lexer.cpp:
+        (JSC::Lexer<T>::Lexer):
+        (JSC::isNonLatin1IdentStart):
+        (JSC::isNonLatin1IdentPart):
+        (JSC::isIdentPart):
+        (JSC::Lexer<T>::lex):
+        Ensure identifier start / part is based on ID_Start / ID_Continue.
+        (Implies a special case for U+00B7, which is Latin-1 but Other_ID_Continue.)
+
 2021-04-23  Michael Saboff  <msaboff@apple.com>
 
         [YARR Interpreter] Improper backtrack of parentheses with non-zero based greedy quantifiers


### PR DESCRIPTION
Back port of f2cb7234703a0120c394c91850f8bcc41242252e to wpe-2.22

https://bugs.webkit.org/show_bug.cgi?id=193050

Reviewed by Yusuke Suzuki.

JSTests:

* test262.yaml:
* test262/expectations.yaml:
Mark 16 tests as passing.

Source/JavaScriptCore:

From https://tc39.github.io/ecma262/#sec-names-and-keywords:
    UnicodeIDStart::
        any Unicode code point with the Unicode property "ID_Start"
    UnicodeIDContinue::
        any Unicode code point with the Unicode property "ID_Continue"

* parser/Lexer.cpp:
(JSC::Lexer<T>::Lexer):
(JSC::isNonLatin1IdentStart):
(JSC::isNonLatin1IdentPart):
(JSC::isIdentPart):
(JSC::Lexer<T>::lex):
Ensure identifier start / part is based on ID_Start / ID_Continue.
(Implies a special case for U+00B7, which is Latin-1 but Other_ID_Continue.)

LayoutTests:

* sputnik/Unicode/Unicode_218/S7.6_A1.1_T2-expected.txt:
* sputnik/Unicode/Unicode_218/S7.6_A1.1_T6-expected.txt:
* sputnik/Unicode/Unicode_218/S7.6_A5.2_T2-expected.txt:
* sputnik/Unicode/Unicode_218/S7.6_A5.2_T6-expected.txt:
* sputnik/Unicode/Unicode_218/S7.6_A5.3_T1-expected.txt:
* sputnik/Unicode/Unicode_218/S7.6_A5.3_T2-expected.txt:
* sputnik/Unicode/Unicode_320/S7.6_A1.1_T6-expected.txt:
* sputnik/Unicode/Unicode_320/S7.6_A2.3-expected.txt:
* sputnik/Unicode/Unicode_320/S7.6_A3.1-expected.txt:
* sputnik/Unicode/Unicode_320/S7.6_A5.2_T6-expected.txt:
* sputnik/Unicode/Unicode_320/S7.6_A5.2_T9-expected.txt:
* sputnik/Unicode/Unicode_320/S7.6_A5.3_T1-expected.txt:
* sputnik/Unicode/Unicode_320/S7.6_A5.3_T2-expected.txt:
* sputnik/Unicode/Unicode_410/S7.6_A1.1_T6-expected.txt:
* sputnik/Unicode/Unicode_410/S7.6_A3.1-expected.txt:
* sputnik/Unicode/Unicode_410/S7.6_A5.2_T6-expected.txt:
* sputnik/Unicode/Unicode_410/S7.6_A5.3_T1-expected.txt:
* sputnik/Unicode/Unicode_410/S7.6_A5.3_T2-expected.txt:
* sputnik/Unicode/Unicode_500/S7.6_A1.1_T6-expected.txt:
* sputnik/Unicode/Unicode_500/S7.6_A3.1-expected.txt:
* sputnik/Unicode/Unicode_500/S7.6_A5.2_T6-expected.txt:
* sputnik/Unicode/Unicode_500/S7.6_A5.3_T1-expected.txt:
* sputnik/Unicode/Unicode_500/S7.6_A5.3_T2-expected.txt:
* sputnik/Unicode/Unicode_510/S7.6_A1.1_T4-expected.txt:
* sputnik/Unicode/Unicode_510/S7.6_A1.1_T6-expected.txt:
* sputnik/Unicode/Unicode_510/S7.6_A5.2_T4-expected.txt:
* sputnik/Unicode/Unicode_510/S7.6_A5.2_T6-expected.txt:
Update expectations for outdated tests.

git-svn-id: http://svn.webkit.org/repository/webkit/trunk@239559 268f45cc-cd09-0410-ab3c-d52691b4dbfc