### PR TITLE
Disable hasBrokenEncryptedMediaAPISupportQuirk for Thunder backend

### DIFF
--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -126,6 +126,10 @@ bool Quirks::shouldAutoplayForArbitraryUserGesture() const
 
 bool Quirks::hasBrokenEncryptedMediaAPISupportQuirk() const
 {
+#if ENABLE(THUNDER)
+    return false;
+#endif
+
     if (!needsQuirks())
         return false;
 


### PR DESCRIPTION
Encrypted playback on Hulu and YouTube works fine on our device, so I think it makes sense to disable this quirk when Thunder is enabled.