### PR TITLE
[XIONE-6079] licenseRenewal fix for multiple MediaKeySession use case

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/eme/CDMOpenCDM.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/CDMOpenCDM.cpp
@@ -336,7 +336,7 @@ CDMInstanceOpenCDM::Session::Session(CDMInstanceOpenCDM* parent, OpenCDMSystem& 
 
     m_session.reset(session);
     m_id = String::fromUTF8(opencdm_session_id(m_session.get()));
-    GST_DEBUG("set m_CDMInstanceClient to %p for sessionid: %s\n", m_CDMInstanceClient, m_id.utf8().data());
+    GST_TRACE("set m_CDMInstanceClient to %p for sessionid: %s\n", m_CDMInstanceClient, m_id.utf8().data());
 
     Session::m_validSessions.add(this);
 }
@@ -367,7 +367,7 @@ void CDMInstanceOpenCDM::Session::challengeGeneratedCallback(RefPtr<SharedBuffer
             sessionChangedCallback(this, true, message.copyRef(), m_keyStatuses);
         m_sessionChangedCallbacks.clear();
     } else {
-        GST_DEBUG("calling issueMessage for m_CDMInstanceClient: %p, sessionid: %s\n", m_CDMInstanceClient, m_id.utf8().data());
+        GST_TRACE("calling issueMessage for m_CDMInstanceClient: %p, sessionid: %s\n", m_CDMInstanceClient, m_id.utf8().data());
         if (m_CDMInstanceClient && requestType.has_value())
             m_CDMInstanceClient->issueMessage(static_cast<CDMInstanceClient::MessageType>(requestType.value()), message.releaseNonNull());
     }
@@ -375,7 +375,6 @@ void CDMInstanceOpenCDM::Session::challengeGeneratedCallback(RefPtr<SharedBuffer
 
 void CDMInstanceOpenCDM::Session::keyUpdatedCallback(RefPtr<SharedBuffer>&& buffer)
 {
-    GST_DEBUG("keyUpdatedCallback for m_CDMInstanceClient %p, sessionid: %s\n", m_CDMInstanceClient, m_id.utf8().data());
     GST_MEMDUMP("Updated key", reinterpret_cast<const guint8*>(buffer->data()), buffer->size());
     auto index = m_keyStatuses.findMatching([&buffer](const std::pair<Ref<SharedBuffer>, KeyStatus>& item) {
         return memmem(buffer->data(), buffer->size(), item.first->data(), item.first->size());
@@ -390,7 +389,6 @@ void CDMInstanceOpenCDM::Session::keyUpdatedCallback(RefPtr<SharedBuffer>&& buff
 
 void CDMInstanceOpenCDM::Session::keysUpdateDoneCallback(RefPtr<SharedBuffer>&&)
 {
-    GST_DEBUG("keysUpdateDoneCallback m_CDMInstanceClient %p, sessionid: %s\n", m_CDMInstanceClient, m_id.utf8().data());
     bool appliesToApiCall = !m_sessionChangedCallbacks.isEmpty();
     if (!appliesToApiCall && m_parent && m_CDMInstanceClient) {
         m_CDMInstanceClient->updateKeyStatuses(copyAndMaybeReplaceValue(m_keyStatuses));

--- a/Source/WebCore/platform/graphics/gstreamer/eme/CDMOpenCDM.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/CDMOpenCDM.cpp
@@ -163,6 +163,7 @@ private:
     String m_keySystem;
     OpenCDMSystem& m_ocdmSystem;
     CDMInstanceOpenCDM* m_parent;
+    CDMInstanceClient*  m_CDMInstanceClient;
     // Accessed only on the main thread allowing to track if the Session is still valid and could be used.
     // Needed due to the fact the Session pointer is passed to the OCDM as the userData for notifications which are no
     // warranted to be called on the main thread the Session lives on.
@@ -330,8 +331,13 @@ CDMInstanceOpenCDM::Session::Session(CDMInstanceOpenCDM* parent, OpenCDMSystem& 
         GST_ERROR("Could not create session");
         return;
     }
+
+    m_CDMInstanceClient = m_parent->client();
+
     m_session.reset(session);
     m_id = String::fromUTF8(opencdm_session_id(m_session.get()));
+    GST_DEBUG("set m_CDMInstanceClient to %p for sessionid: %s\n", m_CDMInstanceClient, m_id.utf8().data());
+
     Session::m_validSessions.add(this);
 }
 
@@ -361,13 +367,15 @@ void CDMInstanceOpenCDM::Session::challengeGeneratedCallback(RefPtr<SharedBuffer
             sessionChangedCallback(this, true, message.copyRef(), m_keyStatuses);
         m_sessionChangedCallbacks.clear();
     } else {
-        if (m_parent->client() && requestType.has_value())
-            m_parent->client()->issueMessage(static_cast<CDMInstanceClient::MessageType>(requestType.value()), message.releaseNonNull());
+        GST_DEBUG("calling issueMessage for m_CDMInstanceClient: %p, sessionid: %s\n", m_CDMInstanceClient, m_id.utf8().data());
+        if (m_CDMInstanceClient && requestType.has_value())
+            m_CDMInstanceClient->issueMessage(static_cast<CDMInstanceClient::MessageType>(requestType.value()), message.releaseNonNull());
     }
 }
 
 void CDMInstanceOpenCDM::Session::keyUpdatedCallback(RefPtr<SharedBuffer>&& buffer)
 {
+    GST_DEBUG("keyUpdatedCallback for m_CDMInstanceClient %p, sessionid: %s\n", m_CDMInstanceClient, m_id.utf8().data());
     GST_MEMDUMP("Updated key", reinterpret_cast<const guint8*>(buffer->data()), buffer->size());
     auto index = m_keyStatuses.findMatching([&buffer](const std::pair<Ref<SharedBuffer>, KeyStatus>& item) {
         return memmem(buffer->data(), buffer->size(), item.first->data(), item.first->size());
@@ -382,9 +390,10 @@ void CDMInstanceOpenCDM::Session::keyUpdatedCallback(RefPtr<SharedBuffer>&& buff
 
 void CDMInstanceOpenCDM::Session::keysUpdateDoneCallback(RefPtr<SharedBuffer>&&)
 {
+    GST_DEBUG("keysUpdateDoneCallback m_CDMInstanceClient %p, sessionid: %s\n", m_CDMInstanceClient, m_id.utf8().data());
     bool appliesToApiCall = !m_sessionChangedCallbacks.isEmpty();
-    if (!appliesToApiCall && m_parent && m_parent->client()) {
-        m_parent->client()->updateKeyStatuses(copyAndMaybeReplaceValue(m_keyStatuses));
+    if (!appliesToApiCall && m_parent && m_CDMInstanceClient) {
+        m_CDMInstanceClient->updateKeyStatuses(copyAndMaybeReplaceValue(m_keyStatuses));
         return;
     }
 


### PR DESCRIPTION
All CDM sessions use the same CDMInstanceClient / MediaKeySession object saved in CDMInstanceOpenCDM
which is updated everytime a new MediaKeySession is created. So only the most recent MediaKeySession
object is used.This breaks licenseRenewal requests when there are multiple MediaKeySessions are
present.

Signed-off-by: Gurdal Oruklu <gurdal_oruklu@comcast.com>