### PR TITLE
Make the CDMInstance a ThreadSafeRefCounted

### DIFF
--- a/Source/WebCore/platform/encryptedmedia/CDMInstance.h
+++ b/Source/WebCore/platform/encryptedmedia/CDMInstance.h
@@ -54,7 +54,7 @@ public:
     virtual void issueMessage(MessageType, Ref<SharedBuffer>&&) = 0;
 };
 
-class CDMInstance : public RefCounted<CDMInstance> {
+class CDMInstance : public ThreadSafeRefCounted<CDMInstance> {
 public:
     virtual ~CDMInstance() = default;
 


### PR DESCRIPTION
Make the CDMInstance a ThreadSafeRefCounted as it is frequently passed to
multiple threads.
Fixes an issue reported by customer where crash happens
randomly during the teardown of playback when MediaKeySession tries
to access the CDMInstance but the CDMInstance was already destroyed.