### PR TITLE
Provision to disable console logging completely

### DIFF
--- a/Source/JavaScriptCore/runtime/ConsoleObject.cpp
+++ b/Source/JavaScriptCore/runtime/ConsoleObject.cpp
@@ -31,6 +31,7 @@
 #include "JSCInlines.h"
 #include "ScriptArguments.h"
 #include "ScriptCallStackFactory.h"
+#include "Options.h"
 
 namespace JSC {
 
@@ -130,6 +131,9 @@ static EncodedJSValue consoleLogWithLevel(JSGlobalObject* globalObject, CallFram
 {
     ConsoleClient* client = globalObject->consoleClient();
     if (!client)
+        return JSValue::encode(jsUndefined());
+
+    if (Options::disableConsoleLog())
         return JSValue::encode(jsUndefined());
 
     client->logWithLevel(globalObject, Inspector::createScriptArguments(globalObject, callFrame, 0), level);

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -493,6 +493,7 @@ constexpr bool enableWebAssemblyStreamingApi = false;
     v(Bool, forceOSRExitToLLInt, false, Normal, "If true, we always exit to the LLInt. If false, we exit to whatever is most convenient.") \
     v(Unsigned, getByValICMaxNumberOfIdentifiers, 4, Normal, "Number of identifiers we see in the LLInt that could cause us to bail on generating an IC for get_by_val.") \
     v(Bool, useClassFields, false, Normal, "If true, the parser will understand data fields inside classes.") \
+    v(Bool, disableConsoleLog, false, Normal, "Disable printing of JS console logs.") \
 
 enum OptionEquivalence {
     SameOption,


### PR DESCRIPTION
This option was helpful to determine the performance of apps w/ & w/o console logs