### PR TITLE
Set readystate to match wpe-2.22/firefox/chrome during seek

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -207,7 +207,7 @@ void MediaPlayerPrivateGStreamerMSE::seek(const MediaTime& time)
 
     m_isEndReached = false;
     if (m_isSeeking && oldReadyState > MediaPlayer::ReadyState::HaveMetadata) {
-        updateReadyStateForSeekTarget();
+        m_readyState = MediaPlayer::ReadyState::HaveMetadata;
         if (m_readyState != oldReadyState)
             m_player->readyStateChanged();
     }


### PR DESCRIPTION
Issue at https://github.com/WebPlatformForEmbedded/WPEWebKit/issues/910

Attached is a sample app showing the difference between wpe-2.28 vs wpe-2.22/firefox/chrome, in the readystate during seeking and events sent out after seek is done
[seek-five-seconds-tv.html.txt](https://github.com/WebPlatformForEmbedded/WPEWebKit/files/9118414/seek-five-seconds-tv.html.txt)

Buffered range [0,119]
Seek 5s after play starts. 

When seek is initiated, readyState moves to HAVE_METADATA in firefox and chrome (and wpe-2.22). Seek is well within buffered range. On wpe-2.28 it stays at HAVE_ENOUGHDATA

On firefox
```
start play! seek-five-seconds-tv.html:66:22
timeupdate, readyState=4 paused=false 17 seek-five-seconds-tv.html:120:21
seekfwd5s seek-five-seconds-tv.html:203:21
seeking, readyState=1 paused=false seek-five-seconds-tv.html:106:22
waiting, readyState=1 paused=false seek-five-seconds-tv.html:124:21
timeupdate, readyState=4 paused=false seek-five-seconds-tv.html:120:21
seeked, readyState=4 paused=false seek-five-seconds-tv.html:116:21
canplay, readyState=4 paused=false seek-five-seconds-tv.html:111:21
playing, readyState=4 paused=false seek-five-seconds-tv.html:98:22
timeupdate, readyState=4 paused=false 42 seek-five-seconds-tv.html:120:21
```
On chrome
```
start play!
seek-five-seconds-tv.html:120 timeupdate, readyState=4 paused=false
seek-five-seconds-tv.html:203 seekfwd5s
seek-five-seconds-tv.html:106 seeking, readyState=1 paused=false
seek-five-seconds-tv.html:124 waiting, readyState=1 paused=false
seek-five-seconds-tv.html:120 timeupdate, readyState=4 paused=false
seek-five-seconds-tv.html:116 seeked, readyState=2 paused=false
seek-five-seconds-tv.html:111 canplay, readyState=2 paused=false
seek-five-seconds-tv.html:98 playing, readyState=2 paused=false
```
on wpe-2.22
```
[Log] start play! (seek-five-seconds.html, line 66)
[Log] timeupdate, readyState=4 paused=false (seek-five-seconds.html, line 120, x25)
[Log] seekfwd5s (seek-five-seconds.html, line 203)
[Log] seeking, readyState=1 paused=false (seek-five-seconds.html, line 106)
[Log] waiting, readyState=1 paused=false (seek-five-seconds.html, line 124)
[Log] timeupdate, readyState=1 paused=false (seek-five-seconds.html, line 120)
[Log] timeupdate, readyState=4 paused=false (seek-five-seconds.html, line 120)
[Log] seeked, readyState=4 paused=false (seek-five-seconds.html, line 116)
[Log] canplay, readyState=4 paused=false (seek-five-seconds.html, line 111)
[Log] playing, readyState=4 paused=false (seek-five-seconds.html, line 98)
[Log] timeupdate, readyState=4 paused=false (seek-five-seconds.html, line 120, x23)
```
on wpe-2.28
```
[Log] start play! (seek-five-seconds.html, line 66)
[Log] timeupdate, readyState=4 paused=false (seek-five-seconds.html, line 120, x20)
[Log] seekfwd5s (seek-five-seconds.html, line 203)
[Log] seeking, readyState=4 paused=false (seek-five-seconds.html, line 106)
[Log] timeupdate, readyState=4 paused=false (seek-five-seconds.html, line 120, x2)
[Log] seeked, readyState=4 paused=false (seek-five-seconds.html, line 116)
[Log] timeupdate, readyState=4 paused=false (seek-five-seconds.html, line 120, x29)
```
Some background
An issue was seen on Spotify with wpe-2.28 where the first seek works and any subsequent seeks, the app does not respond to them 
A forced update of m_readystate to HAVE_METADATA resolves this problem on Spotify
```
diff --git a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
index 2152227..3ee1926 100644
--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -210,7 +210,7 @@ void MediaPlayerPrivateGStreamerMSE::seek(const MediaTime& time)
 
     m_isEndReached = false;
     if (m_isSeeking && oldReadyState > MediaPlayer::ReadyState::HaveMetadata) {
-        updateReadyStateForSeekTarget();
+        m_readyState = MediaPlayer::ReadyState::HaveMetadata;
         if (m_readyState != oldReadyState)
             m_player->readyStateChanged();
     }
```
