### PR TITLE
Backport MSE pipeline restart capability

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
@@ -136,6 +136,7 @@ private:
     bool m_gstSeekCompleted = true;
     RefPtr<MediaSourcePrivateClient> m_mediaSource;
     RefPtr<MediaSourceClientGStreamerMSE> m_mediaSourceClient;
+    RefPtr<MediaSourceGStreamer> m_mediaSourcePrivate;
     MediaTime m_mediaTimeDuration;
     bool m_mseSeekCompleted = true;
     RefPtr<PlaybackPipeline> m_playbackPipeline;

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourceGStreamer.cpp
@@ -50,9 +50,11 @@
 
 namespace WebCore {
 
-void MediaSourceGStreamer::open(MediaSourcePrivateClient& mediaSource, MediaPlayerPrivateGStreamerMSE& playerPrivate)
+Ref<MediaSourceGStreamer> MediaSourceGStreamer::open(MediaSourcePrivateClient& mediaSource, MediaPlayerPrivateGStreamerMSE& playerPrivate)
 {
-    mediaSource.setPrivateAndOpen(adoptRef(*new MediaSourceGStreamer(mediaSource, playerPrivate)));
+    auto mediaSourcePrivate = adoptRef(*new MediaSourceGStreamer(mediaSource, playerPrivate));
+    mediaSource.setPrivateAndOpen(mediaSourcePrivate.copyRef());
+    return mediaSourcePrivate;
 }
 
 MediaSourceGStreamer::MediaSourceGStreamer(MediaSourcePrivateClient& mediaSource, MediaPlayerPrivateGStreamerMSE& playerPrivate)

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourceGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourceGStreamer.h
@@ -52,7 +52,7 @@ class PlatformTimeRanges;
 // FIXME: Should this be called MediaSourcePrivateGStreamer?
 class MediaSourceGStreamer final : public MediaSourcePrivate {
 public:
-    static void open(MediaSourcePrivateClient&, MediaPlayerPrivateGStreamerMSE&);
+    static Ref<MediaSourceGStreamer> open(MediaSourcePrivateClient&, MediaPlayerPrivateGStreamerMSE&);
     virtual ~MediaSourceGStreamer();
 
     MediaSourceClientGStreamerMSE& client() { return m_client.get(); }

--- a/Source/WebCore/platform/graphics/gstreamer/mse/PlaybackPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/PlaybackPipeline.cpp
@@ -114,7 +114,10 @@ MediaSourcePrivate::AddStatus PlaybackPipeline::addSourceBuffer(RefPtr<SourceBuf
 
     Stream* stream = new Stream{ };
     stream->parent = m_webKitMediaSrc.get();
-    stream->appsrc = gst_element_factory_make("appsrc", nullptr);
+
+    // Ensure ownership is not transfered to the bin. The appsrc element is managed by its parent Stream.
+    stream->appsrc = GST_ELEMENT_CAST(gst_object_ref_sink(gst_element_factory_make("appsrc", nullptr)));
+
     stream->appsrcNeedDataFlag = false;
     stream->sourceBuffer = sourceBufferPrivate.get();
 
@@ -138,7 +141,7 @@ MediaSourcePrivate::AddStatus PlaybackPipeline::addSourceBuffer(RefPtr<SourceBuf
     priv->streams.append(stream);
     GST_OBJECT_UNLOCK(m_webKitMediaSrc.get());
 
-    gst_bin_add(GST_BIN(m_webKitMediaSrc.get()), stream->appsrc);
+    gst_bin_add(GST_BIN_CAST(m_webKitMediaSrc.get()), stream->appsrc);
     gst_element_sync_state_with_parent(stream->appsrc);
 
     return MediaSourcePrivate::Ok;

--- a/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
@@ -143,6 +143,73 @@ static void enabledAppsrcNeedData(GstAppSrc* appsrc, guint, gpointer userData)
     }
 }
 
+void webKitMediaSrcRestoreTracks(WebKitMediaSrc* oldSource, WebKitMediaSrc* newSource)
+{
+    newSource->priv->streams = WTFMove(oldSource->priv->streams);
+    for (auto* stream : newSource->priv->streams) {
+        stream->parent = newSource;
+
+        auto oldSourcePad = adoptGRef(gst_element_get_static_pad(stream->appsrc, "src"));
+        unsigned padId = static_cast<unsigned>(GPOINTER_TO_INT(g_object_get_data(G_OBJECT(oldSourcePad.get()), "padId")));
+
+        gst_object_unref(stream->appsrc);
+
+        // Ensure ownership is not transfered to the bin. The appsrc element is managed by its parent Stream.
+        stream->appsrc = GST_ELEMENT_CAST(gst_object_ref_sink(gst_element_factory_make("appsrc", nullptr)));
+        stream->appsrcNeedDataFlag = true;
+
+        gst_app_src_set_callbacks(GST_APP_SRC(stream->appsrc), &enabledAppsrcCallbacks, stream->parent, nullptr);
+        gst_app_src_set_emit_signals(GST_APP_SRC(stream->appsrc), FALSE);
+        gst_app_src_set_stream_type(GST_APP_SRC(stream->appsrc), GST_APP_STREAM_TYPE_SEEKABLE);
+
+        gst_app_src_set_max_bytes(GST_APP_SRC(stream->appsrc), 2 * WTF::MB);
+        g_object_set(G_OBJECT(stream->appsrc), "block", FALSE, "min-percent", 20, "format", GST_FORMAT_TIME, nullptr);
+
+        gst_bin_add(GST_BIN_CAST(newSource), stream->appsrc);
+
+        auto sourcePad = adoptGRef(gst_element_get_static_pad(stream->appsrc, "src"));
+        g_object_set_data(G_OBJECT(sourcePad.get()), "padId", GINT_TO_POINTER(padId));
+    }
+
+    newSource->priv->numberOfAudioStreams = oldSource->priv->numberOfAudioStreams;
+    newSource->priv->numberOfTextStreams = oldSource->priv->numberOfTextStreams;
+    newSource->priv->numberOfVideoStreams = oldSource->priv->numberOfVideoStreams;
+    newSource->priv->numberOfPads = oldSource->priv->numberOfPads;
+    newSource->priv->allTracksConfigured = oldSource->priv->allTracksConfigured;
+}
+
+void webKitMediaSrcSignalTracks(WebKitMediaSrc* source)
+{
+    for (auto* stream : source->priv->streams) {
+        auto sourcePad = adoptGRef(gst_element_get_static_pad(stream->appsrc, "src"));
+        webKitMediaSrcLinkStreamToSrcPad(sourcePad.get(), stream);
+
+        gst_element_sync_state_with_parent(stream->appsrc);
+
+        int signal = -1;
+        switch (stream->type) {
+        case WebCore::MediaSourceStreamTypeGStreamer::Video:
+            signal = SIGNAL_VIDEO_CHANGED;
+            break;
+        case WebCore::MediaSourceStreamTypeGStreamer::Audio:
+            signal = SIGNAL_AUDIO_CHANGED;
+            break;
+        case WebCore::MediaSourceStreamTypeGStreamer::Text:
+            signal = SIGNAL_TEXT_CHANGED;
+            break;
+        default:
+            break;
+        }
+        if (signal != -1)
+            g_signal_emit(G_OBJECT(stream->parent), webKitMediaSrcSignals[signal], 0, nullptr);
+    }
+
+    if (source->priv->streams.size()) {
+        gst_element_no_more_pads(GST_ELEMENT_CAST(source));
+        webKitMediaSrcDoAsyncDone(source);
+    }
+}
+
 static void enabledAppsrcEnoughData(GstAppSrc *appsrc, gpointer userData)
 {
     // No need to lock on webKitMediaSrc, we're on the main thread and nobody is going to remove the stream in the meantime.
@@ -271,6 +338,7 @@ void webKitMediaSrcFinalize(GObject* object)
     WebKitMediaSrc* source = WEBKIT_MEDIA_SRC(object);
     WebKitMediaSrcPrivate* priv = source->priv;
 
+    GST_DEBUG_OBJECT(source, "Finalizing %p", source);
     Vector<Stream*> oldStreams;
     source->priv->streams.swap(oldStreams);
 
@@ -509,10 +577,13 @@ void webKitMediaSrcLinkSourcePad(GstPad* sourcePad, GstCaps* caps, Stream* strea
 
 void webKitMediaSrcFreeStream(WebKitMediaSrc* source, Stream* stream)
 {
+    GST_DEBUG("Releasing stream: %p", stream);
+
     if (GST_IS_APP_SRC(stream->appsrc)) {
         // Don't trigger callbacks from this appsrc to avoid using the stream anymore.
         gst_app_src_set_callbacks(GST_APP_SRC(stream->appsrc), &disabledAppsrcCallbacks, nullptr, nullptr);
         gst_app_src_end_of_stream(GST_APP_SRC(stream->appsrc));
+        gst_object_unref(stream->appsrc);
     }
 
     GST_OBJECT_LOCK(source);
@@ -566,7 +637,6 @@ void webKitMediaSrcFreeStream(WebKitMediaSrc* source, Stream* stream)
         source->priv->streamCondition.notifyOne();
     }
 
-    GST_DEBUG("Releasing stream: %p", stream);
     delete stream;
 }
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.h
@@ -70,6 +70,9 @@ struct _WebKitMediaSrcClass {
 
 GType webkit_media_src_get_type(void);
 
+void webKitMediaSrcRestoreTracks(WebKitMediaSrc*, WebKitMediaSrc*);
+void webKitMediaSrcSignalTracks(WebKitMediaSrc*);
+
 void webKitMediaSrcSetMediaPlayerPrivate(WebKitMediaSrc*, WebCore::MediaPlayerPrivateGStreamerMSE*);
 
 void webKitMediaSrcPrepareSeek(WebKitMediaSrc*, const MediaTime&);


### PR DESCRIPTION
This commit backports:

https://github.com/WebKit/WebKit/commit/45759ff616fe074b33c1389b419a2429a62b35a8

[MSE][GStreamer] SIGSEV in webKitMediaSrcFreeStream

The pipeline used by the MSE player is now able reload the MediaSource from the beginning if
a seek to 0 was requested. The problem was that uridecodebin was creating a new source
element and notifying the player which was then trying to dispose underlying platform track
informations, and also related appsrc elements. The latter was specially problematic because
the appsrc elements ownership was badly handled (elements added to a bin should not be
reused, unless an extra ref is added), leading to racy crashes.

So now when uridecodebin creates a new source element, the player detects this is a new
source and transfers track-related informations to the new element. Additionally, new appsrc
elements are created for the new element and track signals emitted so that the player is
still fully aware of the MSE tracks topology.