### PR TITLE
Fix resuming of ThreadedCompositor run loop.

### DIFF
--- a/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.cpp
+++ b/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.cpp
@@ -155,6 +155,7 @@ void ThreadedCompositor::resume()
 
     m_compositingRunLoop->performTaskSync([this, protectedThis = makeRef(*this)] {
         m_scene->setActive(true);
+        m_suspendToTransparentState = SuspendToTransparentState::None;
     });
     m_compositingRunLoop->resume();
 }


### PR DESCRIPTION
Resume request could come while compositor suspension is still in progress. resulting in an inconsistent state of browser: ThreadedCompositor is suspended, while the browser is not.