### PR TITLE
[MSE][GStreamer] fix video freeze after initial seek

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
@@ -768,9 +768,6 @@ void webKitMediaSrcPrepareInitialSeek(WebKitMediaSrc* source, double rate, const
     for (Stream* stream : source->priv->streams)
         stream->appsrcNeedDataFlag = false;
 
-    // The pending action will be performed in enabledAppsrcSeekData().
-    source->priv->appsrcSeekDataNextAction = MediaSourceSeekToTime;
-
     GUniquePtr<GstSegment> segment(gst_segment_new());
     segment->format = GST_FORMAT_TIME;
     gst_segment_do_seek(segment.get(), rate, GST_FORMAT_TIME,


### PR DESCRIPTION
webKitMediaSrcPrepareInitialSeek can be called after appsrc already
invoked initial 'seek-data' and 'need-data' callbacks. this leaves
webkitmediasrc in inconsitent state, with appsrcSeekDataCount = 0 and
appsrcSeekDataNextAction = MediaSourceSeekToTime.

Because appsrcSeekDataNextAction is set, it blocks ReadyForMoreSamples
notifications. This leads to starvation of video source and
video freeze (after the first 'enough-data').

This fix removes setup of appsrcSeekDataNextAction and
appsrcNeedDataFlag. These are not really required in this case, beacuse:
 - initial seek doesn't block source buffers
 - MediaPlayerPrivateGStreamerMSE calls notifySeekNeedsDataForTime()
 immediately webKitMediaSrcPrepareInitialSeek()