### PR TITLE
Use optional for speech error enum

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -109,6 +109,16 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/plugins/PluginReplacement.h
     Modules/plugins/YouTubePluginReplacement.h
 
+    Modules/speech/DOMWindowSpeechSynthesis.h
+    Modules/speech/SpeechSynthesisErrorCode.h
+    Modules/speech/SpeechSynthesisErrorEvent.h
+    Modules/speech/SpeechSynthesisErrorEventInit.h
+    Modules/speech/SpeechSynthesisEvent.h
+    Modules/speech/SpeechSynthesisEventInit.h
+    Modules/speech/SpeechSynthesis.h
+    Modules/speech/SpeechSynthesisUtterance.h
+    Modules/speech/SpeechSynthesisVoice.h
+
     Modules/streams/ReadableStreamChunk.h
     Modules/streams/ReadableStreamSink.h
     Modules/streams/ReadableStreamSource.h

--- a/Source/WebCore/Modules/speech/SpeechSynthesis.h
+++ b/Source/WebCore/Modules/speech/SpeechSynthesis.h
@@ -73,7 +73,7 @@ private:
     void didPauseSpeaking(PlatformSpeechSynthesisUtterance&) override;
     void didResumeSpeaking(PlatformSpeechSynthesisUtterance&) override;
     void didFinishSpeaking(PlatformSpeechSynthesisUtterance&) override;
-    void speakingErrorOccurred(PlatformSpeechSynthesisUtterance&, SpeechError) override;
+    void speakingErrorOccurred(PlatformSpeechSynthesisUtterance&, Optional<SpeechSynthesisErrorCode>) override;
     void boundaryEventOccurred(PlatformSpeechSynthesisUtterance&, SpeechBoundary, unsigned charIndex, unsigned charLength) override;
 
     // SpeechSynthesisClient override methods
@@ -86,7 +86,7 @@ private:
     void voicesChanged() override;
 
     void startSpeakingImmediately(SpeechSynthesisUtterance&);
-    void handleSpeakingCompleted(SpeechSynthesisUtterance&, bool errorOccurred, SpeechError error = SpeechError::None);
+    void handleSpeakingCompleted(SpeechSynthesisUtterance&, bool errorOccurred, Optional<SpeechSynthesisErrorCode> = WTF::nullopt);
     void fireEvent(const AtomString& type, SpeechSynthesisUtterance&, unsigned long charIndex, unsigned long charLength, const String& name) const;
     void fireErrorEvent(const AtomString& type, SpeechSynthesisUtterance&, SpeechSynthesisErrorCode) const;
 

--- a/Source/WebCore/platform/PlatformSpeechSynthesizer.h
+++ b/Source/WebCore/platform/PlatformSpeechSynthesizer.h
@@ -29,6 +29,8 @@
 #if ENABLE(SPEECH_SYNTHESIS)
 
 #include "PlatformSpeechSynthesisVoice.h"
+#include "SpeechSynthesisErrorCode.h"
+#include <wtf/Optional.h>
 #include <wtf/Vector.h>
 
 #if PLATFORM(COCOA)
@@ -37,22 +39,6 @@ OBJC_CLASS WebSpeechSynthesisWrapper;
 #endif
 
 namespace WebCore {
-
-enum class SpeechError : uint8_t {
-    None,
-    Canceled,
-    Interrupted,
-    AudioBusy,
-    AudioHardware,
-    Network,
-    SynthesisUnavailable,
-    SynthesisFailed,
-    LanguageUnavailable,
-    VoiceUnavailable,
-    TextTooLong,
-    InvalidArgument,
-    NotAllowed
-};
 
 enum class SpeechBoundary : uint8_t {
     SpeechWordBoundary,
@@ -67,7 +53,7 @@ public:
     virtual void didFinishSpeaking(PlatformSpeechSynthesisUtterance&) = 0;
     virtual void didPauseSpeaking(PlatformSpeechSynthesisUtterance&) = 0;
     virtual void didResumeSpeaking(PlatformSpeechSynthesisUtterance&) = 0;
-    virtual void speakingErrorOccurred(PlatformSpeechSynthesisUtterance&, SpeechError) = 0;
+    virtual void speakingErrorOccurred(PlatformSpeechSynthesisUtterance&, Optional<SpeechSynthesisErrorCode>) = 0;
     virtual void boundaryEventOccurred(PlatformSpeechSynthesisUtterance&, SpeechBoundary, unsigned charIndex, unsigned charLength) = 0;
     virtual void voicesDidChange() = 0;
 protected:

--- a/Source/WebCore/platform/mac/PlatformSpeechSynthesizerMac.mm
+++ b/Source/WebCore/platform/mac/PlatformSpeechSynthesizerMac.mm
@@ -160,7 +160,7 @@
         return;
 
     [m_synthesizer stopSpeakingAtBoundary:NSSpeechImmediateBoundary];
-    m_synthesizerObject->client()->speakingErrorOccurred(*m_utterance, WebCore::SpeechError::None);
+    m_synthesizerObject->client()->speakingErrorOccurred(*m_utterance, WTF::nullopt);
     m_utterance = 0;
 }
 
@@ -185,7 +185,7 @@
     if (finishedSpeaking)
         m_synthesizerObject->client()->didFinishSpeaking(*utterance);
     else
-        m_synthesizerObject->client()->speakingErrorOccurred(*utterance, WebCore::SpeechError::None);
+        m_synthesizerObject->client()->speakingErrorOccurred(*utterance, WTF::nullopt);
 }
 
 - (void)speechSynthesizer:(NSSpeechSynthesizer *)sender willSpeakWord:(NSRange)characterRange ofString:(NSString *)string

--- a/Source/WebCore/platform/mock/PlatformSpeechSynthesizerMock.cpp
+++ b/Source/WebCore/platform/mock/PlatformSpeechSynthesizerMock.cpp
@@ -75,7 +75,7 @@ void PlatformSpeechSynthesizerMock::cancel()
         return;
 
     m_speakingFinishedTimer.stop();
-    client()->speakingErrorOccurred(*m_utterance, WebCore::SpeechError::Canceled);
+    client()->speakingErrorOccurred(*m_utterance, WebCore::SpeechSynthesisErrorCode::Canceled);
     m_utterance = nullptr;
 }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -9730,7 +9730,7 @@ void WebPageProxy::didResumeSpeaking(WebCore::PlatformSpeechSynthesisUtterance&)
         speechSynthesisData().speakingResumedCompletionHandler();
 }
 
-void WebPageProxy::speakingErrorOccurred(WebCore::PlatformSpeechSynthesisUtterance&, WebCore::SpeechError)
+void WebPageProxy::speakingErrorOccurred(WebCore::PlatformSpeechSynthesisUtterance&, Optional<WebCore::SpeechSynthesisErrorCode>)
 {
     send(Messages::WebPage::SpeakingErrorOccurred());
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -218,6 +218,7 @@ enum class NotificationDirection : uint8_t;
 enum class RouteSharingPolicy : uint8_t;
 enum class ShouldSample : bool;
 enum class ShouldTreatAsContinuingLoad : bool;
+enum class SpeechSynthesisErrorCode;
 enum class WritingDirection : uint8_t;
 
 struct ApplicationManifest;
@@ -2227,7 +2228,7 @@ private:
     void didFinishSpeaking(WebCore::PlatformSpeechSynthesisUtterance&) override;
     void didPauseSpeaking(WebCore::PlatformSpeechSynthesisUtterance&) override;
     void didResumeSpeaking(WebCore::PlatformSpeechSynthesisUtterance&) override;
-    void speakingErrorOccurred(WebCore::PlatformSpeechSynthesisUtterance&, WebCore::SpeechError) override;
+    void speakingErrorOccurred(WebCore::PlatformSpeechSynthesisUtterance&, Optional<WebCore::SpeechSynthesisErrorCode>) override;
     void boundaryEventOccurred(WebCore::PlatformSpeechSynthesisUtterance&, WebCore::SpeechBoundary, unsigned charIndex, unsigned charLength) override;
     void voicesDidChange() override;
 


### PR DESCRIPTION
When thinking of upstreaming #863, I realized `SpeechError` could be replaced with an `Optional<SpeechSynthesisErrorCode>` to avoid duplicating the enum values.

Note: When upstreaming, `WTF::Optional` would be replaced with `std::optional`.

cc @asurdej-comcast