### PR TITLE
Change color scheme in CairoGlSurface

### DIFF
--- a/Source/WebCore/platform/graphics/cairo/ImageBufferCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/ImageBufferCairo.cpp
@@ -211,7 +211,7 @@ void ImageBufferData::createCairoGLSurface()
 
     glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
 
-    glTexImage2D(GL_TEXTURE_2D, 0 /* level */, GL_RGBA, m_size.width(), m_size.height(), 0 /* border */, GL_RGBA, GL_UNSIGNED_BYTE, 0);
+    glTexImage2D(GL_TEXTURE_2D, 0 /* level */, GL_BGRA_EXT, m_size.width(), m_size.height(), 0 /* border */, GL_BGRA_EXT, GL_UNSIGNED_BYTE, 0);
 
     cairo_device_t* device = context->cairoDevice();
 


### PR DESCRIPTION
ImageBufferData::createCairoGLSurface creates a texture which will be used by Cairo to render accelerated content. Cairo inside library executes glTexSubImage2D method to update the canvas with GL_BGRA_EXT parameter as color order.
According to https://registry.khronos.org/OpenGL-Refpages/es2.0 /xhtml/glTexSubImage2D.xml documentation we need to use the same color order in glTexImage2D (from ImageBufferData) and glTexSubImage2D.
This commit uses GL_BGRA_EXT in glTexImage2D to use the same color order that is used in cairo.