### PR TITLE
Don't evict the same samples range multiple times

### DIFF
--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -982,14 +982,15 @@ void SourceBuffer::evictCodedFrames(size_t newDataSize)
     while (rangeStart < maximumRangeEnd) {
         // 4. For each range in removal ranges, run the coded frame removal algorithm with start and
         // end equal to the removal range start and end timestamp respectively.
-        removeCodedFrames(rangeStart, std::min(rangeEnd, maximumRangeEnd));
+        rangeEnd = std::min(rangeEnd, maximumRangeEnd);
+        removeCodedFrames(rangeStart, rangeEnd);
         if (extraMemoryCost() + newDataSize < maximumBufferSize) {
             m_bufferFull = false;
             break;
         }
 
-        rangeStart += thirtySeconds;
-        rangeEnd += thirtySeconds;
+        rangeStart = rangeEnd;
+        rangeEnd = rangeStart + thirtySeconds;
     }
 
 #if !RELEASE_LOG_DISABLED
@@ -1020,7 +1021,7 @@ void SourceBuffer::evictCodedFrames(size_t newDataSize)
     }
 
     rangeStart = rangeEnd - thirtySeconds;
-    while (rangeStart > minimumRangeStart) {
+    while (rangeEnd > minimumRangeStart) {
 
         // Do not evict data from the time range that contains currentTime.
         size_t startTimeRange = buffered.find(rangeStart);
@@ -1034,14 +1035,15 @@ void SourceBuffer::evictCodedFrames(size_t newDataSize)
 
         // 4. For each range in removal ranges, run the coded frame removal algorithm with start and
         // end equal to the removal range start and end timestamp respectively.
-        removeCodedFrames(std::max(minimumRangeStart, rangeStart), rangeEnd);
+        rangeStart = std::max(minimumRangeStart, rangeStart);
+        removeCodedFrames(rangeStart, rangeEnd);
         if (extraMemoryCost() + newDataSize < maximumBufferSize) {
             m_bufferFull = false;
             break;
         }
 
-        rangeStart -= thirtySeconds;
-        rangeEnd -= thirtySeconds;
+        rangeEnd = rangeStart;
+        rangeStart = rangeEnd - thirtySeconds;
     }
 
 #if !RELEASE_LOG_DISABLED


### PR DESCRIPTION
Improve moving coded frames removal window to skip
already removed parts and start from the end of previous
removal.
The only 'real' change here is termination condition
for loop that removes data ahead of current time
(some time ranges was not removed if rangeStart < minRangeStart
and rangeEnd > minRangeStart).
All the rest improves looping but the internal flow
is exactly the same (the same set of samples would be removed)

E.g. Having start of buffered range at 100sec and maximumRangeEnd and 200sec:
was:
1) (0-100)
2) (30-130)
3) (60-160)
...
will be:
1) (0-100)
2) (100-130)
3) (130-160)
...

The same for removing sampleas ahead of currentTime (with termination point
fixed)