### PR TITLE
Add APIs to replace and retreive entire cookie jar

### DIFF
--- a/Source/WebCore/platform/network/NetworkStorageSession.h
+++ b/Source/WebCore/platform/network/NetworkStorageSession.h
@@ -146,6 +146,9 @@ public:
     WEBCORE_EXPORT std::pair<String, bool> cookieRequestHeaderFieldValue(const URL& firstParty, const SameSiteInfo&, const URL&, Optional<FrameIdentifier>, Optional<PageIdentifier>, IncludeSecureCookies, ShouldAskITP) const;
     WEBCORE_EXPORT std::pair<String, bool> cookieRequestHeaderFieldValue(const CookieRequestHeaderFieldProxy&) const;
 
+    WEBCORE_EXPORT void setCookieJar(const Vector<Cookie>&);
+    WEBCORE_EXPORT Vector<Cookie> getCookieJar();
+
 #if ENABLE(RESOURCE_LOAD_STATISTICS)
     void setResourceLoadStatisticsEnabled(bool enabled) { m_isResourceLoadStatisticsEnabled = enabled; }
     WEBCORE_EXPORT bool shouldBlockCookies(const ResourceRequest&, Optional<FrameIdentifier>, Optional<PageIdentifier>) const;

--- a/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.cpp
+++ b/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.cpp
@@ -154,4 +154,20 @@ void WebCookieManager::getHTTPCookieAcceptPolicy(CompletionHandler<void(HTTPCook
     completionHandler(m_process.defaultStorageSession().cookieAcceptPolicy());
 }
 
+void WebCookieManager::setCookieJar(PAL::SessionID sessionID, const Vector<WebCore::Cookie>& cookies, CompletionHandler<void()>&& completionHandler)
+{
+    if (auto* storageSession = m_process.storageSession(sessionID))
+        storageSession->setCookieJar(cookies);
+    completionHandler();
+}
+
+void WebCookieManager::getCookieJar(PAL::SessionID sessionID, CompletionHandler<void(Vector<WebCore::Cookie>&&)>&& completionHandler)
+{
+    Vector<Cookie> cookies;
+    if (auto* storageSession = m_process.storageSession(sessionID))
+        cookies = storageSession->getCookieJar();
+    completionHandler(WTFMove(cookies));
+}
+
+
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.h
+++ b/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.h
@@ -85,6 +85,9 @@ private:
     void startObservingCookieChanges(PAL::SessionID);
     void stopObservingCookieChanges(PAL::SessionID);
 
+    void setCookieJar(PAL::SessionID, const Vector<WebCore::Cookie>&, CompletionHandler<void()>&&);
+    void getCookieJar(PAL::SessionID, CompletionHandler<void(Vector<WebCore::Cookie>&&)>&&);
+
     NetworkProcess& m_process;
 };
 

--- a/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.messages.in
+++ b/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.messages.in
@@ -44,4 +44,7 @@ messages -> WebCookieManager NotRefCounted {
 #if USE(SOUP)
     void SetCookiePersistentStorage(PAL::SessionID sessionID, String storagePath, enum:bool WebKit::SoupCookiePersistentStorageType storageType)
 #endif
+
+    void SetCookieJar(PAL::SessionID sessionID, Vector<WebCore::Cookie> cookies) -> () Async
+    void GetCookieJar(PAL::SessionID sessionID) -> (Vector<WebCore::Cookie> cookies) Async
 }

--- a/Source/WebKit/UIProcess/API/wpe/WebKitCookieManager.h
+++ b/Source/WebKit/UIProcess/API/wpe/WebKitCookieManager.h
@@ -145,6 +145,28 @@ webkit_cookie_manager_delete_cookie_finish            (WebKitCookieManager      
                                                        GAsyncResult                 *result,
                                                        GError                      **error);
 
+WEBKIT_API void
+webkit_cookie_manager_set_cookie_jar                  (WebKitCookieManager          *cookie_manager,
+                                                       GList                        *cookies,
+                                                       GCancellable                 *cancellable,
+                                                       GAsyncReadyCallback           callback,
+                                                       gpointer                      user_data);
+
+WEBKIT_API gboolean
+webkit_cookie_manager_set_cookie_jar_finish           (WebKitCookieManager          *cookie_manager,
+                                                       GAsyncResult                 *result,
+                                                       GError                      **error);
+
+WEBKIT_API void
+webkit_cookie_manager_get_cookie_jar                  (WebKitCookieManager          *cookie_manager,
+                                                       GCancellable                 *cancellable,
+                                                       GAsyncReadyCallback           callback,
+                                                       gpointer                      user_data);
+
+WEBKIT_API GList *
+webkit_cookie_manager_get_cookie_jar_finish           (WebKitCookieManager          *cookie_manager,
+                                                       GAsyncResult                 *result,
+                                                       GError                      **error);
 G_END_DECLS
 
 #endif

--- a/Source/WebKit/UIProcess/WebCookieManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebCookieManagerProxy.cpp
@@ -245,4 +245,20 @@ void WebCookieManagerProxy::getHTTPCookieAcceptPolicy(PAL::SessionID, Completion
     });
 }
 
+void WebCookieManagerProxy::setCookieJar(PAL::SessionID sessionID, const Vector<Cookie>& cookies, CompletionHandler<void()>&& callbackFunction)
+{
+    auto& networkProcess = processPool()->ensureNetworkProcess();
+    networkProcess.sendWithAsyncReply(Messages::WebCookieManager::SetCookieJar(sessionID, cookies), [callbackFunction = WTFMove(callbackFunction), activity = networkProcess.throttler().backgroundActivity("WebCookieManagerProxy::setCookieJar"_s)]() mutable {
+        callbackFunction();
+    });
+}
+
+void WebCookieManagerProxy::getCookieJar(PAL::SessionID sessionID, CompletionHandler<void(Vector<Cookie>&&)>&& callbackFunction)
+{
+    auto& networkProcess = processPool()->ensureNetworkProcess();
+    networkProcess.sendWithAsyncReply(Messages::WebCookieManager::GetCookieJar(sessionID), [callbackFunction = WTFMove(callbackFunction), activity = networkProcess.throttler().backgroundActivity("WebCookieManagerProxy::getCookieJar"_s)](Vector<Cookie>&& cookies) mutable {
+        callbackFunction(WTFMove(cookies));
+    });
+}
+
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebCookieManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebCookieManagerProxy.h
@@ -80,6 +80,9 @@ public:
     void setHTTPCookieAcceptPolicy(PAL::SessionID, WebCore::HTTPCookieAcceptPolicy, CompletionHandler<void()>&&);
     void getHTTPCookieAcceptPolicy(PAL::SessionID, CompletionHandler<void(WebCore::HTTPCookieAcceptPolicy)>&&);
 
+    void setCookieJar(PAL::SessionID, const Vector<WebCore::Cookie>&, CompletionHandler<void()>&&);
+    void getCookieJar(PAL::SessionID, CompletionHandler<void(Vector<WebCore::Cookie>&&)>&&);
+
     void startObservingCookieChanges(PAL::SessionID);
     void stopObservingCookieChanges(PAL::SessionID);
 


### PR DESCRIPTION
This is different from existing APIs as it replaces entire cookie jar
(delete all cookies and add fresh ones) in single task.
No "changed" event is generated for such replacement

Some parts are taken from 2.22 branch