### PR TITLE
[ONEM-22550] DynamicsCompressorNode.reduction type should be float

### DIFF
--- a/Source/WebCore/Modules/webaudio/DynamicsCompressorNode.cpp
+++ b/Source/WebCore/Modules/webaudio/DynamicsCompressorNode.cpp
@@ -49,7 +49,7 @@ DynamicsCompressorNode::DynamicsCompressorNode(AudioContext& context, float samp
     m_threshold = AudioParam::create(context, "threshold", -24, -100, 0);
     m_knee = AudioParam::create(context, "knee", 30, 0, 40);
     m_ratio = AudioParam::create(context, "ratio", 12, 1, 20);
-    m_reduction = AudioParam::create(context, "reduction", 0, -20, 0);
+    m_reduction = 0;
     m_attack = AudioParam::create(context, "attack", 0.003, 0, 1);
     m_release = AudioParam::create(context, "release", 0.250, 0, 1);
 
@@ -81,7 +81,7 @@ void DynamicsCompressorNode::process(size_t framesToProcess)
     m_dynamicsCompressor->process(input(0)->bus(), outputBus, framesToProcess);
 
     float reduction = m_dynamicsCompressor->parameterValue(DynamicsCompressor::ParamReduction);
-    m_reduction->setValue(reduction);
+    m_reduction = reduction;
 }
 
 void DynamicsCompressorNode::reset()

--- a/Source/WebCore/Modules/webaudio/DynamicsCompressorNode.h
+++ b/Source/WebCore/Modules/webaudio/DynamicsCompressorNode.h
@@ -55,7 +55,7 @@ public:
     AudioParam* release() { return m_release.get(); }
 
     // Amount by which the compressor is currently compressing the signal in decibels.
-    AudioParam* reduction() { return m_reduction.get(); }
+    float reduction() { return m_reduction; }
 
 private:
     double tailTime() const override;
@@ -67,7 +67,7 @@ private:
     RefPtr<AudioParam> m_threshold;
     RefPtr<AudioParam> m_knee;
     RefPtr<AudioParam> m_ratio;
-    RefPtr<AudioParam> m_reduction;
+    double m_reduction;
     RefPtr<AudioParam> m_attack;
     RefPtr<AudioParam> m_release;
 };

--- a/Source/WebCore/Modules/webaudio/DynamicsCompressorNode.idl
+++ b/Source/WebCore/Modules/webaudio/DynamicsCompressorNode.idl
@@ -29,7 +29,7 @@
     readonly attribute AudioParam threshold; // in Decibels
     readonly attribute AudioParam knee; // in Decibels
     readonly attribute AudioParam ratio; // unit-less
-    readonly attribute AudioParam reduction; // in Decibels
+    readonly attribute unrestricted float reduction; // in Decibels
     readonly attribute AudioParam attack; // in Seconds
     readonly attribute AudioParam release; // in Seconds
 };


### PR DESCRIPTION
Interface mismatch with https://www.w3.org/TR/webaudio/#dynamicscompressornode

Similar change is already present in the upstream:
https://bugs.webkit.org/show_bug.cgi?id=215195