### PR TITLE
[TextureMapper] Backport a couple of fixes for overlap regions

### DIFF
--- a/LayoutTests/compositing/reflections/opacity-in-reflection-expected.html
+++ b/LayoutTests/compositing/reflections/opacity-in-reflection-expected.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <style>
+            .right {
+                position: relative;
+                width: 150px;
+                height: 150px;
+                -webkit-box-reflect: right 10px;
+            }
+            .below {
+                width: 150px;
+                height: 150px;
+                -webkit-box-reflect: below 10px;
+            }
+            .container {
+                height: 100px;
+                width: 100px;
+                background-color: green;
+                opacity: 0.5;
+            }
+            .container div {
+                position: relative;
+                top: 10px;
+                left: 10px;
+                height: 100px;
+                width: 100px;
+            }
+            .child1 {
+                background-color: blue;
+            }
+            .child2 {
+                opacity: 0.5;
+                background-color: yellow;
+            }
+            .child3 {
+                background-color: red;
+            }
+            .child4 {
+                background-color: green;
+            }
+        </style>
+    </head>
+    <body>
+        <div class="right">
+            <div class="below">
+                <div class="container">
+                    <div class="child1">
+                        <div class="child2">
+                            <div class="child3">
+                                <div class="child4">
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </body>
+</html>
+

--- a/LayoutTests/compositing/reflections/opacity-in-reflection.html
+++ b/LayoutTests/compositing/reflections/opacity-in-reflection.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <style>
+            .right {
+                position: relative;
+                width: 150px;
+                height: 150px;
+                -webkit-box-reflect: right 10px;
+            }
+            .below {
+                width: 150px;
+                height: 150px;
+                -webkit-box-reflect: below 10px;
+            }
+            .container {
+                height: 100px;
+                width: 100px;
+                background-color: green;
+                opacity: 0.5;
+                will-change: transform;
+            }
+            .container div {
+                position: relative;
+                top: 10px;
+                left: 10px;
+                height: 100px;
+                width: 100px;
+                will-change: transform;
+            }
+            .child1 {
+                background-color: blue;
+            }
+            .child2 {
+                opacity: 0.5;
+                background-color: yellow;
+            }
+            .child3 {
+                background-color: red;
+            }
+            .child4 {
+                background-color: green;
+            }
+        </style>
+    </head>
+    <body>
+        <div class="right">
+            <div class="below">
+                <div class="container">
+                    <div class="child1">
+                        <div class="child2">
+                            <div class="child3">
+                                <div class="child4">
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </body>
+</html>
+

--- a/LayoutTests/compositing/tiling/huge-layer-with-opacity-expected.html
+++ b/LayoutTests/compositing/tiling/huge-layer-with-opacity-expected.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <style>
+            html {
+                overflow: hidden;
+            }
+            div {
+                width: 1000px;
+                height: 1000px;
+                background: green;
+                border: 10px solid blue;
+                opacity: 0.5;
+                will-change: transform;
+            }
+        </style>
+    </head>
+    <body>
+        Rendering a huge opacity layer shouldn't crash <a href="https://webkit.org/b/214817">Bug 214817</a>.
+        <div>
+            <div>
+                <div></div>
+            </div>
+        </div>
+    </body>
+</html>

--- a/LayoutTests/compositing/tiling/huge-layer-with-opacity.html
+++ b/LayoutTests/compositing/tiling/huge-layer-with-opacity.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <style>
+            html {
+                overflow: hidden;
+            }
+            div {
+                width: 100000px;
+                height: 100000px;
+                background: green;
+                border: 10px solid blue;
+                opacity: 0.5;
+                will-change: transform;
+            }
+        </style>
+    </head>
+    <body>
+        Rendering a huge opacity layer shouldn't crash <a href="https://webkit.org/b/214817">Bug 214817</a>.
+        <div>
+            <div>
+                <div></div>
+            </div>
+        </div>
+    </body>
+</html>

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
@@ -291,18 +291,18 @@ void TextureMapperLayer::computeOverlapRegions(const TextureMapperPaintOptions& 
     if (!m_state.visible || !m_state.contentsVisible)
         return;
 
-    FloatRect boundingRect;
+    FloatRect localBoundingRect;
     if (m_backingStore || m_state.masksToBounds || m_state.maskLayer || hasFilters())
-        boundingRect = layerRect();
+        localBoundingRect = layerRect();
     else if (m_contentsLayer || m_state.solidColor.isVisible())
-        boundingRect = m_state.contentsRect;
+        localBoundingRect = m_state.contentsRect;
 
     if (m_currentFilters.hasOutsets()) {
         auto outsets = m_currentFilters.outsets();
-        IntRect unfilteredTargetRect(boundingRect);
-        boundingRect.move(std::max(0, -outsets.left()), std::max(0, -outsets.top()));
-        boundingRect.expand(outsets.left() + outsets.right(), outsets.top() + outsets.bottom());
-        boundingRect.unite(unfilteredTargetRect);
+        IntRect unfilteredTargetRect(localBoundingRect);
+        localBoundingRect.move(std::max(0, -outsets.left()), std::max(0, -outsets.top()));
+        localBoundingRect.expand(outsets.left() + outsets.right(), outsets.top() + outsets.bottom());
+        localBoundingRect.unite(unfilteredTargetRect);
     }
 
     TransformationMatrix transform;
@@ -312,21 +312,25 @@ void TextureMapperLayer::computeOverlapRegions(const TextureMapperPaintOptions& 
     TransformationMatrix replicaMatrix;
     if (m_state.replicaLayer) {
         replicaMatrix = replicaTransform();
-        boundingRect.unite(replicaMatrix.mapRect(boundingRect));
+        localBoundingRect.unite(replicaMatrix.mapRect(localBoundingRect));
     }
 
-    boundingRect = transform.mapRect(boundingRect);
+    IntRect clipBounds(options.textureMapper.clipBounds());
+    clipBounds.move(-options.offset);
+
+    IntRect viewportBoundingRect = enclosingIntRect(transform.mapRect(localBoundingRect));
+    viewportBoundingRect.intersect(clipBounds);
 
     // Count all masks and filters as overlap layers.
     if (hasFilters() || m_state.maskLayer || (m_state.replicaLayer && m_state.replicaLayer->m_state.maskLayer)) {
-        Region newOverlapRegion(enclosingIntRect(boundingRect));
+        Region newOverlapRegion(viewportBoundingRect);
         nonOverlapRegion.subtract(newOverlapRegion);
         overlapRegion.unite(newOverlapRegion);
         return;
     }
 
     Region newOverlapRegion;
-    Region newNonOverlapRegion(enclosingIntRect(boundingRect));
+    Region newNonOverlapRegion(viewportBoundingRect);
 
     if (!m_state.masksToBounds) {
         for (auto* child : m_children)
@@ -369,9 +373,6 @@ void TextureMapperLayer::paintUsingOverlapRegions(const TextureMapperPaintOption
     auto rects = nonOverlapRegion.rects();
 
     for (auto& rect : rects) {
-        if (!rect.intersects(options.textureMapper.clipBounds()))
-            continue;
-
         options.textureMapper.beginClip(TransformationMatrix(), rect);
         paintSelfAndChildrenWithReplica(options);
         options.textureMapper.endClip();
@@ -385,15 +386,11 @@ void TextureMapperLayer::paintUsingOverlapRegions(const TextureMapperPaintOption
     }
 
     IntSize maxTextureSize = options.textureMapper.maxTextureSize();
-    IntRect adjustedClipBounds(options.textureMapper.clipBounds());
-    adjustedClipBounds.move(-options.offset);
     for (auto& rect : rects) {
         for (int x = rect.x(); x < rect.maxX(); x += maxTextureSize.width()) {
             for (int y = rect.y(); y < rect.maxY(); y += maxTextureSize.height()) {
                 IntRect tileRect(IntPoint(x, y), maxTextureSize);
                 tileRect.intersect(rect);
-                if (!tileRect.intersects(adjustedClipBounds))
-                    continue;
 
                 paintWithIntermediateSurface(options, tileRect);
             }

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h
@@ -129,7 +129,7 @@ public:
         ResolveSelfOverlapAlways = 0,
         ResolveSelfOverlapIfNeeded
     };
-    void computeOverlapRegions(Region& overlapRegion, Region& nonOverlapRegion, ResolveSelfOverlapMode);
+    void computeOverlapRegions(const TextureMapperPaintOptions&, Region& overlapRegion, Region& nonOverlapRegion, ResolveSelfOverlapMode);
 
     void paintRecursive(const TextureMapperPaintOptions&);
     void paintUsingOverlapRegions(const TextureMapperPaintOptions&);


### PR DESCRIPTION
Backports of:

https://commits.webkit.org/231066@main
https://commits.webkit.org/231175@main

Fixes #852 by clipping the region when computing the overlay vs non-overlay regions.