### PR TITLE
WebAudio - Remove scaling of the FFT

### DIFF
--- a/Source/WebCore/Modules/webaudio/RealtimeAnalyser.cpp
+++ b/Source/WebCore/Modules/webaudio/RealtimeAnalyser.cpp
@@ -182,7 +182,7 @@ void RealtimeAnalyser::doFFTAnalysis()
     imagP[0] = 0;
     
     // Normalize so than an input sine wave at 0dBfs registers as 0dBfs (undo FFT scaling factor).
-    const double magnitudeScale = 1.0 / fftSize;
+    const double magnitudeScale = 0.5 / fftSize;
 
     // A value of 0 does no averaging with the previous result.  Larger values produce slower, but smoother changes.
     double k = m_smoothingTimeConstant;


### PR DESCRIPTION
Issue affects BBC ACT-1170 test.
Value calculated by WPE's FFT algorithm gives -8.41dB and test case
expects -14.43dB. The source of this issue comes from the fix delivered
to Chromium community BUG=342530 where strange scaling by 2 of forward
FFT has been removed.
https://codereview.chromium.org/132313018