### PR TITLE
Mse flush backport

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -321,6 +321,7 @@ protected:
 
     void ensureAudioSourceProvider();
     void setAudioStreamProperties(GObject*);
+    void checkPlayingConsitency();
 
     static void setAudioStreamPropertiesCallback(MediaPlayerPrivateGStreamer*, GObject*);
 
@@ -569,6 +570,7 @@ private:
 #endif
 
     String m_errorMessage;
+    bool m_didTryToRecoverPlayingState { false };
 };
 
 }

--- a/Source/WebCore/platform/graphics/gstreamer/mse/PlaybackPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/PlaybackPipeline.cpp
@@ -358,14 +358,6 @@ void PlaybackPipeline::flush(AtomString trackId)
         return;
     }
 
-    if (!gst_element_send_event(GST_ELEMENT(appsrc), gst_event_new_flush_stop(false))) {
-        GST_WARNING("Failed to send flush-stop event for trackId=%s", trackId.string().utf8().data());
-        return;
-    }
-
-    if (static_cast<guint64>(position) == GST_CLOCK_TIME_NONE || static_cast<guint64>(start) == GST_CLOCK_TIME_NONE)
-        return;
-
     GUniquePtr<GstSegment> segment(gst_segment_new());
     gst_segment_init(segment.get(), GST_FORMAT_TIME);
     gst_segment_do_seek(segment.get(), rate, GST_FORMAT_TIME, GST_SEEK_FLAG_NONE,
@@ -381,6 +373,10 @@ void PlaybackPipeline::flush(AtomString trackId)
 
     if (!gst_base_src_new_seamless_segment(GST_BASE_SRC(appsrc), segment->start, segment->stop, segment->start)) {
         GST_WARNING("Failed to send seamless segment event for trackId=%s", trackId.string().utf8().data());
+    }
+
+    if (!gst_element_send_event(GST_ELEMENT(appsrc), gst_event_new_flush_stop(false))) {
+        GST_WARNING("Failed to send flush-stop event for trackId=%s", trackId.string().utf8().data());
         return;
     }
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/PlaybackPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/PlaybackPipeline.cpp
@@ -289,6 +289,25 @@ void PlaybackPipeline::markEndOfStream(MediaSourcePrivate::EndOfStreamStatus)
         gst_app_src_end_of_stream(appsrc);
 }
 
+GstPadProbeReturn segmentFixerProbe(GstPad*, GstPadProbeInfo* info, gpointer)
+{
+    GstEvent* event = GST_EVENT(info->data);
+
+    if (GST_EVENT_TYPE(event) != GST_EVENT_SEGMENT)
+        return GST_PAD_PROBE_OK;
+
+    GstSegment* segment = nullptr;
+    gst_event_parse_segment(event, const_cast<const GstSegment**>(&segment));
+
+    GST_TRACE("Fixed segment base time from %" GST_TIME_FORMAT " to %" GST_TIME_FORMAT,
+        GST_TIME_ARGS(segment->base), GST_TIME_ARGS(segment->start));
+
+    segment->base = segment->start;
+    segment->flags = static_cast<GstSegmentFlags>(0);
+
+    return GST_PAD_PROBE_REMOVE;
+}
+
 void PlaybackPipeline::flush(AtomString trackId)
 {
     ASSERT(WTF::isMainThread());
@@ -322,12 +341,47 @@ void PlaybackPipeline::flush(AtomString trackId)
         return;
     }
 
+    double rate;
+    GstFormat format;
+    gint64 start = GST_CLOCK_TIME_NONE;
+    gint64 stop = GST_CLOCK_TIME_NONE;
+
+    query = adoptGRef(gst_query_new_segment(GST_FORMAT_TIME));
+    if (gst_element_query(pipeline(), query.get()))
+        gst_query_parse_segment(query.get(), &rate, &format, &start, &stop);
+
+    GST_TRACE("segment: [%" GST_TIME_FORMAT ", %" GST_TIME_FORMAT "], rate: %f",
+        GST_TIME_ARGS(start), GST_TIME_ARGS(stop), rate);
+
     if (!gst_element_send_event(GST_ELEMENT(appsrc), gst_event_new_flush_start())) {
         GST_WARNING("Failed to send flush-start event for trackId=%s", trackId.string().utf8().data());
+        return;
     }
 
     if (!gst_element_send_event(GST_ELEMENT(appsrc), gst_event_new_flush_stop(false))) {
         GST_WARNING("Failed to send flush-stop event for trackId=%s", trackId.string().utf8().data());
+        return;
+    }
+
+    if (static_cast<guint64>(position) == GST_CLOCK_TIME_NONE || static_cast<guint64>(start) == GST_CLOCK_TIME_NONE)
+        return;
+
+    GUniquePtr<GstSegment> segment(gst_segment_new());
+    gst_segment_init(segment.get(), GST_FORMAT_TIME);
+    gst_segment_do_seek(segment.get(), rate, GST_FORMAT_TIME, GST_SEEK_FLAG_NONE,
+        GST_SEEK_TYPE_SET, position, GST_SEEK_TYPE_SET, stop, nullptr);
+
+    GRefPtr<GstPad> sinkPad = gst_element_get_static_pad(appsrc, "src");
+    GRefPtr<GstPad> srcPad = sinkPad ? gst_pad_get_peer(sinkPad.get()) : nullptr;
+    if (srcPad)
+        gst_pad_add_probe(srcPad.get(), GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM, segmentFixerProbe, nullptr, nullptr);
+
+    GST_TRACE("Sending new seamless segment: [%" GST_TIME_FORMAT ", %" GST_TIME_FORMAT "], rate: %f",
+        GST_TIME_ARGS(segment->start), GST_TIME_ARGS(segment->stop), segment->rate);
+
+    if (!gst_base_src_new_seamless_segment(GST_BASE_SRC(appsrc), segment->start, segment->stop, segment->start)) {
+        GST_WARNING("Failed to send seamless segment event for trackId=%s", trackId.string().utf8().data());
+        return;
     }
 
     GST_DEBUG("trackId=%s flushed", trackId.string().utf8().data());

--- a/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
@@ -258,8 +258,10 @@ static void webkit_media_src_class_init(WebKitMediaSrcClass* klass)
 static GstFlowReturn webkitMediaSrcChain(GstPad* pad, GstObject* parent, GstBuffer* buffer)
 {
     GRefPtr<WebKitMediaSrc> self = adoptGRef(WEBKIT_MEDIA_SRC(gst_object_get_parent(parent)));
-
-    return gst_flow_combiner_update_pad_flow(self->priv->flowCombiner.get(), pad, gst_proxy_pad_chain_default(pad, GST_OBJECT(self.get()), buffer));
+    GstFlowReturn ret = gst_proxy_pad_chain_default(pad, GST_OBJECT(self.get()), buffer);
+    if (ret != GST_FLOW_FLUSHING)
+        return gst_flow_combiner_update_pad_flow(self->priv->flowCombiner.get(), pad, ret);
+    return ret;
 }
 
 static void webkit_media_src_init(WebKitMediaSrc* source)

--- a/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
@@ -735,8 +735,7 @@ void webKitMediaSrcPrepareSeek(WebKitMediaSrc* source, const MediaTime& time)
 
     for (Stream* stream : source->priv->streams) {
         stream->appsrcNeedDataFlag = false;
-        // Don't allow samples away from the seekTime to be enqueued.
-        stream->lastEnqueuedTime = time;
+        stream->lastEnqueuedTime = MediaTime::invalidTime();
     }
 
     // The pending action will be performed in enabledAppsrcSeekData().
@@ -766,11 +765,8 @@ void webKitMediaSrcPrepareInitialSeek(WebKitMediaSrc* source, double rate, const
     source->priv->appsrcSeekDataCount = 0;
     source->priv->appsrcNeedDataCount = 0;
 
-    for (Stream* stream : source->priv->streams) {
+    for (Stream* stream : source->priv->streams)
         stream->appsrcNeedDataFlag = false;
-        // Don't allow samples away from the seekTime to be enqueued.
-        stream->lastEnqueuedTime = seekTime;
-    }
 
     // The pending action will be performed in enabledAppsrcSeekData().
     source->priv->appsrcSeekDataNextAction = MediaSourceSeekToTime;


### PR DESCRIPTION
media samples re-enqueuing may cause video playback freeze (or replaying of previously enqueued buffers). here is a test case that demonstrates the issue: https://github.com/emutavchi/tests/blob/master/mse/flush_test.html
