### PR TITLE
Add ability to finish non-MSE seek on state change

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -169,6 +169,7 @@ private:
     void purgeInvalidTextTracks(Vector<String> validTrackIds);
 #endif
     virtual bool doSeek(const MediaTime& position, float rate, GstSeekFlags seekType);
+    virtual void maybeFinishSeek();
     virtual void updatePlaybackRate();
 
     String engineDescription() const override { return "GStreamer"; }

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
@@ -117,7 +117,7 @@ private:
 
     bool doSeek(const MediaTime&, float, GstSeekFlags) override;
     bool doSeek();
-    void maybeFinishSeek();
+    void maybeFinishSeek() override;
     void updatePlaybackRate() override;
     void asyncStateChangeDone() override;
 


### PR DESCRIPTION
When audio sink is not working in async mode, this demo: https://scony.github.io/stb-lab/non-mse-audio-loop/ plays the asset twice on `wpe-2.22`. While the first run is normal, during a second one the pipeline changes its state to `PLAYING` but the media player is not aware of that - it still waits for seek to complete - although `async-done` never comes.

This PR introduces a solution to that - the `maybeFinishSeek` apporach which is almost the same as in case of MSE. This way the `seek` will finish properly regardless of what mode the sink is using.

Please note that I'm intentionally not trying to unify the code between MSE and non-MSE code to simplify the patch.