### PR TITLE
Fix Nicosia buffer leak in NonCompositedWebGL mode

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
@@ -792,7 +792,9 @@ void CoordinatedGraphicsLayer::flushCompositingStateForThisLayerOnly()
     m_nicosia.delta.animatedBackingStoreClientChanged = true;
 
     // Determine image backing presence according to the composited image source.
-    if (m_compositedNativeImagePtr) {
+    if (m_coordinator->nonCompositedWebGLEnabled()) {
+        ASSERT(m_nicosia.imageBacking == nullptr);
+    } else if (m_compositedNativeImagePtr) {
         ASSERT(m_compositedImage);
         auto& image = *m_compositedImage;
         uintptr_t imageID = reinterpret_cast<uintptr_t>(&image);
@@ -963,6 +965,11 @@ void CoordinatedGraphicsLayer::requestBackingStoreUpdate()
 {
     setNeedsVisibleRectAdjustment();
     notifyFlushRequired();
+}
+
+bool CoordinatedGraphicsLayer::canHaveBackingStore() const
+{
+    return m_coordinator && !m_coordinator->nonCompositedWebGLEnabled();
 }
 
 void CoordinatedGraphicsLayer::updateContentBuffersIncludingSubLayers()
@@ -1237,7 +1244,7 @@ void CoordinatedGraphicsLayer::computeTransformedVisibleRect()
 
 bool CoordinatedGraphicsLayer::shouldHaveBackingStore() const
 {
-    return drawsContent() && contentsAreVisible() && !m_size.isEmpty()
+    return canHaveBackingStore() && drawsContent() && contentsAreVisible() && !m_size.isEmpty()
         && (!!opacity() || m_animations.hasActiveAnimationsOfType(AnimatedPropertyOpacity));
 }
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h
@@ -53,6 +53,7 @@ public:
     virtual void attachLayer(CoordinatedGraphicsLayer*) = 0;
     virtual Nicosia::PaintingEngine& paintingEngine() = 0;
     virtual void syncLayerState() = 0;
+    virtual bool nonCompositedWebGLEnabled() const = 0;
 };
 
 class WEBCORE_EXPORT CoordinatedGraphicsLayer : public GraphicsLayer {
@@ -190,6 +191,7 @@ private:
     void requestPendingTileCreationTimerFired();
 
     bool filtersCanBeComposited(const FilterOperations&) const;
+    bool canHaveBackingStore() const;
 
     Nicosia::PlatformLayer::LayerID m_id;
     GraphicsLayerTransform m_layerTransform;

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.cpp
@@ -40,6 +40,7 @@
 #include <WebCore/NicosiaImageBackingTextureMapperImpl.h>
 #include <WebCore/NicosiaPaintingEngine.h>
 #include <WebCore/Page.h>
+#include <WebCore/Settings.h>
 #include <wtf/MemoryPressureHandler.h>
 #include <wtf/SetForScope.h>
 
@@ -209,6 +210,11 @@ void CompositingCoordinator::initializeRootCompositingLayerIfNeeded()
 void CompositingCoordinator::syncLayerState()
 {
     m_shouldSyncFrame = true;
+}
+
+bool CompositingCoordinator::nonCompositedWebGLEnabled() const
+{
+    return m_page.corePage()->settings().nonCompositedWebGLEnabled();
 }
 
 void CompositingCoordinator::notifyFlushRequired(const GraphicsLayer*)

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.h
@@ -103,6 +103,7 @@ private:
     void attachLayer(WebCore::CoordinatedGraphicsLayer*) override;
     Nicosia::PaintingEngine& paintingEngine() override;
     void syncLayerState() override;
+    bool nonCompositedWebGLEnabled() const override;
 
     // GraphicsLayerFactory
     Ref<WebCore::GraphicsLayer> createGraphicsLayer(WebCore::GraphicsLayer::Type, WebCore::GraphicsLayerClient&) override;


### PR DESCRIPTION
Tile updates aren't commited in non-composited mode. Which leads to
accumulation of Nicosia buffers in coordinated backing store.

This change fixes the issue in 2 steps:

 - disable backing store allocation in coordinated layer in
   non-composited-webgl mode. the backing store wouldn't be used
   anyway, so this also reduces memory pressure.
 - apply tile updates in non-composited-webgl mode as well. this
   is needed commit removal of the tiles and clear tile updates (image
   backing)