### PR TITLE
Force RenderVideo composition even if poster image is used.

### DIFF
--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -2853,7 +2853,7 @@ bool RenderLayerCompositor::requiresCompositingForVideo(RenderLayerModelObject& 
         return false;
 
     auto& video = downcast<RenderVideo>(renderer);
-    if ((video.requiresImmediateCompositing() || video.shouldDisplayVideo()) && canAccelerateVideoRendering(video))
+    if (canAccelerateVideoRendering(video))
         return true;
 #else
     UNUSED_PARAM(renderer);


### PR DESCRIPTION
This is a workaround for https://github.com/WebPlatformForEmbedded/WPEWebKit/issues/919

Always compose video so the video element can make layer updates on
its own via updateRenderer() call that will trigger a repaint.

This change may affect poster image visibility in some cases