### PR TITLE
WebSpeech: Update event constructor idl

### DIFF
--- a/Source/WebCore/Modules/speech/SpeechSynthesisErrorEvent.idl
+++ b/Source/WebCore/Modules/speech/SpeechSynthesisErrorEvent.idl
@@ -26,9 +26,8 @@
 // https://wicg.github.io/speech-api/#speechsynthesiserrorevent
 [
     Conditional=SPEECH_SYNTHESIS,
-    Exposed=Window
+    Exposed=Window,
+    Constructor(DOMString type, SpeechSynthesisErrorEventInit eventInitDict)
 ] interface SpeechSynthesisErrorEvent : SpeechSynthesisEvent {
-    constructor(DOMString type, SpeechSynthesisErrorEventInit eventInitDict);
-
     readonly attribute SpeechSynthesisErrorCode error;
 };

--- a/Source/WebCore/Modules/speech/SpeechSynthesisEvent.idl
+++ b/Source/WebCore/Modules/speech/SpeechSynthesisEvent.idl
@@ -24,10 +24,9 @@
  */
  
 [
-    Conditional=SPEECH_SYNTHESIS
+    Conditional=SPEECH_SYNTHESIS,
+    Constructor(DOMString type, SpeechSynthesisEventInit eventInitDict)
 ] interface SpeechSynthesisEvent : Event {
-    constructor(DOMString type, SpeechSynthesisEventInit eventInitDict);
-
     readonly attribute SpeechSynthesisUtterance utterance;
     readonly attribute unsigned long charIndex;
     readonly attribute unsigned long charLength;


### PR DESCRIPTION
These event classes were added in
c35817724cc13e01b2e7c3554d025c7f9b6e98b7, using a newer IDL syntax where
the constructor is declared inside the element body.

This was leading to their constructor not being properly generated,
causing the respective WPT suite to fail.

http://wpt.live/speech-api/SpeechSynthesisEvent-constructor.html
http://wpt.live/speech-api/SpeechSynthesisErrorEvent-constructor.html

For reference, the move to constructor as members was done upstream in
June 2020 in https://bugs.webkit.org/show_bug.cgi?id=201397.

cc @asurdej-comcast 