### PR TITLE
Don't assert there is no checkpoint side state when dropping the JSLock

### DIFF
--- a/Source/JavaScriptCore/ChangeLog
+++ b/Source/JavaScriptCore/ChangeLog
@@ -1,3 +1,23 @@
+2020-11-03  Saam Barati  <sbarati@apple.com>
+
+        Don't assert there is no checkpoint side state when dropping the JSLock
+        https://bugs.webkit.org/show_bug.cgi?id=218537
+
+        Reviewed by Filip Pizlo.
+
+        You may have multiple OSR exit sidestate data on the stack, and then call into
+        API code, which might DropAllLocks. Hence, this assert is wrong.
+
+        Working on a test. Will land in a followup.
+
+        * runtime/JSLock.cpp:
+        (JSC::JSLock::willReleaseLock):
+
+2020-11-03  Yusuke Suzuki  <ysuzuki@apple.com>
+
+        REGRESSION (r254038): Simple.com money transfer UI is very laggy (multiple seconds per keypress)
+        https://bugs.webkit.org/show_bug.cgi?id=218348
+
 2020-07-20  Keith Miller  <keith_miller@apple.com>
 
         Add support for FinalizationRegistries

--- a/Source/JavaScriptCore/runtime/JSLock.cpp
+++ b/Source/JavaScriptCore/runtime/JSLock.cpp
@@ -201,10 +201,9 @@ void JSLock::unlock(intptr_t unlockCount)
 }
 
 void JSLock::willReleaseLock()
-{   
+{
     RefPtr<VM> vm = m_vm;
     if (vm) {
-        RELEASE_ASSERT_WITH_MESSAGE(!vm->hasCheckpointOSRSideState(), "Releasing JSLock but pending checkpoint side state still available");
         vm->drainMicrotasks();
 
         if (!vm->topCallFrame)
@@ -212,7 +211,7 @@ void JSLock::willReleaseLock()
 
         vm->heap.releaseDelayedReleasedObjects();
         vm->setStackPointerAtVMEntry(nullptr);
-        
+
         if (m_shouldReleaseHeapAccess)
             vm->heap.releaseAccess();
     }


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=218537

Reviewed by Filip Pizlo.

You may have multiple OSR exit sidestate data on the stack, and then call into API code, which might DropAllLocks. Hence, this assert is wrong.

Working on a test. Will land in a followup.

* runtime/JSLock.cpp: (JSC::JSLock::willReleaseLock):

Canonical link: https://commits.webkit.org/231185@main git-svn-id: https://svn.webkit.org/repository/webkit/trunk@269338 268f45cc-cd09-0410-ab3c-d52691b4dbfc

Author:    Saam Barati <sbarati@apple.com>
Date:      Tue Nov 3 23:36:18 2020 +0000

Backport from: https://github.com/WebKit/WebKit/commit/d8db90e0fb9b5b3aba8bf05770a96cbad4ee8186