### PR TITLE
Backport ability to prevent scrolling in `Element.focus()`

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -716,6 +716,7 @@ set(WebCore_NON_SVG_IDL_FILES
     dom/EventModifierInit.idl
     dom/EventTarget.idl
     dom/FocusEvent.idl
+    dom/FocusOptions.idl
     dom/GlobalEventHandlers.idl
     dom/HashChangeEvent.idl
     dom/IdleDeadline.idl

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -614,6 +614,7 @@ JS_BINDING_IDLS = \
     $(WebCore)/dom/EventModifierInit.idl \
     $(WebCore)/dom/EventTarget.idl \
     $(WebCore)/dom/FocusEvent.idl \
+    $(WebCore)/dom/FocusOptions.idl \
     $(WebCore)/dom/GlobalEventHandlers.idl \
     $(WebCore)/dom/HashChangeEvent.idl \
     $(WebCore)/dom/IdleDeadline.idl \

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -418,6 +418,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     dom/ExceptionCode.h
     dom/ExceptionData.h
     dom/ExceptionOr.h
+    dom/FocusOptions.h
     dom/FragmentScriptingPermission.h
     dom/FullscreenManager.h
     dom/GCReachableRef.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2879,6 +2879,7 @@ JSFileSystemEntryCallback.cpp
 JSFileSystemFileEntry.cpp
 JSFillMode.cpp
 JSFocusEvent.cpp
+JSFocusOptions.cpp
 JSFontFace.cpp
 JSFontFaceSet.cpp
 JSGetAnimationsOptions.cpp

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2955,7 +2955,7 @@ static RefPtr<Element> findFirstProgramaticallyFocusableElementInComposedTree(El
     return nullptr;
 }
 
-void Element::focus(bool restorePreviousSelection, FocusDirection direction)
+void Element::focus(const FocusOptions& options)
 {
     if (!isConnected())
         return;
@@ -2996,7 +2996,7 @@ void Element::focus(bool restorePreviousSelection, FocusDirection direction)
         // Focus and change event handlers can cause us to lose our last ref.
         // If a focus event handler changes the focus to a different node it
         // does not make sense to continue and update appearence.
-        if (!page->focusController().setFocusedElement(newTarget.get(), *document->frame(), direction))
+        if (!page->focusController().setFocusedElement(newTarget.get(), *document->frame(), options.direction))
             return;
     }
 
@@ -3014,7 +3014,8 @@ void Element::focus(bool restorePreviousSelection, FocusDirection direction)
     if (!target)
         return;
 
-    target->updateFocusAppearance(restorePreviousSelection ? SelectionRestorationMode::Restore : SelectionRestorationMode::SetDefault, revealMode);
+    if (!options.preventScroll)
+        target->updateFocusAppearance(options.restorePreviousSelection ? SelectionRestorationMode::Restore : SelectionRestorationMode::SetDefault, revealMode);
 }
 
 // https://html.spec.whatwg.org/#focus-processing-model

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -27,6 +27,7 @@
 #include "AXTextStateChangeIntent.h"
 #include "Document.h"
 #include "ElementData.h"
+#include "FocusOptions.h"
 #include "HTMLNames.h"
 #include "ScrollTypes.h"
 #include "ShadowRootMode.h"
@@ -396,7 +397,7 @@ public:
     virtual String target() const { return String(); }
 
     static AXTextStateChangeIntent defaultFocusTextStateChangeIntent() { return AXTextStateChangeIntent(AXTextStateChangeTypeSelectionMove, AXTextSelection { AXTextSelectionDirectionDiscontiguous, AXTextSelectionGranularityUnknown, true }); }
-    virtual void focus(bool restorePreviousSelection = true, FocusDirection = FocusDirectionNone);
+    virtual void focus(const FocusOptions& = { });
     virtual RefPtr<Element> focusAppearanceUpdateTarget();
     virtual void updateFocusAppearance(SelectionRestorationMode, SelectionRevealMode = SelectionRevealMode::Reveal);
     virtual void blur();

--- a/Source/WebCore/dom/FocusOptions.h
+++ b/Source/WebCore/dom/FocusOptions.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Igalia S.L. All rights reserved.
+ * Copyright (C) 2020 Igalia S.L. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,14 +23,16 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-// https://html.spec.whatwg.org/multipage/dom.html#htmlorsvgelement
-// FIXME: update above link when this change has been implemented:
-// https://github.com/whatwg/html/issues/4702
-[
-    NoInterfaceObject,
-] interface HTMLOrForeignElement {
-    readonly attribute DOMStringMap dataset; // FIXME: Should be [SameObject].
-    [CEReactions, ImplementedAs=tabIndexForBindings] attribute long tabIndex;
-    void focus(optional FocusOptions options);
-    void blur();
+#pragma once
+
+#include "FocusDirection.h"
+
+namespace WebCore {
+
+struct FocusOptions {
+    bool restorePreviousSelection { true };
+    FocusDirection direction { FocusDirectionNone };
+    bool preventScroll { false };
 };
+
+} // namespace WebCore

--- a/Source/WebCore/dom/FocusOptions.idl
+++ b/Source/WebCore/dom/FocusOptions.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Igalia S.L. All rights reserved.
+ * Copyright (C) 2020 Igalia S.L. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,14 +23,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-// https://html.spec.whatwg.org/multipage/dom.html#htmlorsvgelement
-// FIXME: update above link when this change has been implemented:
-// https://github.com/whatwg/html/issues/4702
-[
-    NoInterfaceObject,
-] interface HTMLOrForeignElement {
-    readonly attribute DOMStringMap dataset; // FIXME: Should be [SameObject].
-    [CEReactions, ImplementedAs=tabIndexForBindings] attribute long tabIndex;
-    void focus(optional FocusOptions options);
-    void blur();
+dictionary FocusOptions {
+   boolean preventScroll = false;
 };

--- a/Source/WebCore/html/HTMLLabelElement.cpp
+++ b/Source/WebCore/html/HTMLLabelElement.cpp
@@ -172,21 +172,21 @@ bool HTMLLabelElement::willRespondToMouseClickEvents()
     return (element && element->willRespondToMouseClickEvents()) || HTMLElement::willRespondToMouseClickEvents();
 }
 
-void HTMLLabelElement::focus(bool restorePreviousSelection, FocusDirection direction)
+void HTMLLabelElement::focus(const FocusOptions& options)
 {
     Ref<HTMLLabelElement> protectedThis(*this);
     if (document().haveStylesheetsLoaded()) {
         document().updateLayout();
         if (isFocusable()) {
             // The value of restorePreviousSelection is not used for label elements as it doesn't override updateFocusAppearance.
-            Element::focus(restorePreviousSelection, direction);
+            Element::focus(options);
             return;
         }
     }
 
     // To match other browsers, always restore previous selection.
     if (auto element = control())
-        element->focus(true, direction);
+        element->focus({ true, options.direction });
 }
 
 void HTMLLabelElement::accessKeyAction(bool sendMouseEvents)

--- a/Source/WebCore/html/HTMLLabelElement.h
+++ b/Source/WebCore/html/HTMLLabelElement.h
@@ -51,7 +51,7 @@ private:
     // Overridden to either click() or focus() the corresponding control.
     void defaultEventHandler(Event&) final;
 
-    void focus(bool restorePreviousSelection, FocusDirection) final;
+    void focus(const FocusOptions&) final;
 
     bool isInteractiveContent() const final { return true; }
 };

--- a/Source/WebCore/html/HTMLLegendElement.cpp
+++ b/Source/WebCore/html/HTMLLegendElement.cpp
@@ -57,19 +57,19 @@ RefPtr<HTMLFormControlElement> HTMLLegendElement::associatedControl()
     return descendantsOfType<HTMLFormControlElement>(*enclosingFieldset).first();
 }
 
-void HTMLLegendElement::focus(bool restorePreviousSelection, FocusDirection direction)
+void HTMLLegendElement::focus(const FocusOptions& options)
 {
     if (document().haveStylesheetsLoaded()) {
         document().updateLayoutIgnorePendingStylesheets();
         if (isFocusable()) {
-            Element::focus(restorePreviousSelection, direction);
+            Element::focus(options);
             return;
         }
     }
 
     // To match other browsers' behavior, never restore previous selection.
     if (auto control = associatedControl())
-        control->focus(false, direction);
+        control->focus({ false, options.direction });
 }
 
 void HTMLLegendElement::accessKeyAction(bool sendMouseEvents)

--- a/Source/WebCore/html/HTMLLegendElement.h
+++ b/Source/WebCore/html/HTMLLegendElement.h
@@ -43,7 +43,7 @@ private:
     RefPtr<HTMLFormControlElement> associatedControl();
 
     void accessKeyAction(bool sendMouseEvents) final;
-    void focus(bool restorePreviousSelection, FocusDirection) final;
+    void focus(const FocusOptions&) final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/InputType.cpp
+++ b/Source/WebCore/html/InputType.cpp
@@ -595,7 +595,7 @@ void InputType::handleBlurEvent()
 void InputType::accessKeyAction(bool)
 {
     ASSERT(element());
-    element()->focus(false);
+    element()->focus({ false });
 }
 
 void InputType::addSearchResult()

--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -520,7 +520,7 @@ bool FocusController::advanceFocusInDocumentOrder(FocusDirection direction, Keyb
         }
     }
 
-    element->focus(false, direction);
+    element->focus({ false, direction });
     return true;
 }
 
@@ -1092,7 +1092,7 @@ bool FocusController::advanceFocusDirectionallyInContainer(Node* container, cons
     Element* element = downcast<Element>(focusCandidate.focusableNode);
     ASSERT(element);
 
-    element->focus(false, direction);
+    element->focus({ false, direction });
     return true;
 }
 


### PR DESCRIPTION
Same as https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/770 but for `2.28` this time.

See 6f15b9669d3951f1bfa46d52dab68a2ab168339e in WebKit
See https://bugs.webkit.org/show_bug.cgi?id=178583

This commit fixes BBC Sounds app glitches related to scrolling

It can be tested using `ACT-1292 element-focus-supports-prevent-scroll` from `CSS` section, from https://certification.bbctvapps.co.uk/act/client/ test suite