### PR TITLE
[MSE][GStreamer] allow positive infinity duration

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp
@@ -92,7 +92,7 @@ void MediaSourcePrivateGStreamer::durationChanged()
 
     MediaTime duration = m_mediaSource->duration();
     GST_TRACE("duration: %f", duration.toFloat());
-    if (!duration.isValid() || duration.isPositiveInfinite() || duration.isNegativeInfinite())
+    if (!duration.isValid() || duration.isNegativeInfinite())
         return;
 
     m_playerPrivate.durationChanged();


### PR DESCRIPTION
This is a fix for ' 22. StartPlayAtTimeGt0H264+AAC' https://ytlr-cert.appspot.com/2021/main.html?tests=22, cherry-picked from https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/69a9afe2272aa9814e6227b3833b22338e0ec2ae

MSE duration remained 0 after appending a/v data. This caped seek time to '0', causing test failure due to timeout. 