### PR TITLE
Improve SourceBuffer memory cost reporting

### DIFF
--- a/Source/WebCore/Modules/mediasource/SourceBuffer.h
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.h
@@ -130,6 +130,8 @@ public:
     MediaTime highestPresentationTimestamp() const;
     void readyStateChanged();
 
+    size_t memoryCost() const;
+
     void trySignalAllSamplesEnqueued();
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.idl
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.idl
@@ -37,6 +37,7 @@
     ActiveDOMObject,
     Conditional=MEDIA_SOURCE,
     ExportMacro=WEBCORE_EXPORT,
+    ReportExtraMemoryCost,
 ] interface SourceBuffer : EventTarget {
     attribute AppendMode mode;
 


### PR DESCRIPTION
1) Extend SourceBuffer interface with ReportExtraMemoryCost attribute
2) Implement memoryCost() method for the interface
3) Fix calculations for removed buffers