### PR TITLE
[MSE][GStreamer] Add KEY_UNIT seek flag

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -416,7 +416,7 @@ GstSeekFlags MediaPlayerPrivateGStreamer::hardwareDependantSeekFlags()
     // in a key frame.
     return static_cast<GstSeekFlags>(GST_SEEK_FLAG_KEY_UNIT | GST_SEEK_FLAG_SNAP_NEAREST);
 #else
-    return GST_SEEK_FLAG_ACCURATE;
+    return static_cast<GstSeekFlags>(GST_SEEK_FLAG_ACCURATE | GST_SEEK_FLAG_KEY_UNIT);
 #endif
 }
 


### PR DESCRIPTION
An issue has been discovered on Nexus based platforms, where after a seek there was a temporary freeze of one of the streams (audio/video).

If a `GST_SEEK_FLAG_ACCURATE` is used for seeking, the start time of a segment is defined to be exactly the PTS passed to a seek event. It does not specify, which keyframe should be used as a start point for pushing data. Adding `GST_SEEK_FLAG_KEY_UNIT` makes sure that after a seek, data is always pushed from a nearest keyframe.