### PR TITLE
Fix for animations flashing back to initial state after starting

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/TextureMapperAnimation.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperAnimation.h
@@ -46,7 +46,6 @@ public:
     void apply(ApplicationResult&, MonotonicTime);
     void pause(Seconds);
     void resume();
-    bool isActive() const;
 
     const String& name() const { return m_name; }
     const KeyframeValueList& keyframes() const { return m_keyframes; }
@@ -89,7 +88,6 @@ public:
 
     bool hasRunningAnimations() const;
     bool hasActiveAnimationsOfType(AnimatedPropertyID type) const;
-    TextureMapperAnimations getActiveAnimations() const;
 
 private:
     Vector<TextureMapperAnimation> m_animations;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
@@ -757,7 +757,7 @@ void CoordinatedGraphicsLayer::syncAnimations()
         return;
 
     m_shouldSyncAnimations = false;
-    m_layerState.animations = m_animations.getActiveAnimations();
+    m_layerState.animations = m_animations;
     m_layerState.animationsChanged = true;
     m_nicosia.delta.animationsChanged = true;
 }
@@ -853,7 +853,7 @@ void CoordinatedGraphicsLayer::flushCompositingStateForThisLayerOnly()
                 if (localDelta.filtersChanged)
                     state.filters = filters();
                 if (localDelta.animationsChanged)
-                    state.animations = m_animations.getActiveAnimations();
+                    state.animations = m_animations;
 
                 if (localDelta.childrenChanged) {
                     state.children = WTF::map(children(),


### PR DESCRIPTION
Fix for animations flashing back to initial state after they have already started running, backported for 2.22

See https://bugs.webkit.org/show_bug.cgi?id=206280
See https://trac.webkit.org/changeset/254680/webkit