### PR TITLE
[GST][MSE] Fix crash on an attempt to load different private player i…

### DIFF
--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -1230,7 +1230,14 @@ void MediaPlayer::networkStateChanged()
     if (m_private->networkState() >= MediaPlayer::NetworkState::FormatError && m_private->readyState() < MediaPlayer::ReadyState::HaveMetadata) {
         m_lastErrorMessage = m_private->errorMessage();
         client().mediaPlayerEngineFailedToLoad();
-        if (!m_activeEngineIdentifier && installedMediaEngines().size() > 1 && (m_contentType.isEmpty() || nextBestMediaEngine(m_currentMediaEngine))) {
+        bool shouldReload = !m_activeEngineIdentifier
+            && installedMediaEngines().size() > 1
+            && (m_contentType.isEmpty() || nextBestMediaEngine(m_currentMediaEngine))
+#if ENABLE(MEDIA_SOURCE)
+            && !m_mediaSource
+#endif
+            ;
+        if (shouldReload) {
             m_reloadTimer.startOneShot(0_s);
             return;
         }

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -1225,10 +1225,11 @@ void MediaPlayer::setPrivateBrowsingMode(bool privateBrowsingMode)
 // Client callbacks.
 void MediaPlayer::networkStateChanged()
 {
+    if (m_private->networkState() >= MediaPlayer::NetworkState::FormatError)
+        m_lastErrorMessage = m_private->errorMessage();
     // If more than one media engine is installed and this one failed before finding metadata,
     // let the next engine try.
     if (m_private->networkState() >= MediaPlayer::NetworkState::FormatError && m_private->readyState() < MediaPlayer::ReadyState::HaveMetadata) {
-        m_lastErrorMessage = m_private->errorMessage();
         client().mediaPlayerEngineFailedToLoad();
         bool shouldReload = !m_activeEngineIdentifier
             && installedMediaEngines().size() > 1


### PR DESCRIPTION
…nstance on error

The media source instance should be detached before destroying MSE
private player.