### PR TITLE
Video was not scaled properly on successive launch of page / app

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -5811,13 +5811,8 @@ void HTMLMediaElement::visibilityStateChanged()
 
     updateSleepDisabling();
     m_mediaSession->visibilityChanged();
-    if (m_player) {
+    if (m_player)
         m_player->setVisible(!m_elementIsHidden);
-        if (m_elementIsHidden)
-            m_player->platformHide();
-        else
-            m_player->platformShow();
-    }
 
     // A suspended and hidden view must resume playback when the view is resumed (despite only audio will
     // work). The code below prevents that behavior requiring the player to be visible in oder to resume

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -3253,6 +3253,16 @@ void MediaPlayerPrivateGStreamer::flushCurrentBuffer()
 }
 #endif
 
+void MediaPlayerPrivateGStreamer::setVisible(bool visible)
+{
+    if (m_visible != visible) {
+        if ((m_visible = visible))
+            platformShow();
+        else
+            platformHide();
+    }
+}
+
 void MediaPlayerPrivateGStreamer::setSize(const IntSize& size)
 {
     m_size = size;
@@ -3477,14 +3487,14 @@ static void setRectangleToVideoSink(GstElement* videoSink, const IntRect& rect, 
     static Lock mutex;
     static bool isVisible = true;
 
-    if (!videoSink)
-        return;
+    LockHolder holder(mutex);
+    isVisible = changeVisibleState ? newVisibility : isVisible;
 
     if (!isVisible && !changeVisibleState)
         return;
 
-    LockHolder holder(mutex);
-    isVisible = changeVisibleState ? newVisibility : isVisible;
+    if (!videoSink)
+        return;
 
 #if USE(WESTEROS_SINK) || USE(WPEWEBKIT_PLATFORM_BCM_NEXUS)
     // Valid for brcmvideosink and westerossink.

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -167,7 +167,7 @@ public:
     void setMuted(bool) final;
     MediaPlayer::NetworkState networkState() const final;
     MediaPlayer::ReadyState readyState() const final;
-    void setVisible(bool) final { }
+    void setVisible(bool) override;
     void setSize(const IntSize&) final;
     // Prefer MediaTime based methods over float based.
     float duration() const final { return durationMediaTime().toFloat(); }
@@ -571,6 +571,7 @@ private:
 
     String m_errorMessage;
     bool m_didTryToRecoverPlayingState { false };
+    bool m_visible { false };
 };
 
 }


### PR DESCRIPTION
It looks like the isVisible inside doesn't reflect the actual visibility
state of the element. On exiting from the test page / app for the first
time the isVisible is set to false by HTMLMediaElement but on next
launch platformShow() is not triggered leaving the isVisible false.

The subsequent calls from GStreamerHolePunchClient bails out as
isVisible is false.

The change tries to align isVisible with element's visibility state by
calling platformShow() / platformHide() from MediaPlayer::setVisible()

Also have reordered the statements in setRectangleToVideoSink() to
* decouple visibility state update from existence of videoSink
* updating isVisible before actually checking for bailing out