### PR TITLE
CoordinatedGraphicsScene.cpp : Add out of bounds check

### DIFF
--- a/Source/WebKit/Shared/CoordinatedGraphics/CoordinatedGraphicsScene.cpp
+++ b/Source/WebKit/Shared/CoordinatedGraphics/CoordinatedGraphicsScene.cpp
@@ -428,6 +428,9 @@ void CoordinatedGraphicsScene::assignImageBackingToLayer(TextureMapperLayer* lay
 
     auto it = m_imageBackings.find(imageID);
     ASSERT(it != m_imageBackings.end());
+    if (it == m_imageBackings.end()) {
+        return;
+    }
     layer->setContentsLayer(it->value.get());
 }
 


### PR DESCRIPTION
Launching a particular deeplink URL for the peacock app, the iterator does not find the imageID. The unchecked out of bounds iterator leads to a segmentation fault.