### PR TITLE
Fix rendering logo on AppleTV

### DIFF
--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -789,6 +789,7 @@ void WebGLRenderingContextBase::initializeNewContext()
     m_context->reshape(canvasSize.width(), canvasSize.height());
     m_context->viewport(0, 0, canvasSize.width(), canvasSize.height());
     m_context->scissor(0, 0, canvasSize.width(), canvasSize.height());
+    m_context->disable(GraphicsContextGL::SCISSOR_TEST);
 }
 
 void WebGLRenderingContextBase::setupFlags()

--- a/Source/WebCore/platform/graphics/nicosia/texmap/NicosiaNonCompositedGC3DLayer.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/texmap/NicosiaNonCompositedGC3DLayer.cpp
@@ -94,6 +94,7 @@ PlatformGraphicsContextGL NonCompositedGC3DLayer::platformContext() const
 void NonCompositedGC3DLayer::swapBuffersIfNeeded()
 {
     ASSERT(s_windowContext);
+    makeContextCurrent();
     s_windowContext->swapBuffers();
 }
 


### PR DESCRIPTION
This change ensure that current context is updated on swapbuffer to make sure the eglSwapBuffer() call succeeds. Also another change was made to disable scissors to let the WebGLRenderingContext update the full surface.