### PR TITLE
Use timer instead of DocumentAnimationScheduler for scheduling reques…

### DIFF
--- a/Source/WebCore/dom/ScriptedAnimationController.h
+++ b/Source/WebCore/dom/ScriptedAnimationController.h
@@ -93,7 +93,7 @@ private:
 
 #if USE(REQUEST_ANIMATION_FRAME_DISPLAY_MONITOR)
     OptionSet<ThrottlingReason> m_throttlingReasons;
-    bool m_isUsingTimer { false };
+    bool m_isUsingTimer { true };
 #endif
 };
 


### PR DESCRIPTION
…tAnimationFrame

Using DocumentAnimationScheduler has a side-effect of pushing new frames to compositor all the time while RAF is scheduled.
With timer, new frames are only pushed when there are actual changes requiring redraw