### PR TITLE
Allow scripts to close windows

### DIFF
--- a/Source/WebCore/page/DOMWindow.cpp
+++ b/Source/WebCore/page/DOMWindow.cpp
@@ -1063,7 +1063,9 @@ void DOMWindow::close()
     if (!frame->isMainFrame())
         return;
 
-    if (!(page->openedByDOM() || page->backForward().count() <= 1)) {
+    bool allowScriptsToCloseWindows = frame->settings().allowScriptsToCloseWindows();
+
+    if (!(page->openedByDOM() || page->backForward().count() <= 1 || allowScriptsToCloseWindows)) {
         console()->addMessage(MessageSource::JS, MessageLevel::Warning, "Can't close the window since it was not opened by JavaScript"_s);
         return;
     }

--- a/Source/WebCore/page/Settings.yaml
+++ b/Source/WebCore/page/Settings.yaml
@@ -215,6 +215,8 @@ enforceCSSMIMETypeInNoQuirksMode:
   initial: true
 usesEncodingDetector:
   initial: false
+allowScriptsToCloseWindows:
+  initial: false
 canvasUsesAcceleratedDrawing:
   initial: false
 acceleratedDrawingEnabled:

--- a/Source/WebKit/Shared/WebPreferences.yaml
+++ b/Source/WebKit/Shared/WebPreferences.yaml
@@ -1948,6 +1948,13 @@ NonCompositedWebGLEnabled:
     defaultValue: false
     condition: PLATFORM(WPE)
 
+AllowScriptsToCloseWindows:
+    type: bool
+    defaultValue: false
+    humanReadableName: "Allow Scripts to Close Windows"
+    humanReadableDescription: "Enable whether scripts can close already opened windows"
+    condition: PLATFORM(WPE)
+
 # Deprecated
 
 ICECandidateFilteringEnabled:

--- a/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
@@ -179,6 +179,9 @@ enum {
     PROP_ENABLE_WEBSECURITY,
     PROP_ALLOW_RUNNING_OF_INSECURE_CONTENT,
     PROP_ALLOW_DISPLAY_OF_INSECURE_CONTENT,
+#if PLATFORM(WPE)
+    PROP_ALLOW_SCRIPTS_TO_CLOSE_WINDOWS,
+#endif
 };
 
 static void webKitSettingsDispose(GObject* object)
@@ -426,6 +429,11 @@ static void webKitSettingsSetProperty(GObject* object, guint propId, const GValu
     case PROP_ALLOW_DISPLAY_OF_INSECURE_CONTENT:
         webkit_settings_set_allow_display_of_insecure_content(settings, g_value_get_boolean(value));
         break;
+#if PLATFORM(WPE)
+    case PROP_ALLOW_SCRIPTS_TO_CLOSE_WINDOWS:
+        webkit_settings_set_allow_scripts_to_close_windows(settings, g_value_get_boolean(value));
+        break;
+#endif
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propId, paramSpec);
         break;
@@ -634,6 +642,11 @@ static void webKitSettingsGetProperty(GObject* object, guint propId, GValue* val
     case PROP_ALLOW_DISPLAY_OF_INSECURE_CONTENT:
         g_value_set_boolean(value, webkit_settings_get_allow_display_of_insecure_content(settings));
         break;
+#if PLATFORM(WPE)
+    case PROP_ALLOW_SCRIPTS_TO_CLOSE_WINDOWS:
+        g_value_set_boolean(value, webkit_settings_get_allow_scripts_to_close_windows(settings));
+        break;
+#endif
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propId, paramSpec);
         break;
@@ -1654,6 +1667,20 @@ static void webkit_settings_class_init(WebKitSettingsClass* klass)
             FALSE,
             readWriteConstructParamFlags));
 
+#if PLATFORM(WPE)
+    /**
+     * WebKitSettings:allow-scripts-to-close-windows:
+     *
+     * Allow scripts to close windows they did not open
+     */
+    g_object_class_install_property(gObjectClass,
+        PROP_ALLOW_SCRIPTS_TO_CLOSE_WINDOWS,
+        g_param_spec_boolean("allow-scripts-to-close-windows",
+            _("Allow scripts to close windows"),
+            _("Whether scripts can close windows they did not open."),
+            FALSE,
+            readWriteConstructParamFlags));
+#endif
 
 }
 
@@ -4105,3 +4132,42 @@ void webkit_settings_set_allow_display_of_insecure_content(WebKitSettings* setti
     g_object_notify(G_OBJECT(settings), "allow-display-of-insecure-content");
 }
 
+#if PLATFORM(WPE)
+
+/**
+ * webkit_settings_get_allow_scripts_to_close_windows:
+ * @settings: a #WebKitSettings
+ *
+ * Get the #WebKitSettings:allow-scripts-to-close-windows property.
+ *
+ * Returns: %TRUE If script can close windows not opened by them or %FALSE otherwise.
+ */
+gboolean webkit_settings_get_allow_scripts_to_close_windows (WebKitSettings *settings)
+{
+    g_return_val_if_fail(WEBKIT_IS_SETTINGS(settings), FALSE);
+
+    return settings->priv->preferences->allowScriptsToCloseWindows();
+}
+
+/**
+ * webkit_settings_set_allow_scripts_to_close_windows
+ * @settings: a #WebKitSettings
+ * @allowed: Value to be set
+ *
+ * Set the #WebKitSettings:allow-scripts-to-close-windows property.
+ */
+WEBKIT_API void
+webkit_settings_set_allow_scripts_to_close_windows(WebKitSettings *settings, gboolean allowed)
+{
+    g_return_if_fail(WEBKIT_IS_SETTINGS(settings));
+
+    WebKitSettingsPrivate* priv = settings->priv;
+    bool currentValue = priv->preferences->allowScriptsToCloseWindows();
+    if (currentValue == allowed)
+        return;
+
+    priv->preferences->setAllowScriptsToCloseWindows(allowed);
+    g_object_notify(G_OBJECT(settings), "allow-scripts-to-close-windows");
+}
+
+#endif

--- a/Source/WebKit/UIProcess/API/wpe/WebKitSettings.h
+++ b/Source/WebKit/UIProcess/API/wpe/WebKitSettings.h
@@ -497,6 +497,13 @@ WEBKIT_API void
 webkit_settings_set_allow_display_of_insecure_content          (WebKitSettings *settings,
                                                                 gboolean        allowed);
 
+WEBKIT_API gboolean
+webkit_settings_get_allow_scripts_to_close_windows              (WebKitSettings *settings);
+
+WEBKIT_API void
+webkit_settings_set_allow_scripts_to_close_windows              (WebKitSettings *settings,
+                                                                gboolean        allowed);
+
 G_END_DECLS
 
 #endif /* WebKitSettings_h */

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -3667,6 +3667,8 @@ void WebPage::updatePreferences(const WebPreferencesStore& store)
 
     settings.setLayoutViewportHeightExpansionFactor(store.getDoubleValueForKey(WebPreferencesKey::layoutViewportHeightExpansionFactorKey()));
 
+    settings.setAllowScriptsToCloseWindows(store.getBoolValueForKey(WebPreferencesKey::allowScriptsToCloseWindowsKey()));
+
     if (m_drawingArea)
         m_drawingArea->updatePreferences(store);
 

--- a/Tools/TestWebKitAPI/glib/WebKitGLib/WebViewTest.h
+++ b/Tools/TestWebKitAPI/glib/WebKitGLib/WebViewTest.h
@@ -112,6 +112,7 @@ public:
     size_t m_resourceDataSize { 0 };
     cairo_surface_t* m_surface { nullptr };
     bool m_expectedWebProcessCrash { false };
+    bool m_closeCalled { false };
 
 #if PLATFORM(GTK)
     GtkWidget* m_parentWindow { nullptr };


### PR DESCRIPTION
Added API to WebKitSettings: Bool property `allow-scripts-to-close-windows` and respective getters.

Fixes #897 .