### PR TITLE
[MSE] fix browser hang caused by recursive MediaSource::completeSeek

### DIFF
--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -280,7 +280,8 @@ void MediaSource::completeSeek()
     // 4. Resume the seek algorithm at the "Await a stable state" step.
     m_private->seekCompleted();
 
-    monitorSourceBuffers();
+    if (m_pendingSeekTime.isInvalid())
+        monitorSourceBuffers();
 }
 
 Ref<TimeRanges> MediaSource::seekable()


### PR DESCRIPTION
This happens when current media time (reported by HTMLMediaElement)
differs from the seek media time requested by the media player private.

For example if MediaSource::monitorSourceBuffers() is invoked after
HTMLMediaElement::seekWithTolerance() has updated
HTMLMediaElement::m_lastSeekTime but before actuall
HTMLMediaElement::seekTask() is executed.

Randomly reproducible on https://ytlr-cert.appspot.com/2021/main.html?&test_type=msecodec-test&tests=55&command=run .

Crash call stack:
```
...
#93504 0xb27b6c20 in WebCore::MediaSource::monitorSourceBuffers () at /usr/src/debug/wpe-webkit/2.28+gitAUTOINC+aa569f0366-r0/git/Source/WebCore/Modules/mediasource/MediaSource.cpp:489
#93505 0xb27b6b34 in WebCore::MediaSource::completeSeek () at /usr/src/debug/wpe-webkit/2.28+gitAUTOINC+aa569f0366-r0/git/Source/WebCore/Modules/mediasource/MediaSource.cpp:283
#93506 WebCore::MediaSource::completeSeek () at /usr/src/debug/wpe-webkit/2.28+gitAUTOINC+aa569f0366-r0/git/Source/WebCore/Modules/mediasource/MediaSource.cpp:259
#93507 0xb27b6c20 in WebCore::MediaSource::monitorSourceBuffers () at /usr/src/debug/wpe-webkit/2.28+gitAUTOINC+aa569f0366-r0/git/Source/WebCore/Modules/mediasource/MediaSource.cpp:489
#93508 0xb27b6b34 in WebCore::MediaSource::completeSeek () at /usr/src/debug/wpe-webkit/2.28+gitAUTOINC+aa569f0366-r0/git/Source/WebCore/Modules/mediasource/MediaSource.cpp:283
#93509 WebCore::MediaSource::completeSeek () at /usr/src/debug/wpe-webkit/2.28+gitAUTOINC+aa569f0366-r0/git/Source/WebCore/Modules/mediasource/MediaSource.cpp:259
#93510 0xb27b6c20 in WebCore::MediaSource::monitorSourceBuffers () at /usr/src/debug/wpe-webkit/2.28+gitAUTOINC+aa569f0366-r0/git/Source/WebCore/Modules/mediasource/MediaSource.cpp:489
#93511 0xb27b6b34 in WebCore::MediaSource::completeSeek () at /usr/src/debug/wpe-webkit/2.28+gitAUTOINC+aa569f0366-r0/git/Source/WebCore/Modules/mediasource/MediaSource.cpp:283
#93512 WebCore::MediaSource::completeSeek () at /usr/src/debug/wpe-webkit/2.28+gitAUTOINC+aa569f0366-r0/git/Source/WebCore/Modules/mediasource/MediaSource.cpp:259
#93513 0xb27b6c20 in WebCore::MediaSource::monitorSourceBuffers () at /usr/src/debug/wpe-webkit/2.28+gitAUTOINC+aa569f0366-r0/git/Source/WebCore/Modules/mediasource/MediaSource.cpp:489
#93514 0xb2afffd6 in WebCore::HTMLMediaElement::playbackProgressTimerFired () at /usr/src/debug/wpe-webkit/2.28+gitAUTOINC+aa569f0366-r0/git/Source/WebCore/html/HTMLMediaElement.cpp:3987
#93515 WebCore::HTMLMediaElement::playbackProgressTimerFired () at /usr/src/debug/wpe-webkit/2.28+gitAUTOINC+aa569f0366-r0/git/Source/WebCore/html/HTMLMediaElement.cpp:3961
#93516 0xb2d21f84 in WebCore::ThreadTimers::sharedTimerFiredInternal () at /usr/src/debug/wpe-webkit/2.28+gitAUTOINC+aa569f0366-r0/git/Source/WebCore/platform/ThreadTimers.cpp:129
#93517 WebCore::ThreadTimers::sharedTimerFiredInternal () at /usr/src/debug/wpe-webkit/2.28+gitAUTOINC+aa569f0366-r0/git/Source/WebCore/platform/ThreadTimers.cpp:101
#93518 0xb383da7c in operator() () at /usr/src/debug/wpe-webkit/2.28+gitAUTOINC+aa569f0366-r0/git/Source/WTF/wtf/glib/RunLoopGLib.cpp:177
#93519 _FUN () at /usr/src/debug/wpe-webkit/2.28+gitAUTOINC+aa569f0366-r0/git/Source/WTF/wtf/glib/RunLoopGLib.cpp:183
#93520 0xb0d18864 in g_main_dispatch (context=...) at ../glib-2.62.4/glib/gmain.c:3216
#93521 g_main_context_dispatch (context=...) at ../glib-2.62.4/glib/gmain.c:3885
#93522 0xb0d189ce in g_main_context_iterate (context=..., block=..., dispatch=..., self=...) at ../glib-2.62.4/glib/gmain.c:3958
#93523 0xb0d18d08 in g_main_loop_run (loop=...) at ../glib-2.62.4/glib/gmain.c:4152
#93524 0xb383de24 in WTF::RunLoop::run () at /usr/src/debug/wpe-webkit/2.28+gitAUTOINC+aa569f0366-r0/git/Source/WTF/wtf/glib/RunLoopGLib.cpp:96
#93525 0xb23fc876 in WebKit::AuxiliaryProcessMain<WebKit::WebProcess, WebKit::WebProcessMainWPE> () at /usr/src/debug/wpe-webkit/2.28+gitAUTOINC+aa569f0366-r0/git/Source/WebKit/Shared/AuxiliaryProcessMain.h:68
#93526 0xb1de198e in __libc_start_main (main=..., argc=..., argv=..., init=..., fini=..., rtld_fini=..., stack_end=...) at libc-start.c:308

```
