### PR TITLE
webkit: mediasource: hang while playing high bitrate content

### DIFF
--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -1000,12 +1000,10 @@ void SourceBuffer::evictCodedFrames(size_t newDataSize)
         minimumRangeStart = m_groupEndTimestamp;
     }
 
-    if (m_source->duration().isPositiveInfinite()) {
-        if (!buffered.length())
-            return;
-        rangeEnd = buffered.end(buffered.length() - 1);
-    } else
-        rangeEnd = m_source->duration();
+    if (!buffered.length())
+        return;
+
+    rangeEnd = buffered.end(buffered.length() - 1);
 #else
     if (currentTimeRange == buffered.length() - 1) {
         LOG(MediaSource, "SourceBuffer::evictCodedFrames(%p) - evicted %zu bytes but FAILED to free enough", this, initialBufferedSize - extraMemoryCost());


### PR DESCRIPTION
It was observed that while playing a stream with high bitrate,
especially Live content, the playback freezes in between and webkit
crashes.
On debugging, it was identified that the crash was due to a watchdog
running in the webkit browser. The watchdog is continuously monitoring
the webkit's Webprocess and if it detects a hang, or the webprocess
becomes on responsive for configured time, the watchdog will set SIGFPE
to crash the process. In this case as well this is what happening.

Reason for Hang:
While playing a content with MSE, JS creates the source buffer and
pushes to webkit for playback. In webkit, there is a logic, for removing
buffer that are not needed to make room for new buffer. Logic is
explained in
https://www.w3.org/TR/media-source/#sourcebuffer-coded-frame-eviction.
Function `evictCodedFrames`, is doing this. There are two phase for this
function, in the first phase, removes the buffers which are already
presented. If this step is able to make enough room, this function will
return immediately. For most of the streams this phase is enough. For
for streams with high bitrate, the second phase is also needed. In the
second phase, the function will try to remove some buffer from end of
the buffered range to make enough room.

The issue is in this second phase. In the original implementation, the
webkit was using the duration of the stream to find the end of the
buffer. For the live streams, the duration is set as `4294967296` seconds  from
the application (ie from the player,
https://github.com/shaka-project/shaka-player/issues/1052). This is a
very big number compared to the current media time, according to the
original logic, a while loop running from this large number till the
current time with detriment value of 30 until we get enough space.
But since we dont have any buffer the loop reaches some value near to
the current time, function wont free any memory and at the same time the
loop is running so tightly so that the watchdog is getting blocked. This
causes the crash.

Solution:
The solution would be, instead of counting down from duration, count
down from the buffered range. This commit is doing the same by setting
the rangeEnd to the buffered end time.