### PR TITLE
AudioNode.connect should return passed destination node

### DIFF
--- a/Source/WebCore/Modules/webaudio/AudioBasicInspectorNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioBasicInspectorNode.cpp
@@ -49,7 +49,7 @@ void AudioBasicInspectorNode::pullInputs(size_t framesToProcess)
     input(0)->pull(output(0)->bus(), framesToProcess);
 }
 
-ExceptionOr<void> AudioBasicInspectorNode::connect(AudioNode& destination, unsigned outputIndex, unsigned inputIndex)
+ExceptionOr<AudioNode&> AudioBasicInspectorNode::connect(AudioNode& destination, unsigned outputIndex, unsigned inputIndex)
 {
     ASSERT(isMainThread());
 

--- a/Source/WebCore/Modules/webaudio/AudioBasicInspectorNode.h
+++ b/Source/WebCore/Modules/webaudio/AudioBasicInspectorNode.h
@@ -37,7 +37,7 @@ public:
 
 private:
     void pullInputs(size_t framesToProcess) override;
-    ExceptionOr<void> connect(AudioNode&, unsigned outputIndex, unsigned inputIndex) override;
+    ExceptionOr<AudioNode&> connect(AudioNode&, unsigned outputIndex, unsigned inputIndex) override;
     ExceptionOr<void> disconnect(unsigned outputIndex) override;
     void checkNumberOfChannelsForInput(AudioNodeInput*) override;
 

--- a/Source/WebCore/Modules/webaudio/AudioNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioNode.cpp
@@ -122,7 +122,7 @@ AudioNodeOutput* AudioNode::output(unsigned i)
     return nullptr;
 }
 
-ExceptionOr<void> AudioNode::connect(AudioNode& destination, unsigned outputIndex, unsigned inputIndex)
+ExceptionOr<AudioNode&> AudioNode::connect(AudioNode& destination, unsigned outputIndex, unsigned inputIndex)
 {
     ASSERT(isMainThread()); 
     AudioContext::AutoLocker locker(context());
@@ -144,7 +144,7 @@ ExceptionOr<void> AudioNode::connect(AudioNode& destination, unsigned outputInde
     // Let context know that a connection has been made.
     context().incrementConnectionCount();
 
-    return { };
+    return destination;
 }
 
 ExceptionOr<void> AudioNode::connect(AudioParam& param, unsigned outputIndex)

--- a/Source/WebCore/Modules/webaudio/AudioNode.h
+++ b/Source/WebCore/Modules/webaudio/AudioNode.h
@@ -123,7 +123,7 @@ public:
     AudioNodeOutput* output(unsigned);
 
     // Called from main thread by corresponding JavaScript methods.
-    virtual ExceptionOr<void> connect(AudioNode&, unsigned outputIndex, unsigned inputIndex);
+    virtual ExceptionOr<AudioNode&> connect(AudioNode&, unsigned outputIndex, unsigned inputIndex);
     ExceptionOr<void> connect(AudioParam&, unsigned outputIndex);
     virtual ExceptionOr<void> disconnect(unsigned outputIndex);
 

--- a/Source/WebCore/Modules/webaudio/AudioNode.idl
+++ b/Source/WebCore/Modules/webaudio/AudioNode.idl
@@ -34,7 +34,7 @@
     attribute DOMString channelCountMode;
     attribute DOMString channelInterpretation;
 
-    [MayThrowException] void connect(AudioNode destination, optional unsigned long output = 0, optional unsigned long input = 0);
+    [MayThrowException] AudioNode connect(AudioNode destination, optional unsigned long output = 0, optional unsigned long input = 0);
     [MayThrowException] void connect(AudioParam destination, optional unsigned long output = 0);
     [MayThrowException] void disconnect(optional unsigned long output = 0);
 };


### PR DESCRIPTION
Based on:
https://bugs.webkit.org/show_bug.cgi?id=188834