### PR TITLE
[GST][MSE] relax seek delay

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -259,6 +259,8 @@ static bool checkShouldDelaySeek(GstStateChangeReturn getStateResult, GstState c
         return false;
     if (currentState == GST_STATE_READY && newState >= GST_STATE_PAUSED)
         return false;
+    if (GST_STATE_TRANSITION(currentState, newState) == GST_STATE_CHANGE_PAUSED_TO_PAUSED)
+        return false;
     return true;
 }
 


### PR DESCRIPTION
Allow seek on pause-to-pause. The pipeline could endup in this state
if application cleared the SB triggering a flush.