### PR TITLE
Evict coded frames

### DIFF
--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -1006,12 +1006,12 @@ void SourceBuffer::evictCodedFrames(size_t newDataSize)
         rangeEnd += thirtySeconds;
     }
 
-#if !RELEASE_LOG_DISABLED
     if (!m_bufferFull) {
+#if !RELEASE_LOG_DISABLED
         DEBUG_LOG(LOGIDENTIFIER, "evicted ", initialBufferedSize - extraMemoryCost());
+#endif
         return;
     }
-#endif
 
     // If there still isn't enough free space and there buffers in time ranges after the current range (ie. there is a gap after
     // the current buffered range), delete 30 seconds at a time from duration back to the current time range or 30 seconds after


### PR DESCRIPTION
1) Improve coded frames eviction by removing more samples from the back of currentTime to avoid quota exceed exception (taken from 2.22 branch)
2) Minor fixes that don't impact overall algorithm 