### PR TITLE
Backport 'jump-*' step positions

### DIFF
--- a/Source/WebCore/css/CSSComputedStyleDeclaration.cpp
+++ b/Source/WebCore/css/CSSComputedStyleDeclaration.cpp
@@ -1278,7 +1278,7 @@ static Ref<CSSValue> createTimingFunctionValue(const TimingFunction& timingFunct
     }
     case TimingFunction::StepsFunction: {
         auto& function = downcast<StepsTimingFunction>(timingFunction);
-        return CSSStepsTimingFunctionValue::create(function.numberOfSteps(), function.stepAtStart());
+        return CSSStepsTimingFunctionValue::create(function.numberOfSteps(), function.stepPosition());
     }
     case TimingFunction::SpringFunction: {
         auto& function = downcast<SpringTimingFunction>(timingFunction);

--- a/Source/WebCore/css/CSSTimingFunctionValue.cpp
+++ b/Source/WebCore/css/CSSTimingFunctionValue.cpp
@@ -45,16 +45,36 @@ String CSSStepsTimingFunctionValue::customCSSText() const
     StringBuilder builder;
     builder.appendLiteral("steps(");
     builder.appendNumber(m_steps);
-    if (m_stepAtStart)
-        builder.appendLiteral(", start)");
-    else
-        builder.appendLiteral(", end)");
+    if (m_stepPosition) {
+        switch (m_stepPosition.value()) {
+        case StepsTimingFunction::StepPosition::JumpStart:
+            builder.appendLiteral(", jump-start");
+            break;
+
+        case StepsTimingFunction::StepPosition::JumpNone:
+            builder.appendLiteral(", jump-none");
+            break;
+
+        case StepsTimingFunction::StepPosition::JumpBoth:
+            builder.appendLiteral(", jump-both");
+            break;
+
+        case StepsTimingFunction::StepPosition::Start:
+            builder.appendLiteral(", start");
+            break;
+
+        case StepsTimingFunction::StepPosition::JumpEnd:
+        case StepsTimingFunction::StepPosition::End:
+            break;
+        }
+    }
+    builder.appendLiteral(")");
     return builder.toString();
 }
 
 bool CSSStepsTimingFunctionValue::equals(const CSSStepsTimingFunctionValue& other) const
 {
-    return m_steps == other.m_steps && m_stepAtStart == other.m_stepAtStart;
+    return m_steps == other.m_steps && m_stepPosition == other.m_stepPosition;
 }
 
 String CSSSpringTimingFunctionValue::customCSSText() const

--- a/Source/WebCore/css/CSSTimingFunctionValue.h
+++ b/Source/WebCore/css/CSSTimingFunctionValue.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "CSSValue.h"
+#include "TimingFunction.h"
 
 namespace WebCore {
 
@@ -63,28 +64,28 @@ private:
 
 class CSSStepsTimingFunctionValue final : public CSSValue {
 public:
-    static Ref<CSSStepsTimingFunctionValue> create(int steps, bool stepAtStart)
+    static Ref<CSSStepsTimingFunctionValue> create(int steps, Optional<StepsTimingFunction::StepPosition> stepPosition)
     {
-        return adoptRef(*new CSSStepsTimingFunctionValue(steps, stepAtStart));
+        return adoptRef(*new CSSStepsTimingFunctionValue(steps, stepPosition));
     }
 
     int numberOfSteps() const { return m_steps; }
-    bool stepAtStart() const { return m_stepAtStart; }
+    Optional<StepsTimingFunction::StepPosition> stepPosition() const { return m_stepPosition; }
 
     String customCSSText() const;
 
     bool equals(const CSSStepsTimingFunctionValue&) const;
 
 private:
-    CSSStepsTimingFunctionValue(int steps, bool stepAtStart)
+    CSSStepsTimingFunctionValue(int steps, Optional<StepsTimingFunction::StepPosition> stepPosition)
         : CSSValue(StepsTimingFunctionClass)
         , m_steps(steps)
-        , m_stepAtStart(stepAtStart)
+        , m_stepPosition(stepPosition)
     {
     }
 
     int m_steps;
-    bool m_stepAtStart;
+    Optional<StepsTimingFunction::StepPosition> m_stepPosition;
 };
 
 class CSSSpringTimingFunctionValue final : public CSSValue {

--- a/Source/WebCore/css/CSSToStyleMap.cpp
+++ b/Source/WebCore/css/CSSToStyleMap.cpp
@@ -478,10 +478,10 @@ void CSSToStyleMap::mapAnimationTimingFunction(Animation& animation, const CSSVa
             animation.setTimingFunction(CubicBezierTimingFunction::create(CubicBezierTimingFunction::EaseInOut));
             break;
         case CSSValueStepStart:
-            animation.setTimingFunction(StepsTimingFunction::create(1, true));
+            animation.setTimingFunction(StepsTimingFunction::create(1, StepsTimingFunction::StepPosition::Start));
             break;
         case CSSValueStepEnd:
-            animation.setTimingFunction(StepsTimingFunction::create(1, false));
+            animation.setTimingFunction(StepsTimingFunction::create(1, StepsTimingFunction::StepPosition::End));
             break;
         default:
             break;
@@ -494,7 +494,7 @@ void CSSToStyleMap::mapAnimationTimingFunction(Animation& animation, const CSSVa
         animation.setTimingFunction(CubicBezierTimingFunction::create(cubicTimingFunction.x1(), cubicTimingFunction.y1(), cubicTimingFunction.x2(), cubicTimingFunction.y2()));
     } else if (is<CSSStepsTimingFunctionValue>(value)) {
         auto& stepsTimingFunction = downcast<CSSStepsTimingFunctionValue>(value);
-        animation.setTimingFunction(StepsTimingFunction::create(stepsTimingFunction.numberOfSteps(), stepsTimingFunction.stepAtStart()));
+        animation.setTimingFunction(StepsTimingFunction::create(stepsTimingFunction.numberOfSteps(), stepsTimingFunction.stepPosition()));
     } else if (is<CSSSpringTimingFunctionValue>(value)) {
         auto& springTimingFunction = downcast<CSSSpringTimingFunctionValue>(value);
         animation.setTimingFunction(SpringTimingFunction::create(springTimingFunction.mass(), springTimingFunction.stiffness(), springTimingFunction.damping(), springTimingFunction.initialVelocity()));

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -977,6 +977,12 @@ ease-out
 ease-in-out
 step-start
 step-end
+jump-start
+jump-end
+jump-none
+jump-both
+// start
+// end
 
 //
 // CSS_PROP_ZOOM

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -1468,34 +1468,57 @@ static RefPtr<CSSValue> consumeTransitionProperty(CSSParserTokenRange& range)
     
 static RefPtr<CSSValue> consumeSteps(CSSParserTokenRange& range)
 {
+    // https://drafts.csswg.org/css-easing-1/#funcdef-step-easing-function-steps
+
     ASSERT(range.peek().functionId() == CSSValueSteps);
     CSSParserTokenRange rangeCopy = range;
     CSSParserTokenRange args = consumeFunction(rangeCopy);
     
-    RefPtr<CSSPrimitiveValue> steps = consumePositiveInteger(args);
-    if (!steps)
+    RefPtr<CSSPrimitiveValue> stepsValue = consumePositiveInteger(args);
+    if (!stepsValue)
         return nullptr;
     
-    // FIXME-NEWPARSER: Support the middle value and change from a boolean to an enum.
-    bool stepAtStart = false;
+    Optional<StepsTimingFunction::StepPosition> stepPosition;
     if (consumeCommaIncludingWhitespace(args)) {
         switch (args.consumeIncludingWhitespace().id()) {
-            case CSSValueStart:
-                stepAtStart = true;
+        case CSSValueJumpStart:
+            stepPosition = StepsTimingFunction::StepPosition::JumpStart;
             break;
-            case CSSValueEnd:
-                stepAtStart = false;
-                break;
-            default:
-                return nullptr;
+
+        case CSSValueJumpEnd:
+            stepPosition = StepsTimingFunction::StepPosition::JumpEnd;
+            break;
+
+        case CSSValueJumpNone:
+            stepPosition = StepsTimingFunction::StepPosition::JumpNone;
+            break;
+
+        case CSSValueJumpBoth:
+            stepPosition = StepsTimingFunction::StepPosition::JumpBoth;
+            break;
+
+        case CSSValueStart:
+            stepPosition = StepsTimingFunction::StepPosition::Start;
+            break;
+
+        case CSSValueEnd:
+            stepPosition = StepsTimingFunction::StepPosition::End;
+            break;
+
+        default:
+            return nullptr;
         }
     }
     
     if (!args.atEnd())
         return nullptr;
+
+    auto steps = stepsValue->intValue();
+    if (steps <= 1 && stepPosition == StepsTimingFunction::StepPosition::JumpNone)
+        return nullptr;
     
     range = rangeCopy;
-    return CSSStepsTimingFunctionValue::create(steps->intValue(), stepAtStart);
+    return CSSStepsTimingFunctionValue::create(steps, stepPosition);
 }
 
 static RefPtr<CSSValue> consumeCubicBezier(CSSParserTokenRange& range)
@@ -1558,10 +1581,25 @@ static RefPtr<CSSValue> consumeSpringFunction(CSSParserTokenRange& range)
 
 static RefPtr<CSSValue> consumeAnimationTimingFunction(CSSParserTokenRange& range, const CSSParserContext& context)
 {
-    CSSValueID id = range.peek().id();
-    if (id == CSSValueEase || id == CSSValueLinear || id == CSSValueEaseIn
-        || id == CSSValueEaseOut || id == CSSValueEaseInOut || id == CSSValueStepStart || id == CSSValueStepEnd)
+    switch (range.peek().id()) {
+    case CSSValueLinear:
+    case CSSValueEase:
+    case CSSValueEaseIn:
+    case CSSValueEaseOut:
+    case CSSValueEaseInOut:
         return consumeIdent(range);
+
+    case CSSValueStepStart:
+        range.consumeIncludingWhitespace();
+        return CSSStepsTimingFunctionValue::create(1, StepsTimingFunction::StepPosition::Start);
+
+    case CSSValueStepEnd:
+        range.consumeIncludingWhitespace();
+        return CSSStepsTimingFunctionValue::create(1, StepsTimingFunction::StepPosition::End);
+
+    default:
+        break;
+    }
 
     CSSValueID function = range.peek().functionId();
     if (function == CSSValueCubicBezier)

--- a/Source/WebCore/platform/animation/TimingFunction.cpp
+++ b/Source/WebCore/platform/animation/TimingFunction.cpp
@@ -48,7 +48,36 @@ TextStream& operator<<(TextStream& ts, const TimingFunction& timingFunction)
     }
     case TimingFunction::StepsFunction: {
         auto& function = downcast<StepsTimingFunction>(timingFunction);
-        ts << "steps(" << function.numberOfSteps() << ", " << (function.stepAtStart() ? "start" : "end") << ")";
+        ts << "steps(" << function.numberOfSteps();
+        if (auto stepPosition = function.stepPosition()) {
+            ts << ", ";
+            switch (stepPosition.value()) {
+            case StepsTimingFunction::StepPosition::JumpStart:
+                ts << "jump-start";
+                break;
+
+            case StepsTimingFunction::StepPosition::JumpEnd:
+                ts << "jump-end";
+                break;
+
+            case StepsTimingFunction::StepPosition::JumpNone:
+                ts << "jump-none";
+                break;
+
+            case StepsTimingFunction::StepPosition::JumpBoth:
+                ts << "jump-both";
+                break;
+
+            case StepsTimingFunction::StepPosition::Start:
+                ts << "start";
+                break;
+
+            case StepsTimingFunction::StepPosition::End:
+                ts << "end";
+                break;
+            }
+        }
+        ts << ")";
         break;
     }
     case TimingFunction::SpringFunction: {
@@ -73,14 +102,15 @@ double TimingFunction::transformTime(double inputTime, double duration, bool bef
         return UnitBezier(function.x1(), function.y1(), function.x2(), function.y2()).solve(inputTime, epsilon);
     }
     case TimingFunction::StepsFunction: {
-        // https://drafts.csswg.org/css-timing/#step-timing-functions
+        // https://drafts.csswg.org/css-easing-1/#step-timing-functions
         auto& function = downcast<StepsTimingFunction>(*this);
         auto steps = function.numberOfSteps();
+        auto stepPosition = function.stepPosition();
         // 1. Calculate the current step as floor(input progress value × steps).
         auto currentStep = std::floor(inputTime * steps);
         // 2. If the step position property is start, increment current step by one.
-        if (function.stepAtStart())
-            currentStep++;
+        if (stepPosition == StepsTimingFunction::StepPosition::JumpStart || stepPosition == StepsTimingFunction::StepPosition::Start || stepPosition == StepsTimingFunction::StepPosition::JumpBoth)
+            ++currentStep;
         // 3. If both of the following conditions are true:
         //    - the before flag is set, and
         //    - input progress value × steps mod 1 equals zero (that is, if input progress value × steps is integral), then
@@ -90,10 +120,15 @@ double TimingFunction::transformTime(double inputTime, double duration, bool bef
         // 4. If input progress value ≥ 0 and current step < 0, let current step be zero.
         if (inputTime >= 0 && currentStep < 0)
             currentStep = 0;
-        // 5. If input progress value ≤ 1 and current step > steps, let current step be steps.
+        // 5. Calculate jumps based on the step position.
+        if (stepPosition == StepsTimingFunction::StepPosition::JumpNone)
+            --steps;
+        else if (stepPosition == StepsTimingFunction::StepPosition::JumpBoth)
+            ++steps;
+        // 6. If input progress value ≤ 1 and current step > jumps, let current step be jumps.
         if (inputTime <= 1 && currentStep > steps)
             currentStep = steps;
-        // 6. The output progress value is current step / steps.
+        // 7. The output progress value is current step / jumps.
         return currentStep / steps;
     }
     case TimingFunction::SpringFunction: {
@@ -140,9 +175,9 @@ RefPtr<TimingFunction> TimingFunction::createFromCSSValue(const CSSValue& value)
         case CSSValueEaseInOut:
             return CubicBezierTimingFunction::create(CubicBezierTimingFunction::EaseInOut);
         case CSSValueStepStart:
-            return StepsTimingFunction::create(1, true);
+            return StepsTimingFunction::create(1, StepsTimingFunction::StepPosition::Start);
         case CSSValueStepEnd:
-            return StepsTimingFunction::create(1, false);
+            return StepsTimingFunction::create(1, StepsTimingFunction::StepPosition::End);
         default:
             return nullptr;
         }
@@ -154,7 +189,7 @@ RefPtr<TimingFunction> TimingFunction::createFromCSSValue(const CSSValue& value)
     }
     if (is<CSSStepsTimingFunctionValue>(value)) {
         auto& stepsTimingFunction = downcast<CSSStepsTimingFunctionValue>(value);
-        return StepsTimingFunction::create(stepsTimingFunction.numberOfSteps(), stepsTimingFunction.stepAtStart());
+        return StepsTimingFunction::create(stepsTimingFunction.numberOfSteps(), stepsTimingFunction.stepPosition());
     }
     if (is<CSSSpringTimingFunctionValue>(value)) {
         auto& springTimingFunction = downcast<CSSSpringTimingFunctionValue>(value);
@@ -181,7 +216,7 @@ String TimingFunction::cssText() const
 
     if (m_type == TimingFunction::StepsFunction) {
         auto& function = downcast<StepsTimingFunction>(*this);
-        if (!function.stepAtStart())
+        if (function.stepPosition() == StepsTimingFunction::StepPosition::JumpEnd || function.stepPosition() == StepsTimingFunction::StepPosition::End)
             return makeString("steps(", function.numberOfSteps(), ')');
     }
 

--- a/Source/WebCore/platform/animation/TimingFunction.h
+++ b/Source/WebCore/platform/animation/TimingFunction.h
@@ -192,13 +192,22 @@ private:
 
 class StepsTimingFunction final : public TimingFunction {
 public:
-    static Ref<StepsTimingFunction> create(int steps, bool stepAtStart)
+    enum class StepPosition {
+        JumpStart,
+        JumpEnd,
+        JumpNone,
+        JumpBoth,
+        Start,
+        End,
+    };
+
+    static Ref<StepsTimingFunction> create(int steps, Optional<StepPosition> stepPosition)
     {
-        return adoptRef(*new StepsTimingFunction(steps, stepAtStart));
+        return adoptRef(*new StepsTimingFunction(steps, stepPosition));
     }
     static Ref<StepsTimingFunction> create()
     {
-        return adoptRef(*new StepsTimingFunction(1, true));
+        return adoptRef(*new StepsTimingFunction(1, StepPosition::End));
     }
     
     bool operator==(const TimingFunction& other) const final
@@ -206,30 +215,30 @@ public:
         if (!is<StepsTimingFunction>(other))
             return false;
         auto& otherSteps = downcast<StepsTimingFunction>(other);
-        return m_steps == otherSteps.m_steps && m_stepAtStart == otherSteps.m_stepAtStart;
+        return m_steps == otherSteps.m_steps && m_stepPosition == otherSteps.m_stepPosition;
     }
     
     int numberOfSteps() const { return m_steps; }
     void setNumberOfSteps(int steps) { m_steps = steps; }
 
-    bool stepAtStart() const { return m_stepAtStart; }
-    void setStepAtStart(bool stepAtStart) { m_stepAtStart = stepAtStart; }
+    Optional<StepPosition> stepPosition() const { return m_stepPosition; }
+    void setStepPosition(Optional<StepPosition> stepPosition) { m_stepPosition = stepPosition; }
 
 private:
-    StepsTimingFunction(int steps, bool stepAtStart)
+    StepsTimingFunction(int steps, Optional<StepPosition> stepPosition)
         : TimingFunction(StepsFunction)
         , m_steps(steps)
-        , m_stepAtStart(stepAtStart)
+        , m_stepPosition(stepPosition)
     {
     }
 
     Ref<TimingFunction> clone() const final
     {
-        return adoptRef(*new StepsTimingFunction(m_steps, m_stepAtStart));
+        return adoptRef(*new StepsTimingFunction(m_steps, m_stepPosition));
     }
     
     int m_steps;
-    bool m_stepAtStart;
+    Optional<StepPosition> m_stepPosition;
 };
 
 class SpringTimingFunction final : public TimingFunction {
@@ -301,3 +310,19 @@ SPECIALIZE_TYPE_TRAITS_TIMINGFUNCTION(WebCore::LinearTimingFunction, isLinearTim
 SPECIALIZE_TYPE_TRAITS_TIMINGFUNCTION(WebCore::CubicBezierTimingFunction, isCubicBezierTimingFunction())
 SPECIALIZE_TYPE_TRAITS_TIMINGFUNCTION(WebCore::StepsTimingFunction, isStepsTimingFunction())
 SPECIALIZE_TYPE_TRAITS_TIMINGFUNCTION(WebCore::SpringTimingFunction, isSpringTimingFunction())
+
+namespace WTF {
+
+template<> struct EnumTraits<WebCore::StepsTimingFunction::StepPosition> {
+    using values = EnumValues<
+        WebCore::StepsTimingFunction::StepPosition,
+        WebCore::StepsTimingFunction::StepPosition::JumpStart,
+        WebCore::StepsTimingFunction::StepPosition::JumpEnd,
+        WebCore::StepsTimingFunction::StepPosition::JumpNone,
+        WebCore::StepsTimingFunction::StepPosition::JumpBoth,
+        WebCore::StepsTimingFunction::StepPosition::Start,
+        WebCore::StepsTimingFunction::StepPosition::End
+    >;
+};
+
+} // namespace WTF

--- a/Source/WebInspectorUI/UserInterface/Models/CSSKeywordCompletions.js
+++ b/Source/WebInspectorUI/UserInterface/Models/CSSKeywordCompletions.js
@@ -114,6 +114,8 @@ WI.CSSKeywordCompletions.forFunction = function(functionName)
         suggestions.push("url()");
     else if (functionName === "repeat")
         suggestions.push("auto", "auto-fill", "auto-fit", "min-content", "max-content");
+    else if (functionName === "steps")
+        suggestions.push("jump-none", "jump-start", "jump-end", "jump-both", "start", "end");
     else if (functionName.endsWith("gradient")) {
         suggestions.push("to", "left", "right", "top", "bottom");
         suggestions.pushAll(WI.CSSKeywordCompletions._colors);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -490,7 +490,7 @@ void ArgumentCoder<StepsTimingFunction>::encode(Encoder& encoder, const StepsTim
     encoder.encodeEnum(timingFunction.type());
     
     encoder << timingFunction.numberOfSteps();
-    encoder << timingFunction.stepAtStart();
+    encoder << timingFunction.stepPosition();
 }
 
 bool ArgumentCoder<StepsTimingFunction>::decode(Decoder& decoder, StepsTimingFunction& timingFunction)
@@ -500,12 +500,12 @@ bool ArgumentCoder<StepsTimingFunction>::decode(Decoder& decoder, StepsTimingFun
     if (!decoder.decode(numSteps))
         return false;
 
-    bool stepAtStart;
-    if (!decoder.decode(stepAtStart))
+    Optional<StepsTimingFunction::StepPosition> stepPosition;
+    if (!decoder.decode(stepPosition))
         return false;
 
     timingFunction.setNumberOfSteps(numSteps);
-    timingFunction.setStepAtStart(stepAtStart);
+    timingFunction.setStepPosition(stepPosition);
 
     return true;
 }


### PR DESCRIPTION
See https://github.com/WebKit/WebKit/commit/d87f68e8f8ee21db09b93b6911bb7fc8a805e34f (r261046)
See https://bugs.webkit.org/show_bug.cgi?id=211271

This commit fixes `ACT-1277` and `ACT-1314` test cases from `Animation` section from https://certification.bbctvapps.co.uk/act/client/ test suite