### PR TITLE
Update network state on error condition.

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -2157,6 +2157,9 @@ void HTMLMediaElement::noneSupported()
 
 void HTMLMediaElement::mediaLoadingFailedFatally(MediaPlayer::NetworkState error)
 {
+    // https://html.spec.whatwg.org/#loading-the-media-resource:dom-media-have_nothing-2
+    // 17 March 2021
+
     // 1 - The user agent should cancel the fetching process.
     stopPeriodicTimers();
     m_loadState = WaitingForSource;
@@ -2182,20 +2185,18 @@ void HTMLMediaElement::mediaLoadingFailedFatally(MediaPlayer::NetworkState error
     else
         ASSERT_NOT_REACHED();
 
-    // 3 - Queue a task to fire a simple event named error at the media element.
-    scheduleEvent(eventNames().errorEvent);
-
 #if ENABLE(MEDIA_SOURCE)
     detachMediaSource();
 #endif
 
-    // 4 - Set the element's networkState attribute to the NETWORK_EMPTY value and queue a
-    // task to fire a simple event called emptied at the element.
-    m_networkState = NETWORK_EMPTY;
-    scheduleEvent(eventNames().emptiedEvent);
+    // 3 - Set the element's networkState attribute to the NETWORK_IDLE value.
+    m_networkState = NETWORK_IDLE;
 
-    // 5 - Set the element's delaying-the-load-event flag to false. This stops delaying the load event.
+    // 4 - Set the element's delaying-the-load-event flag to false. This stops delaying the load event.
     setShouldDelayLoadEvent(false);
+
+    // 5 - Fire an event named error at the media element.
+    dispatchEvent(Event::create(eventNames().errorEvent, Event::CanBubble::No, Event::IsCancelable::No));
 
     // 6 - Abort the overall resource selection algorithm.
     m_currentSourceNode = nullptr;

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -2160,21 +2160,18 @@ void HTMLMediaElement::mediaLoadingFailedFatally(MediaPlayer::NetworkState error
     // https://html.spec.whatwg.org/#loading-the-media-resource:dom-media-have_nothing-2
     // 17 March 2021
 
-    // 1 - The user agent should cancel the fetching process.
-    stopPeriodicTimers();
-    m_loadState = WaitingForSource;
-
+    const String playerErrMsg = m_player ? m_player->lastErrorMessage() : ""_s;
     const auto getErrorMessage = [&] (String&& defaultMessage) {
-        String message = WTFMove(defaultMessage);
-        if (!m_player)
-            return message;
-
-        auto lastErrorMessage = m_player->lastErrorMessage();
-        if (!lastErrorMessage)
-            return message;
-
-        return makeString(message, ": ", lastErrorMessage);
+        if (playerErrMsg.isEmpty()) {
+            return defaultMessage;
+        }
+        return makeString(defaultMessage, ": ", playerErrMsg);
     };
+
+    ERROR_LOG(LOGIDENTIFIER, "error = ", static_cast<int>(error));
+
+    // 1 - The user agent should cancel the fetching process.
+    clearMediaPlayer();
 
     // 2 - Set the error attribute to a new MediaError object whose code attribute is
     // set to MEDIA_ERR_NETWORK/MEDIA_ERR_DECODE.
@@ -2184,10 +2181,6 @@ void HTMLMediaElement::mediaLoadingFailedFatally(MediaPlayer::NetworkState error
         m_error = MediaError::create(MediaError::MEDIA_ERR_DECODE, getErrorMessage("Media failed to decode"_s));
     else
         ASSERT_NOT_REACHED();
-
-#if ENABLE(MEDIA_SOURCE)
-    detachMediaSource();
-#endif
 
     // 3 - Set the element's networkState attribute to the NETWORK_IDLE value.
     m_networkState = NETWORK_IDLE;


### PR DESCRIPTION
Set the NETWORK_IDLE state on decode or network errors for high enough ready state
as specified in '4.8.11.5 Loading the media resource':
https://html.spec.whatwg.org/multipage/media.html#loading-the-media-resource

This change fixes orphant HTML video tag removal that is in error state.
removedFromAncestor() -> pauseAfterDetachedTask() cycle
will trigger pause() switching m_playing to 0 so the object
won't report any pending activity from virtualHasPendingActivity()
and can be cleared by GC.