### PR TITLE
Skip updateStates call on reaching end of looped video

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -2333,13 +2333,16 @@ void MediaPlayerPrivateGStreamer::didEnd()
         m_player->durationChanged();
 
     m_isEndReached = true;
-    timeChanged();
 
     if (!m_player->client().mediaPlayerIsLooping() && !isMediaSource()) {
+        timeChanged();
         m_paused = true;
         m_durationAtEOS = durationMediaTime();
         changePipelineState(GST_STATE_READY);
         m_downloadFinished = false;
+    } else {
+        // Skip updateStates() as that would eventually result in play(), clearing m_isEndReached
+        m_player->timeChanged();
     }
 }
 


### PR DESCRIPTION
updateStates would trigger play() call, clearing m_isEndReached and changing reported position
Fixes looped playback for progresive streaming where audio track is longer than video
Issue is reproducible on RPi