### PR TITLE
[MSE] adjust end of the initial range for eviction

### DIFF
--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -978,7 +978,7 @@ void SourceBuffer::evictCodedFrames(size_t newDataSize)
 #endif
 
     MediaTime rangeStart = MediaTime::zeroTime();
-    MediaTime rangeEnd = rangeStart + thirtySeconds;
+    MediaTime rangeEnd = std::max(m_buffered->ranges().start(0), rangeStart + thirtySeconds);
     while (rangeStart < maximumRangeEnd) {
         // 4. For each range in removal ranges, run the coded frame removal algorithm with start and
         // end equal to the removal range start and end timestamp respectively.


### PR DESCRIPTION
Eviction consumes a lot of CPU and time on some live channels.
For example buffered range on Hulu news live starts with high PTS
>1650000000 seconds.

This change adjusts end of the intial removal range so eviction
algorithm covers it in one "cycle".