### PR TITLE
Hide IndexedDB API under runtime feature flag and allow better storage control

### DIFF
--- a/Source/WebCore/Modules/indexeddb/DOMWindowIndexedDatabase.idl
+++ b/Source/WebCore/Modules/indexeddb/DOMWindowIndexedDatabase.idl
@@ -27,7 +27,7 @@
 [
     Conditional=INDEXED_DATABASE,
 ] partial interface DOMWindow {
-    readonly attribute IDBFactory indexedDB;
-    [ImplementedAs=indexedDB] readonly attribute IDBFactory webkitIndexedDB;
+    [EnabledAtRuntime=Databases] readonly attribute IDBFactory indexedDB;
+    [EnabledAtRuntime=Databases, ImplementedAs=indexedDB] readonly attribute IDBFactory webkitIndexedDB;
 };
 

--- a/Source/WebCore/Modules/indexeddb/IDBCursor.idl
+++ b/Source/WebCore/Modules/indexeddb/IDBCursor.idl
@@ -26,6 +26,7 @@
 [
     Conditional=INDEXED_DATABASE,
     CustomToJSObject,
+    EnabledAtRuntime=Databases,
     JSCustomMarkFunction,
     SkipVTableValidation,
 ] interface IDBCursor {

--- a/Source/WebCore/Modules/indexeddb/IDBCursorDirection.idl
+++ b/Source/WebCore/Modules/indexeddb/IDBCursorDirection.idl
@@ -25,6 +25,7 @@
 
 [
     Conditional=INDEXED_DATABASE,
+    EnabledAtRuntime=Databases,
 ] enum IDBCursorDirection {
     "next",
     "nextunique",

--- a/Source/WebCore/Modules/indexeddb/IDBCursorWithValue.idl
+++ b/Source/WebCore/Modules/indexeddb/IDBCursorWithValue.idl
@@ -25,6 +25,7 @@
 
 [
     Conditional=INDEXED_DATABASE,
+    EnabledAtRuntime=Databases,
     SkipVTableValidation,
     JSCustomMarkFunction,
 ] interface IDBCursorWithValue : IDBCursor {

--- a/Source/WebCore/Modules/indexeddb/IDBDatabase.idl
+++ b/Source/WebCore/Modules/indexeddb/IDBDatabase.idl
@@ -27,6 +27,7 @@
 [
     Conditional=INDEXED_DATABASE,
     ActiveDOMObject,
+    EnabledAtRuntime=Databases,
     SkipVTableValidation,
 ] interface IDBDatabase : EventTarget {
     readonly attribute DOMString name;

--- a/Source/WebCore/Modules/indexeddb/IDBFactory.idl
+++ b/Source/WebCore/Modules/indexeddb/IDBFactory.idl
@@ -25,6 +25,7 @@
 
 [
     Conditional=INDEXED_DATABASE,
+    EnabledAtRuntime=Databases,
     SkipVTableValidation,
 ] interface IDBFactory {
     [CallWith=ScriptExecutionContext, MayThrowException] IDBOpenDBRequest open(DOMString name, optional [EnforceRange] unsigned long long version);

--- a/Source/WebCore/Modules/indexeddb/IDBIndex.idl
+++ b/Source/WebCore/Modules/indexeddb/IDBIndex.idl
@@ -30,6 +30,7 @@ typedef (DOMString or sequence<DOMString>) IDBKeyPath;
 [
     ActiveDOMObject,
     Conditional=INDEXED_DATABASE,
+    EnabledAtRuntime=Databases,
     GenerateIsReachable=Impl,
     JSCustomMarkFunction,
     SkipVTableValidation,

--- a/Source/WebCore/Modules/indexeddb/IDBKeyRange.idl
+++ b/Source/WebCore/Modules/indexeddb/IDBKeyRange.idl
@@ -26,6 +26,7 @@
 [
     Conditional=INDEXED_DATABASE,
     ImplementationLacksVTable,
+    EnabledAtRuntime=Databases,
 ] interface IDBKeyRange {
     readonly attribute [OverrideIDLType=IDLIDBKey] any lower;
     readonly attribute [OverrideIDLType=IDLIDBKey] any upper;

--- a/Source/WebCore/Modules/indexeddb/IDBObjectStore.idl
+++ b/Source/WebCore/Modules/indexeddb/IDBObjectStore.idl
@@ -30,6 +30,7 @@ typedef (DOMString or sequence<DOMString>) IDBKeyPath;
 [
     ActiveDOMObject,
     Conditional=INDEXED_DATABASE,
+    EnabledAtRuntime=Databases,
     GenerateIsReachable=Impl,
     JSCustomMarkFunction,
     SkipVTableValidation,

--- a/Source/WebCore/Modules/indexeddb/IDBOpenDBRequest.idl
+++ b/Source/WebCore/Modules/indexeddb/IDBOpenDBRequest.idl
@@ -27,6 +27,7 @@
     Conditional=INDEXED_DATABASE,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
+    EnabledAtRuntime=Databases,
     SkipVTableValidation,
 ] interface IDBOpenDBRequest : IDBRequest {
     attribute EventHandler onblocked;

--- a/Source/WebCore/Modules/indexeddb/IDBRequest.idl
+++ b/Source/WebCore/Modules/indexeddb/IDBRequest.idl
@@ -30,6 +30,7 @@
 [
     ActiveDOMObject,
     Conditional=INDEXED_DATABASE,
+    EnabledAtRuntime=Databases,
     GenerateIsReachable=Impl,
     JSCustomMarkFunction,
     SkipVTableValidation,

--- a/Source/WebCore/Modules/indexeddb/IDBTransaction.idl
+++ b/Source/WebCore/Modules/indexeddb/IDBTransaction.idl
@@ -27,6 +27,7 @@
 [
     ActiveDOMObject,
     Conditional=INDEXED_DATABASE,
+    EnabledAtRuntime=Databases,
     JSCustomMarkFunction,
     SkipVTableValidation,
 ] interface IDBTransaction : EventTarget {

--- a/Source/WebCore/Modules/indexeddb/IDBTransactionMode.idl
+++ b/Source/WebCore/Modules/indexeddb/IDBTransactionMode.idl
@@ -25,6 +25,7 @@
 
 [
     Conditional=INDEXED_DATABASE,
+    EnabledAtRuntime=Databases,
 ] enum IDBTransactionMode {
     "readonly",
     "readwrite",

--- a/Source/WebCore/Modules/indexeddb/IDBVersionChangeEvent.idl
+++ b/Source/WebCore/Modules/indexeddb/IDBVersionChangeEvent.idl
@@ -26,6 +26,7 @@
 // FIXME: This should be exposed to workers as well.
 [
     Conditional=INDEXED_DATABASE,
+    EnabledAtRuntime=Databases,
     Constructor(DOMString type, optional IDBVersionChangeEventInit eventInitDict),
 ] interface IDBVersionChangeEvent : Event {
     readonly attribute unsigned long long oldVersion;

--- a/Source/WebCore/bindings/js/JSDOMWindowCustom.cpp
+++ b/Source/WebCore/bindings/js/JSDOMWindowCustom.cpp
@@ -21,7 +21,6 @@
 #include "config.h"
 #include "JSDOMWindowCustom.h"
 
-#include "DOMWindowIndexedDatabase.h"
 #include "DOMWindowWebDatabase.h"
 #include "Frame.h"
 #include "HTMLCollection.h"

--- a/Source/WebCore/page/RuntimeEnabledFeatures.h
+++ b/Source/WebCore/page/RuntimeEnabledFeatures.h
@@ -215,6 +215,9 @@ public:
     bool attachmentElementEnabled() const { return m_isAttachmentElementEnabled; }
 #endif
 
+    void setDatabasesEnabled(bool isEnabled) { m_areDatabasesEnabled = isEnabled; }
+    bool databasesEnabled() const { return m_areDatabasesEnabled; }
+
 #if ENABLE(INDEXED_DATABASE_IN_WORKERS)
     void setIndexedDBWorkersEnabled(bool isEnabled) { m_isIndexedDBWorkersEnabled = isEnabled; }
     bool indexedDBWorkersEnabled() const { return m_isIndexedDBWorkersEnabled; }
@@ -449,6 +452,7 @@ private:
     bool m_keygenElementEnabled { false };
     bool m_pageAtRuleSupportEnabled { false };
     bool m_highlightAPIEnabled { false };
+    bool m_areDatabasesEnabled { true };
 
 #if ENABLE(LAYOUT_FORMATTING_CONTEXT)
     bool m_layoutFormattingContextEnabled { false };

--- a/Source/WebKit/Shared/WebPreferences.yaml
+++ b/Source/WebKit/Shared/WebPreferences.yaml
@@ -88,7 +88,9 @@ LocalStorageEnabled:
 DatabasesEnabled:
   type: bool
   defaultValue: true
-  webcoreBinding: custom
+  humanReadableName: "DatabasesEnabled"
+  humanReadableDescription: "Controls availailability of HTML5 databases (indexedDB, webdatabase(deprecated))"
+  webcoreBinding: RuntimeEnabledFeatures
 
 XSSAuditorEnabled:
   type: bool

--- a/Source/WebKit/UIProcess/API/glib/WebKitUIClient.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitUIClient.cpp
@@ -248,8 +248,8 @@ private:
 
     void exceededDatabaseQuota(WebPageProxy*, WebFrameProxy*, API::SecurityOrigin*, const String&, const String&, unsigned long long /*currentQuota*/, unsigned long long /*currentOriginUsage*/, unsigned long long /*currentDatabaseUsage*/, unsigned long long /*expectedUsage*/, Function<void(unsigned long long)>&& completionHandler) final
     {
-        static const unsigned long long defaultQuota = 5 * 1024 * 1204; // 5 MB
-        // FIXME: Provide API for this.
+        static const unsigned long long defaultQuota = 5 * 1024 * 1024; // 5 MB
+        // FIXME: Provide API for this. This value will enlarge per origin storage quota if anything lower was used
         completionHandler(defaultQuota);
     }
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -3620,7 +3620,7 @@ void WebPage::updatePreferences(const WebPreferencesStore& store)
     settings.setDataDetectorTypes(static_cast<DataDetectorTypes>(store.getUInt32ValueForKey(WebPreferencesKey::dataDetectorTypesKey())));
 #endif
 
-    DatabaseManager::singleton().setIsAvailable(store.getBoolValueForKey(WebPreferencesKey::databasesEnabledKey()));
+    DatabaseManager::singleton().setIsAvailable(RuntimeEnabledFeatures::sharedFeatures().databasesEnabled());
 
     m_tabToLinks = store.getBoolValueForKey(WebPreferencesKey::tabsToLinksKey());
     m_asynchronousPluginInitializationEnabled = store.getBoolValueForKey(WebPreferencesKey::asynchronousPluginInitializationEnabledKey());


### PR DESCRIPTION
as we don't want to expose Indexed Database API to all applications.

1) Hide all IndexedDB APIs under feature flag (Databases).
2) Reuse existing DatabasesEnabled preference to control the feature flag.
   The same pref is also used to control webdatabase availability
   but this feature is deprecated now.
3) Enabled by default (no change here).
4) Add API to control perOriginStorageQuota that is used for
   CacheStorage and IndexedDatabase.
Extra:
 * Remove stalled header from JSDOMWindowCustom.cpp
 * Fix 5MB calculations for WebKitUIClient

NOTES: Feature flag disables JS APIs only. IndexedDB server
will still run in NetworkProcess and may maintain its directory structure.