### PR TITLE
Restore visibility change behavior

### DIFF
--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -6628,7 +6628,7 @@ void WebGLRenderingContextBase::activityStateDidChange(OptionSet<ActivityState::
 
     if (m_nonCompositedWebGLMode) {
         if (((changed & ActivityState::IsSuspended) && (newActivityState & ActivityState::IsSuspended)) ||
-            ((changed & ActivityState::IsInWindow) && !(newActivityState & ActivityState::IsInWindow))) {
+            ((changed & ActivityState::IsVisible) && !(newActivityState & ActivityState::IsVisible))) {
             if (m_scissorEnabled)
                 m_context->disable(GraphicsContextGL::SCISSOR_TEST);
             m_context->clearColor(0, 0, 0, 0);

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -4584,6 +4584,7 @@ void webkit_web_view_suspend(WebKitWebView *webView)
 
     auto viewStateFlags = webView->priv->view->viewState();
     viewStateFlags.add(WebCore::ActivityState::IsSuspended);
+    viewStateFlags.remove(WebCore::ActivityState::IsInWindow);
     webView->priv->view->setViewState(viewStateFlags);
 }
 
@@ -4593,6 +4594,7 @@ void webkit_web_view_resume(WebKitWebView *webView)
 
     auto viewStateFlags = webView->priv->view->viewState();
     viewStateFlags.remove(WebCore::ActivityState::IsSuspended);
+    viewStateFlags.add(WebCore::ActivityState::IsInWindow);
     webView->priv->view->setViewState(viewStateFlags);
 }
 
@@ -4608,7 +4610,7 @@ void webkit_web_view_hide(WebKitWebView *webView)
     g_return_if_fail(WEBKIT_IS_WEB_VIEW(webView));
 
     auto viewStateFlags = webView->priv->view->viewState();
-    viewStateFlags.remove(WebCore::ActivityState::IsInWindow);
+    viewStateFlags.remove(WebCore::ActivityState::IsVisible);
     webView->priv->view->setViewState(viewStateFlags);
 }
 
@@ -4617,7 +4619,7 @@ void webkit_web_view_show(WebKitWebView *webView)
     g_return_if_fail(WEBKIT_IS_WEB_VIEW(webView));
 
     auto viewStateFlags = webView->priv->view->viewState();
-    viewStateFlags.add(WebCore::ActivityState::IsInWindow);
+    viewStateFlags.add(WebCore::ActivityState::IsVisible);
     webView->priv->view->setViewState(viewStateFlags);
 }
 

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
@@ -385,26 +385,20 @@ RefPtr<DisplayRefreshMonitor> DrawingAreaCoordinatedGraphics::createDisplayRefre
 
 void DrawingAreaCoordinatedGraphics::activityStateDidChange(OptionSet<ActivityState::Flag> changed, ActivityStateChangeID, const Vector<CallbackID>&)
 {
-    if (changed & ActivityState::IsInWindow && !m_isViewSuspended) {
-        if (m_webPage.corePage()->isInWindow()) {
-            m_webPage.corePage()->resumeActiveDOMObjectsAndAnimations();
+    if (changed & ActivityState::IsVisible) {
+        if (m_webPage.isVisible())
             resumePainting();
-        } else {
+        else
             suspendPainting();
-            m_webPage.corePage()->suspendActiveDOMObjectsAndAnimations();
-        }
     }
 
     if (changed & ActivityState::IsSuspended) {
         if (m_isViewSuspended) {
-            // DOM objects will be disabled if the page is hidden. We need to activate them so the call to resumeAllMediaPlayback works.
             m_webPage.corePage()->resumeActiveDOMObjectsAndAnimations();
             m_webPage.corePage()->resumeAllMediaPlayback();
-            // If the page is visible, resume rendering, otherwise disable DOM objects so the videoSink rectangle is hidden.
-            if (m_webPage.corePage()->isInWindow())
+            // If the page is visible, resume rendering.
+            if (m_isPaintingSuspended && m_webPage.isVisible())
                 resumePainting();
-            else
-                m_webPage.corePage()->suspendActiveDOMObjectsAndAnimations();
             m_isViewSuspended = false;
         } else {
             suspendPainting();


### PR DESCRIPTION
The change of IsInWindow activity state could suspend active DOM
objects and so make hide/show API behave similar to
suspend/resume. The web application is not notified about the visibility
state in this case, which is a regression compared to wpe-2.22 behavior.

This change tries to restore the previous behavior. The IsVisible activity
state is used to notify about visibility changes and also suspend
painting.