### PR TITLE
Decrease DisplayRefreshMonitorTimer priority

### DIFF
--- a/Source/WTF/wtf/glib/RunLoopSourcePriority.h
+++ b/Source/WTF/wtf/glib/RunLoopSourcePriority.h
@@ -95,8 +95,8 @@ enum RunLoopSourcePriority {
     JavascriptTimer = -60,
     MainThreadSharedTimer = -60,
 
-    LayerFlushTimer = -70,
-    DisplayRefreshMonitorTimer = -70,
+    LayerFlushTimer = -60,
+    DisplayRefreshMonitorTimer = -60,
 
     CompositingThreadUpdateTimer = -70,
 


### PR DESCRIPTION
DisplayRefreshMonitorTimer priority is used for timers that schedule callbacks in
requestAnimationFrame api. They have higher priority than regular timers
scheduled in setTimeout api. On pages with lots of animations the result
is that setTimeout timers are starved out and can execute seconds after
they're supposed to (sometimes even tens of seconds).

This commits makes sure both priorities are the same.