### PR TITLE
[EME] Keep MediaKeySystemAccess alive in createMediaKeys() async task

### DIFF
--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySystemAccess.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySystemAccess.cpp
@@ -40,13 +40,14 @@
 
 namespace WebCore {
 
-Ref<MediaKeySystemAccess> MediaKeySystemAccess::create(const String& keySystem, MediaKeySystemConfiguration&& configuration, Ref<CDM>&& implementation)
+Ref<MediaKeySystemAccess> MediaKeySystemAccess::create(Document& document, const String& keySystem, MediaKeySystemConfiguration&& configuration, Ref<CDM>&& implementation)
 {
-    return adoptRef(*new MediaKeySystemAccess(keySystem, WTFMove(configuration), WTFMove(implementation)));
+    return adoptRef(*new MediaKeySystemAccess(document, keySystem, WTFMove(configuration), WTFMove(implementation)));
 }
 
-MediaKeySystemAccess::MediaKeySystemAccess(const String& keySystem, MediaKeySystemConfiguration&& configuration, Ref<CDM>&& implementation)
-    : m_keySystem(keySystem)
+MediaKeySystemAccess::MediaKeySystemAccess(Document& document, const String& keySystem, MediaKeySystemConfiguration&& configuration, Ref<CDM>&& implementation)
+    : ActiveDOMObject(document)
+    , m_keySystem(keySystem)
     , m_configuration(new MediaKeySystemConfiguration(WTFMove(configuration)))
     , m_implementation(WTFMove(implementation))
 {
@@ -107,6 +108,17 @@ void MediaKeySystemAccess::createMediaKeys(Ref<DeferredPromise>&& promise)
     });
 
     // 3. Return promise.
+}
+
+bool MediaKeySystemAccess::virtualHasPendingActivity() const
+{
+    // Don't destroy this object if it has unresolved createMediaKeys() promisses
+    return m_taskQueue.hasPendingTasks();
+}
+
+const char* MediaKeySystemAccess::activeDOMObjectName() const
+{
+    return "MediaKeySystemAccess";
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySystemAccess.h
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySystemAccess.h
@@ -30,6 +30,7 @@
 
 #if ENABLE(ENCRYPTED_MEDIA)
 
+#include "ActiveDOMObject.h"
 #include "GenericTaskQueue.h"
 #include "MediaKeySystemConfiguration.h"
 #include <wtf/RefCounted.h>
@@ -41,9 +42,9 @@ class CDM;
 class DeferredPromise;
 class MediaKeys;
 
-class MediaKeySystemAccess : public RefCounted<MediaKeySystemAccess> {
+class MediaKeySystemAccess : public RefCounted<MediaKeySystemAccess>, public ActiveDOMObject {
 public:
-    static Ref<MediaKeySystemAccess> create(const String& keySystem, MediaKeySystemConfiguration&&, Ref<CDM>&&);
+    static Ref<MediaKeySystemAccess> create(Document& document, const String& keySystem, MediaKeySystemConfiguration&&, Ref<CDM>&&);
     ~MediaKeySystemAccess();
 
     const String& keySystem() const { return m_keySystem; }
@@ -51,7 +52,11 @@ public:
     void createMediaKeys(Ref<DeferredPromise>&&);
 
 private:
-    MediaKeySystemAccess(const String& keySystem, MediaKeySystemConfiguration&&, Ref<CDM>&&);
+    MediaKeySystemAccess(Document& document, const String& keySystem, MediaKeySystemConfiguration&&, Ref<CDM>&&);
+
+    // ActiveDOMObject
+    const char* activeDOMObjectName() const final;
+    bool virtualHasPendingActivity() const final;
 
     String m_keySystem;
     std::unique_ptr<MediaKeySystemConfiguration> m_configuration;

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySystemAccess.idl
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySystemAccess.idl
@@ -27,10 +27,10 @@
  */
 
 [
+    ActiveDOMObject,
     Conditional=ENCRYPTED_MEDIA,
     EnabledAtRuntime=EncryptedMediaAPI,
     DisabledByQuirk=hasBrokenEncryptedMediaAPISupport,
-    ImplementationLacksVTable,
 ] interface MediaKeySystemAccess {
     readonly attribute DOMString keySystem;
     MediaKeySystemConfiguration getConfiguration();


### PR DESCRIPTION
Put MediaKeySystemAccess under ActiveDOMObject interface
and make sure that GC won't destroy an object before
it executes its async task and createMediaKeys() func is completed.

Sometimes it happens that GC destroys MediaKeySystemAccess object
in the middle of createMediaKeys() func, before promise is completed
and JS MediaKeys are never created.

This fixes YT Cert Test: EME, WidevineH264MultiMediaKeySessions