### PR TITLE
Return cached position if sink reports an invalid one

### DIFF
--- a/Source/WebCore/page/Settings.yaml
+++ b/Source/WebCore/page/Settings.yaml
@@ -495,7 +495,7 @@ mediaSourceEnabled:
   conditional: MEDIA_SOURCE
 
 sourceBufferChangeTypeEnabled:
-  initial: true
+  initial: false
   conditional: MEDIA_SOURCE
 
 # FIXME: Rename to allowMultiElementImplicitFormSubmission once we upstream the iOS changes to WebView.mm.

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -1450,6 +1450,8 @@ MediaTime MediaPlayerPrivateGStreamer::playbackPosition() const
         playbackPosition = MediaTime(gstreamerPosition, GST_SECOND);
     else if (m_canFallBackToLastFinishedSeekPosition)
         playbackPosition = m_seekTime;
+    else if (m_cachedPosition.isValid())
+        playbackPosition = m_cachedPosition;
 
     m_cachedPosition = playbackPosition;
     return playbackPosition;
@@ -2711,7 +2713,7 @@ void MediaPlayerPrivateGStreamer::didEnd()
     // Synchronize position and duration values to not confuse the
     // HTMLMediaElement. In some cases like reverse playback the
     // position is not always reported as 0 for instance.
-    m_cachedPosition = MediaTime::invalidTime();
+    m_lastQueryTime.reset();
     MediaTime now = currentMediaTime();
     if (now > MediaTime::zeroTime() && !m_isSeeking) {
         m_cachedDuration = now;

--- a/Source/WebKit/Shared/WebPreferences.yaml
+++ b/Source/WebKit/Shared/WebPreferences.yaml
@@ -1223,7 +1223,7 @@ IsSecureContextAttributeEnabled:
 
 SourceBufferChangeTypeEnabled:
   type: bool
-  defaultValue: true
+  defaultValue: false
   condition: ENABLE(MEDIA_SOURCE)
 
 KeygenElementEnabled:


### PR DESCRIPTION
And also backport:
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/859df20bc72151a13c5add8bff715d7b25f18fa4