### PR TITLE
Clear surface when a new page is loaded

### DIFF
--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -6629,7 +6629,7 @@ void WebGLRenderingContextBase::activityStateDidChange(OptionSet<ActivityState::
 
     if (m_nonCompositedWebGLMode) {
         if (((changed & ActivityState::IsInWindow) && !(newActivityState & ActivityState::IsInWindow)) ||
-            ((changed & ActivityState::IsVisible) && !(newActivityState & ActivityState::IsVisible))) {
+            (!(newActivityState & ActivityState::IsVisible) && (changed & ActivityState::IsLoading) && (newActivityState & ActivityState::IsLoading))) {
             if (m_scissorEnabled)
                 m_context->disable(GraphicsContextGL::SCISSOR_TEST);
             m_context->clearColor(0, 0, 0, 0);


### PR DESCRIPTION
This solution works for #882. The change actually clears the buffer only when a new page is loaded, to avoid clearing it on navigations triggered by the app the visibility is checked to see if the navigation is done when the app is not visible/background.