### PR TITLE
Allow PlatformSpeechSynthesiser to report error code on failure

### DIFF
--- a/Source/WebCore/Modules/speech/SpeechSynthesis.cpp
+++ b/Source/WebCore/Modules/speech/SpeechSynthesis.cpp
@@ -41,6 +41,26 @@
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/NeverDestroyed.h>
 
+namespace {
+WebCore::SpeechSynthesisErrorCode toSpeechSynthesisErrorEventCode(WebCore::SpeechError error) {
+    switch(error) {
+        case WebCore::SpeechError::Canceled:               return WebCore::SpeechSynthesisErrorCode::Canceled;
+        case WebCore::SpeechError::Interrupted:            return WebCore::SpeechSynthesisErrorCode::Interrupted;
+        case WebCore::SpeechError::AudioBusy:              return WebCore::SpeechSynthesisErrorCode::AudioBusy;
+        case WebCore::SpeechError::AudioHardware:          return WebCore::SpeechSynthesisErrorCode::AudioHardware;
+        case WebCore::SpeechError::Network:                return WebCore::SpeechSynthesisErrorCode::Network;
+        case WebCore::SpeechError::SynthesisUnavailable:   return WebCore::SpeechSynthesisErrorCode::SynthesisUnavailable;
+        case WebCore::SpeechError::SynthesisFailed:        return WebCore::SpeechSynthesisErrorCode::SynthesisFailed;
+        case WebCore::SpeechError::LanguageUnavailable:    return WebCore::SpeechSynthesisErrorCode::LanguageUnavailable;
+        case WebCore::SpeechError::VoiceUnavailable:       return WebCore::SpeechSynthesisErrorCode::VoiceUnavailable;
+        case WebCore::SpeechError::TextTooLong:            return WebCore::SpeechSynthesisErrorCode::TextTooLong;
+        case WebCore::SpeechError::InvalidArgument:        return WebCore::SpeechSynthesisErrorCode::InvalidArgument;
+        case WebCore::SpeechError::NotAllowed:             return WebCore::SpeechSynthesisErrorCode::NotAllowed;
+        default: ASSERT(false, "Invalid SpeechError code"); return WebCore::SpeechSynthesisErrorCode::Interrupted;
+    }
+}
+} // namespace
+
 namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(SpeechSynthesis);
@@ -207,18 +227,21 @@ void SpeechSynthesis::fireErrorEvent(const AtomString& type, SpeechSynthesisUtte
     utterance.dispatchEvent(SpeechSynthesisErrorEvent::create(type, { { &utterance, 0, 0, static_cast<float>((MonotonicTime::now() - utterance.startTime()).seconds()), { } }, errorCode }));
 }
 
-void SpeechSynthesis::handleSpeakingCompleted(SpeechSynthesisUtterance& utterance, bool errorOccurred)
+void SpeechSynthesis::handleSpeakingCompleted(SpeechSynthesisUtterance& utterance, bool errorOccurred, SpeechError error)
 {
     ASSERT(m_currentSpeechUtterance);
     Ref<SpeechSynthesisUtterance> protect(utterance);
 
-    m_currentSpeechUtterance = nullptr;
+    if (m_currentSpeechUtterance == &utterance)
+        m_currentSpeechUtterance = nullptr;
 
-    if (errorOccurred)
-        fireErrorEvent(eventNames().errorEvent, utterance, SpeechSynthesisErrorCode::Canceled);
-    else
-        fireEvent(eventNames().endEvent, utterance, 0, 0, String());
-    
+    if (errorOccurred && error != SpeechError::None) {
+        fireErrorEvent(eventNames().errorEvent, utterance, toSpeechSynthesisErrorEventCode(error));
+    } else {
+        // If error occured but no error code wass provided trigger error evt with old style SpeechSynthesisEvent
+        fireEvent(errorOccurred ? eventNames().errorEvent : eventNames().endEvent, utterance, 0, 0, String());
+    }
+
     if (m_utteranceQueue.size()) {
         Ref<SpeechSynthesisUtterance> firstUtterance = m_utteranceQueue.takeFirst();
         ASSERT(&utterance == firstUtterance.ptr());
@@ -280,7 +303,7 @@ void SpeechSynthesis::speakingErrorOccurred()
 {
     if (!m_currentSpeechUtterance)
         return;
-    speakingErrorOccurred(*m_currentSpeechUtterance->platformUtterance());
+    speakingErrorOccurred(*m_currentSpeechUtterance->platformUtterance(), SpeechError::None);
 }
 
 void SpeechSynthesis::boundaryEventOccurred(bool wordBoundary, unsigned charIndex, unsigned charLength)
@@ -321,10 +344,10 @@ void SpeechSynthesis::didFinishSpeaking(PlatformSpeechSynthesisUtterance& uttera
         handleSpeakingCompleted(static_cast<SpeechSynthesisUtterance&>(*utterance.client()), false);
 }
 
-void SpeechSynthesis::speakingErrorOccurred(PlatformSpeechSynthesisUtterance& utterance)
+void SpeechSynthesis::speakingErrorOccurred(PlatformSpeechSynthesisUtterance& utterance, SpeechError error)
 {
     if (utterance.client())
-        handleSpeakingCompleted(static_cast<SpeechSynthesisUtterance&>(*utterance.client()), true);
+        handleSpeakingCompleted(static_cast<SpeechSynthesisUtterance&>(*utterance.client()), true, error);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/speech/SpeechSynthesis.h
+++ b/Source/WebCore/Modules/speech/SpeechSynthesis.h
@@ -73,7 +73,7 @@ private:
     void didPauseSpeaking(PlatformSpeechSynthesisUtterance&) override;
     void didResumeSpeaking(PlatformSpeechSynthesisUtterance&) override;
     void didFinishSpeaking(PlatformSpeechSynthesisUtterance&) override;
-    void speakingErrorOccurred(PlatformSpeechSynthesisUtterance&) override;
+    void speakingErrorOccurred(PlatformSpeechSynthesisUtterance&, SpeechError) override;
     void boundaryEventOccurred(PlatformSpeechSynthesisUtterance&, SpeechBoundary, unsigned charIndex, unsigned charLength) override;
 
     // SpeechSynthesisClient override methods
@@ -84,9 +84,9 @@ private:
     void speakingErrorOccurred() override;
     void boundaryEventOccurred(bool wordBoundary, unsigned charIndex, unsigned charLength) override;
     void voicesChanged() override;
-    
+
     void startSpeakingImmediately(SpeechSynthesisUtterance&);
-    void handleSpeakingCompleted(SpeechSynthesisUtterance&, bool errorOccurred);
+    void handleSpeakingCompleted(SpeechSynthesisUtterance&, bool errorOccurred, SpeechError error = SpeechError::None);
     void fireEvent(const AtomString& type, SpeechSynthesisUtterance&, unsigned long charIndex, unsigned long charLength, const String& name) const;
     void fireErrorEvent(const AtomString& type, SpeechSynthesisUtterance&, SpeechSynthesisErrorCode) const;
 
@@ -99,14 +99,14 @@ private:
 
     bool userGestureRequiredForSpeechStart() const { return m_restrictions & RequireUserGestureForSpeechStartRestriction; }
     void removeBehaviorRestriction(BehaviorRestrictions restriction) { m_restrictions &= ~restriction; }
-    
+
     ScriptExecutionContext* scriptExecutionContext() const final { return ContextDestructionObserver::scriptExecutionContext(); }
     EventTargetInterface eventTargetInterface() const final { return SpeechSynthesisEventTargetInterfaceType; }
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
-    
+
     PlatformSpeechSynthesizer& ensurePlatformSpeechSynthesizer();
-    
+
     std::unique_ptr<PlatformSpeechSynthesizer> m_platformSpeechSynthesizer;
     Vector<Ref<SpeechSynthesisVoice>> m_voiceList;
     RefPtr<SpeechSynthesisUtterance> m_currentSpeechUtterance;

--- a/Source/WebCore/platform/PlatformSpeechSynthesizer.h
+++ b/Source/WebCore/platform/PlatformSpeechSynthesizer.h
@@ -38,6 +38,22 @@ OBJC_CLASS WebSpeechSynthesisWrapper;
 
 namespace WebCore {
 
+enum class SpeechError : uint8_t {
+    None,
+    Canceled,
+    Interrupted,
+    AudioBusy,
+    AudioHardware,
+    Network,
+    SynthesisUnavailable,
+    SynthesisFailed,
+    LanguageUnavailable,
+    VoiceUnavailable,
+    TextTooLong,
+    InvalidArgument,
+    NotAllowed
+};
+
 enum class SpeechBoundary : uint8_t {
     SpeechWordBoundary,
     SpeechSentenceBoundary
@@ -51,7 +67,7 @@ public:
     virtual void didFinishSpeaking(PlatformSpeechSynthesisUtterance&) = 0;
     virtual void didPauseSpeaking(PlatformSpeechSynthesisUtterance&) = 0;
     virtual void didResumeSpeaking(PlatformSpeechSynthesisUtterance&) = 0;
-    virtual void speakingErrorOccurred(PlatformSpeechSynthesisUtterance&) = 0;
+    virtual void speakingErrorOccurred(PlatformSpeechSynthesisUtterance&, SpeechError) = 0;
     virtual void boundaryEventOccurred(PlatformSpeechSynthesisUtterance&, SpeechBoundary, unsigned charIndex, unsigned charLength) = 0;
     virtual void voicesDidChange() = 0;
 protected:

--- a/Source/WebCore/platform/mac/PlatformSpeechSynthesizerMac.mm
+++ b/Source/WebCore/platform/mac/PlatformSpeechSynthesizerMac.mm
@@ -160,7 +160,7 @@
         return;
 
     [m_synthesizer stopSpeakingAtBoundary:NSSpeechImmediateBoundary];
-    m_synthesizerObject->client()->speakingErrorOccurred(*m_utterance);
+    m_synthesizerObject->client()->speakingErrorOccurred(*m_utterance, WebCore::SpeechError::None);
     m_utterance = 0;
 }
 
@@ -185,7 +185,7 @@
     if (finishedSpeaking)
         m_synthesizerObject->client()->didFinishSpeaking(*utterance);
     else
-        m_synthesizerObject->client()->speakingErrorOccurred(*utterance);
+        m_synthesizerObject->client()->speakingErrorOccurred(*utterance, WebCore::SpeechError::None);
 }
 
 - (void)speechSynthesizer:(NSSpeechSynthesizer *)sender willSpeakWord:(NSRange)characterRange ofString:(NSString *)string

--- a/Source/WebCore/platform/mock/PlatformSpeechSynthesizerMock.cpp
+++ b/Source/WebCore/platform/mock/PlatformSpeechSynthesizerMock.cpp
@@ -75,7 +75,7 @@ void PlatformSpeechSynthesizerMock::cancel()
         return;
 
     m_speakingFinishedTimer.stop();
-    client()->speakingErrorOccurred(*m_utterance);
+    client()->speakingErrorOccurred(*m_utterance, WebCore::SpeechError::Canceled);
     m_utterance = nullptr;
 }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -9715,7 +9715,7 @@ void WebPageProxy::didResumeSpeaking(WebCore::PlatformSpeechSynthesisUtterance&)
         speechSynthesisData().speakingResumedCompletionHandler();
 }
 
-void WebPageProxy::speakingErrorOccurred(WebCore::PlatformSpeechSynthesisUtterance&)
+void WebPageProxy::speakingErrorOccurred(WebCore::PlatformSpeechSynthesisUtterance&, WebCore::SpeechError)
 {
     send(Messages::WebPage::SpeakingErrorOccurred());
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2225,7 +2225,7 @@ private:
     void didFinishSpeaking(WebCore::PlatformSpeechSynthesisUtterance&) override;
     void didPauseSpeaking(WebCore::PlatformSpeechSynthesisUtterance&) override;
     void didResumeSpeaking(WebCore::PlatformSpeechSynthesisUtterance&) override;
-    void speakingErrorOccurred(WebCore::PlatformSpeechSynthesisUtterance&) override;
+    void speakingErrorOccurred(WebCore::PlatformSpeechSynthesisUtterance&, WebCore::SpeechError) override;
     void boundaryEventOccurred(WebCore::PlatformSpeechSynthesisUtterance&, WebCore::SpeechBoundary, unsigned charIndex, unsigned charLength) override;
     void voicesDidChange() override;
 


### PR DESCRIPTION
Extend speakingErrorOccurred() of PlatformSpeechSynthesizerClient
with SpeechError code that reflects the source of failure.