### PR TITLE
Adding option to skip JIT code deletion on memory pressure handling

### DIFF
--- a/Source/WebCore/page/MemoryRelease.cpp
+++ b/Source/WebCore/page/MemoryRelease.cpp
@@ -109,7 +109,8 @@ static void releaseCriticalMemory(Synchronous synchronous, MaintainBackForwardCa
         document->cachedResourceLoader().garbageCollectDocumentResources();
     }
 
-    GCController::singleton().deleteAllCode(JSC::DeleteAllCodeIfNotCollecting);
+    if (synchronous == Synchronous::Yes)
+        GCController::singleton().deleteAllCode(JSC::DeleteAllCodeIfNotCollecting);
 
 #if ENABLE(VIDEO)
     for (auto* mediaElement : HTMLMediaElement::allMediaElements()) {


### PR DESCRIPTION
This patch allows to skip / conditionally delete JIT code during handling critical memory pressure. By default the JIT code would be deleted. If overridden with this env "WPE_DELETE_JIT_CODE_ON_SYNC_RELIEF", it takes precedence over the default behavior.

If the env is set to '1' or 'y', JIT code would be deleted, any other value would end up in skipping the deletion