### PR TITLE
[wpe-2.28] Fix crash on appsrc streaming thread when track is being added

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/PlaybackPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/PlaybackPipeline.cpp
@@ -177,10 +177,6 @@ void PlaybackPipeline::attachTrack(RefPtr<SourceBufferPrivateGStreamer> sourceBu
     const char* mediaType = capsMediaType(caps);
     GST_DEBUG_OBJECT(webKitMediaSrc, "Configured track %s: appsrc=%s, padId=%u, mediaType=%s", trackPrivate->id().string().utf8().data(), GST_ELEMENT_NAME(stream->appsrc), padId, mediaType);
 
-    GST_OBJECT_LOCK(webKitMediaSrc);
-    stream->type = Unknown;
-    GST_OBJECT_UNLOCK(webKitMediaSrc);
-
     GRefPtr<GstPad> sourcePad = adoptGRef(gst_element_get_static_pad(stream->appsrc, "src"));
     ASSERT(sourcePad);
 
@@ -208,6 +204,8 @@ void PlaybackPipeline::attachTrack(RefPtr<SourceBufferPrivateGStreamer> sourceBu
         signal = SIGNAL_TEXT_CHANGED;
 
         // FIXME: Support text tracks.
+    } else {
+        stream->type = Unknown;
     }
     GST_OBJECT_UNLOCK(webKitMediaSrc);
 


### PR DESCRIPTION
It looks like on some rare case appsrc tries to refer the Stream's type before it is configured by PlaybackPipeline.

Stack trace from the crash:
```
#0  __libc_do_syscall () at libc-do-syscall.S:49
#1  0xb1e3adb4 in __libc_signal_restore_set (set=0x7b3fe758) at ../sysdeps/unix/sysv/linux/internal-signals.h:86
#2  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:48
#3  0xb1e2e6dc in __GI_abort () at abort.c:79
#4  0xb2462ae8 in CRASH_WITH_INFO(...) () at DerivedSources/ForwardingHeaders/wtf/Assertions.h:740
#5  operator() () at /usr/src/debug/wpe-webkit/2.28+gitAUTOINC+f049f4091f-r0/git/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp:145
#6  enabledAppsrcNeedData () at /usr/src/debug/wpe-webkit/2.28+gitAUTOINC+f049f4091f-r0/git/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp:147
#7  0xb04b7858 in gst_app_src_emit_need_data (appsrc=appsrc@entry=0x20c09e0, size=size@entry=4096) at ../gst-plugins-base-1.18.5/gst-libs/gst/app/gstappsrc.c:1157
#8  0xb04b7ef0 in gst_app_src_create (bsrc=0x20c09e0, offset=<optimized out>, size=4096, buf=0x7b3feb14) at ../gst-plugins-base-1.18.5/gst-libs/gst/app/gstappsrc.c:1360
#9  0xb047ff6c in gst_base_src_get_range (src=src@entry=0x20c09e0, offset=<optimized out>, length=<optimized out>, length@entry=4096, buf=buf@entry=0x7b3febbc) at ../gstreamer-1.18.5/libs/gst/base/gstbasesrc.c:2587
#10 0xb0481584 in gst_base_src_loop (pad=0x20c5cb8) at ../gstreamer-1.18.5/libs/gst/base/gstbasesrc.c:2911
#11 0xb0cc583c in gst_task_func (task=0x90402ac8) at ../gstreamer-1.18.5/gst/gsttask.c:384
#12 0xb0d7c45c in g_thread_pool_thread_proxy (data=<optimized out>) at ../glib-2.62.4/glib/gthreadpool.c:308
#13 0xb0d7bf2e in g_thread_proxy (data=0x972bc2c0) at ../glib-2.62.4/glib/gthread.c:805
#14 0xb060379e in start_thread (arg=0xdd14bdf9) at pthread_create.c:477
#15 0xb1e9822c in ?? () at ../sysdeps/unix/sysv/linux/arm/clone.S:73 from ./lib/libc.so.6
Backtrace stopped: previous frame identical to this frame (corrupt stack?)

#0  syscall () at ../sysdeps/unix/sysv/linux/arm/syscall.S:37
#1  0xb0d8f1ec in g_mutex_lock_slowpath (mutex=0x20a47b4) at ../glib-2.62.4/glib/gthread-posix.c:1340
#2  0xb24645e6 in webKitMediaSrcCheckAllTracksConfigured () at /usr/src/debug/wpe-webkit/2.28+gitAUTOINC+f049f4091f-r0/git/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp:823
#3  0xb310d76e in WebCore::PlaybackPipeline::attachTrack () at /usr/src/debug/wpe-webkit/2.28+gitAUTOINC+f049f4091f-r0/git/Source/WebCore/platform/graphics/gstreamer/mse/PlaybackPipeline.cpp:199
#4  0xb310a358 in std::__atomic_base<unsigned int>::operator-- () at /usr/include/c++/9.3.0/bits/atomic_base.h:327
#5  WTF::ThreadSafeRefCountedBase::derefBase () at DerivedSources/ForwardingHeaders/wtf/ThreadSafeRefCounted.h:86
#6  WTF::ThreadSafeRefCounted<WebCore::TrackPrivateBase, (WTF::DestructionThread)1>::deref () at DerivedSources/ForwardingHeaders/wtf/ThreadSafeRefCounted.h:113
#7  WTF::derefIfNotNull<WebCore::TrackPrivateBase> () at DerivedSources/ForwardingHeaders/wtf/RefPtr.h:44
#8  WTF::RefPtr<WebCore::TrackPrivateBase, WTF::DumbPtrTraits<WebCore::TrackPrivateBase> >::~RefPtr () at DerivedSources/ForwardingHeaders/wtf/RefPtr.h:70
#9  WebCore::MediaPlayerPrivateGStreamerMSE::trackDetected () at /usr/src/debug/wpe-webkit/2.28+gitAUTOINC+f049f4091f-r0/git/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp:738
#10 0xb31e0458 in std::__atomic_base<unsigned int>::operator-- () at /usr/include/c++/9.3.0/bits/atomic_base.h:327
#11 WTF::ThreadSafeRefCountedBase::derefBase () at DerivedSources/ForwardingHeaders/wtf/ThreadSafeRefCounted.h:86
#12 WTF::ThreadSafeRefCounted<WebCore::TrackPrivateBase, (WTF::DestructionThread)1>::deref () at DerivedSources/ForwardingHeaders/wtf/ThreadSafeRefCounted.h:113
#13 WTF::derefIfNotNull<WebCore::TrackPrivateBase> () at DerivedSources/ForwardingHeaders/wtf/RefPtr.h:44
#14 WTF::RefPtr<WebCore::TrackPrivateBase, WTF::DumbPtrTraits<WebCore::TrackPrivateBase> >::~RefPtr () at DerivedSources/ForwardingHeaders/wtf/RefPtr.h:70
#15 WebCore::AppendPipeline::connectDemuxerSrcPadToAppsink () at /usr/src/debug/wpe-webkit/2.28+gitAUTOINC+f049f4091f-r0/git/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp:805
#16 0xb31e09c6 in WTF::VectorDestructor<true, WTF::Ref<WebCore::AbortableTaskQueue::Task, WTF::DumbPtrTraits<WebCore::AbortableTaskQueue::Task> > >::destruct () at DerivedSources/ForwardingHeaders/wtf/Vector.h:65
#17 WTF::VectorTypeOperations<WTF::Ref<WebCore::AbortableTaskQueue::Task, WTF::DumbPtrTraits<WebCore::AbortableTaskQueue::Task> > >::destruct () at DerivedSources/ForwardingHeaders/wtf/Vector.h:242
#18 WTF::Deque<WTF::Ref<WebCore::AbortableTaskQueue::Task, WTF::DumbPtrTraits<WebCore::AbortableTaskQueue::Task> >, 0u>::destroyAll () at DerivedSources/ForwardingHeaders/wtf/Deque.h:359
#19 0xb31df07c in WTF::Detail::CallableWrapper<WebCore::AbortableTaskQueue::postTask(WTF::Function<void ()>&&)::{lambda()#1}, void>::~CallableWrapper() () at DerivedSources/ForwardingHeaders/wtf/Function.h:46
#20 0x7c571000 in ?? ()
```

The change moves setting the type to "Unknown" which would prevent enabledAppsrcNeedData() from asserting