### PR TITLE
Extend list of keys supported by keyCodeForHardwareKeyCode

### DIFF
--- a/Source/WebCore/platform/wpe/PlatformKeyboardEventWPE.cpp
+++ b/Source/WebCore/platform/wpe/PlatformKeyboardEventWPE.cpp
@@ -660,6 +660,8 @@ String PlatformKeyboardEvent::keyCodeForHardwareKeyCode(unsigned keyCode)
         return "AudioVolumeDown"_s;
     case 0x007B:
         return "AudioVolumeUp"_s;
+    case 0x007C:
+        return "PowerOff"_s;
     case 0x007D:
         return "NumpadEqual"_s;
     case 0x007F:
@@ -700,6 +702,8 @@ String PlatformKeyboardEvent::keyCodeForHardwareKeyCode(unsigned keyCode)
         return "Cut"_s;
     case 0x0092:
         return "Help"_s;
+    case 0x0093:
+        return "ContextMenu"_s;
     case 0x0094:
         return "LaunchApp2"_s;
     case 0x0097:
@@ -724,6 +728,10 @@ String PlatformKeyboardEvent::keyCodeForHardwareKeyCode(unsigned keyCode)
         return "MediaTrackPrevious"_s;
     case 0x00AE:
         return "MediaStop"_s;
+    case 0x00AF:
+        return "MediaRecord"_s;
+    case 0x00B0:
+        return "MediaRewind"_s;
     case 0x00B3:
         return "LaunchMediaPlayer"_s;
     case 0x00B4:
@@ -754,8 +762,32 @@ String PlatformKeyboardEvent::keyCodeForHardwareKeyCode(unsigned keyCode)
         return "F23"_s;
     case 0x00CA:
         return "F24"_s;
+    case 0x00D8:
+        return "MediaFastForward"_s;
     case 0x00E1:
         return "BrowserSearch"_s;
+    case 0x016E:
+        return "Info"_s;
+    case 0x0175:
+        return "Guide"_s;
+    case 0x0176:
+        return "DVR"_s;
+    case 0x17A:
+        return "Subtitle"_s;
+    case 0x0181:
+        return "TV"_s;
+    case 0x0196:
+        return "ColorF0Red"_s;
+    case 0x0197:
+        return "ColorF1Green"_s;
+    case 0x0198:
+        return "ColorF2Yellow"_s;
+    case 0x0199:
+        return "ColorF3Blue"_s;
+    case 0x024E:
+        return "MicrophoneToggle"_s;
+    case 0x027F:
+        return "Teletext"_s;
     default:
         break;
     }


### PR DESCRIPTION
Some key events are not handled by the
PlatformKeyboardEvent::keyCodeForHardwareKeyCode function,
because of that JavaScript KeyboardEvents are emitted with
keyCode=Unidentified.

This commit extends list of keys with proper keyCode attribute value
with keys commonly used on set-top boxes.