### PR TITLE
Adding safety check to identify whether m_coordinator has valid value

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
@@ -674,7 +674,7 @@ void CoordinatedGraphicsLayer::syncFilters()
 
 void CoordinatedGraphicsLayer::syncImageBacking()
 {
-    if (m_coordinator->nonCompositedWebGLEnabled())
+    if (m_coordinator && m_coordinator->nonCompositedWebGLEnabled())
         return;
 
     if (!m_shouldSyncImageBacking)
@@ -1046,7 +1046,7 @@ void CoordinatedGraphicsLayer::updateContentBuffersIncludingSubLayers()
 
 void CoordinatedGraphicsLayer::updateContentBuffers()
 {
-    if (m_coordinator->nonCompositedWebGLEnabled())
+    if (m_coordinator && m_coordinator->nonCompositedWebGLEnabled())
         return;
 
     if (!shouldHaveBackingStore()) {


### PR DESCRIPTION
The upstream commit 438caeacda1e915777db1df2c136b5f72b7a1603 to avoid update image backings in nonCompositedWebGL  mode causing a crash while trying to access invalid memory.So,Adding safety check to identify whether m_coordinator has valid value
