### PR TITLE
LLAMA-7399: Drop unsupported initialization data

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -3722,6 +3722,11 @@ void MediaPlayerPrivateGStreamer::initializationDataEncountered(InitData&& initD
         if (!weakThis)
             return;
 
+        if (weakThis->m_cdmInstance && g_strcmp0(initData.systemId().utf8().data(), GStreamerEMEUtilities::keySystemToUuid(weakThis->m_cdmInstance->keySystem()))) {
+            GST_TRACE_OBJECT(weakThis->pipeline(), "skipping initialization data for a different key system");
+            return;
+        }
+
         GST_DEBUG("scheduling initializationDataEncountered %s event of size %zu", initData.payloadContainerType().utf8().data(),
             initData.payload()->size());
         GST_MEMDUMP("init datas", reinterpret_cast<const uint8_t*>(initData.payload()->data()), initData.payload()->size());


### PR DESCRIPTION
In `2.28` we're passing any init data further down to CDM. We're doing it regardless the key system specified in the protection event. This way we're ending up passing e.g. playready init data to widevine CDM if app provides protection events for both.

This PR brings back filtering of non-matching init data which was present in `2.22`:
https://github.com/WebPlatformForEmbedded/WPEWebKit/blob/6b2c308873ae42e9ffd87a189c96541a3735dcfc/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamerBase.cpp#L1458-L1461
