### PR TITLE
Adjust buffering rate monitor to react faster

### DIFF
--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -76,7 +76,7 @@ static inline MediaTime roundTowardsTimeScaleWithRoundingMargin(const MediaTime&
     }
 };
 
-static const double ExponentialMovingAverageCoefficient = 0.1;
+static const double ExponentialMovingAverageCoefficient = 0.2;
 
 // Do not enqueue samples spanning a significant unbuffered gap.
 // NOTE: one second is somewhat arbitrary. MediaSource::monitorSourceBuffers() is run


### PR DESCRIPTION
This PR ports https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/d1acf35e2b3ac9be568964aec01f5ef730b172cf from `2.22` to `2.28`

As data is comming in (in bursts), the buffering rate monitoring algorithm calculates an average rate that will be used to determine if we can play through the content without interruption (assuming relatively constant rate). To filter out variations in rate, the algorithm reacts more slowly (by design) and may take more time to reach the required rate threshold to unblock playback, even though the incoming rate is sufficient to sustain playback. If it takes too long, then a client using MSE may take corrective actions wich may disturb or even abort the playback.

By adjusting the `ExponentialMovingAverageCoefficient` we can make the algorithm react faster to presence of data and unblock playback. Side effect is that it reacts also faster to absence of data, but that should not affect playback as data has been buffered already allowing playback to be sustained.