### PR TITLE
Expose option to allow enabling/disabling directory upload

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
@@ -182,6 +182,7 @@ enum {
 #if PLATFORM(WPE)
     PROP_ALLOW_SCRIPTS_TO_CLOSE_WINDOWS,
 #endif
+    PROP_ENABLE_DIRECTORY_UPLOAD,
 };
 
 static void webKitSettingsDispose(GObject* object)
@@ -434,6 +435,9 @@ static void webKitSettingsSetProperty(GObject* object, guint propId, const GValu
         webkit_settings_set_allow_scripts_to_close_windows(settings, g_value_get_boolean(value));
         break;
 #endif
+    case PROP_ENABLE_DIRECTORY_UPLOAD:
+        webkit_settings_set_enable_directory_upload(settings, g_value_get_boolean(value));
+        break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propId, paramSpec);
         break;
@@ -647,6 +651,9 @@ static void webKitSettingsGetProperty(GObject* object, guint propId, GValue* val
         g_value_set_boolean(value, webkit_settings_get_allow_scripts_to_close_windows(settings));
         break;
 #endif
+    case PROP_ENABLE_DIRECTORY_UPLOAD:
+        g_value_set_boolean(value, webkit_settings_get_enable_directory_upload(settings));
+        break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propId, paramSpec);
         break;
@@ -1681,6 +1688,22 @@ static void webkit_settings_class_init(WebKitSettingsClass* klass)
             FALSE,
             readWriteConstructParamFlags));
 #endif
+
+    /**
+    * WebKitSettings:enable-directory-upload:
+    *
+    * Enable or disable directory upload.
+    */
+    g_object_class_install_property(
+        gObjectClass,
+        PROP_ENABLE_DIRECTORY_UPLOAD,
+        g_param_spec_boolean(
+            "enable-directory-upload",
+            _("Enable Directory Upload"),
+            _("Whether Directory Upload should be enabled"),
+            TRUE,
+            readWriteConstructParamFlags));
+
 
 }
 
@@ -4168,6 +4191,41 @@ webkit_settings_set_allow_scripts_to_close_windows(WebKitSettings *settings, gbo
 
     priv->preferences->setAllowScriptsToCloseWindows(allowed);
     g_object_notify(G_OBJECT(settings), "allow-scripts-to-close-windows");
+}
+
+/**
+ * webkit_settings_get_enable_directory_upload:
+ * @settings: a #WebKitSettings
+ *
+ * Get the #WebKitSettings:enable-directory-upload property.
+ *
+ * Returns: %TRUE If Directory Upload is enabled or %FALSE otherwise.
+ */
+gboolean webkit_settings_get_enable_directory_upload(WebKitSettings* settings)
+{
+    g_return_val_if_fail(WEBKIT_IS_SETTINGS(settings), FALSE);
+
+    return settings->priv->preferences->directoryUploadEnabled();
+}
+
+/**
+ * webkit_settings_set_enable_directory_upload:
+ * @settings: a #WebKitSettings
+ * @enabled: Value to be set
+ *
+ * Set the #WebKitSettings:enable-directory-upload property.
+ */
+void webkit_settings_set_enable_directory_upload(WebKitSettings* settings, gboolean enabled)
+{
+    g_return_if_fail(WEBKIT_IS_SETTINGS(settings));
+
+    WebKitSettingsPrivate* priv = settings->priv;
+    bool currentValue = priv->preferences->directoryUploadEnabled();
+    if (currentValue == enabled)
+        return;
+
+    priv->preferences->setDirectoryUploadEnabled(enabled);
+    g_object_notify(G_OBJECT(settings), "enable-directory-upload");
 }
 
 #endif

--- a/Source/WebKit/UIProcess/API/wpe/WebKitSettings.h
+++ b/Source/WebKit/UIProcess/API/wpe/WebKitSettings.h
@@ -504,6 +504,12 @@ WEBKIT_API void
 webkit_settings_set_allow_scripts_to_close_windows              (WebKitSettings *settings,
                                                                 gboolean        allowed);
 
+WEBKIT_API gboolean
+webkit_settings_get_enable_directory_upload                    (WebKitSettings *settings);
+
+WEBKIT_API void
+webkit_settings_set_enable_directory_upload                    (WebKitSettings *settings,
+                                                                gboolean        enabled);
 G_END_DECLS
 
 #endif /* WebKitSettings_h */


### PR DESCRIPTION
This PR adds missing glib-based-API option which is already available as `WKPreferencesSetDirectoryUploadEnabled` and `WKPreferencesGetDirectoryUploadEnabled`