### PR TITLE
Never destroy RemoteInspectorHTTPServer singleton

### DIFF
--- a/Source/WebKit/UIProcess/Inspector/glib/RemoteInspectorHTTPServer.cpp
+++ b/Source/WebKit/UIProcess/Inspector/glib/RemoteInspectorHTTPServer.cpp
@@ -31,6 +31,7 @@
 #include "RemoteInspectorClient.h"
 #include <WebCore/SoupVersioning.h>
 #include <wtf/FileSystem.h>
+#include <wtf/NeverDestroyed.h>
 #include <wtf/URL.h>
 #include <wtf/glib/GUniquePtr.h>
 
@@ -38,7 +39,7 @@ namespace WebKit {
 
 RemoteInspectorHTTPServer& RemoteInspectorHTTPServer::singleton()
 {
-    static RemoteInspectorHTTPServer server;
+    static NeverDestroyed<RemoteInspectorHTTPServer> server;
     return server;
 }
 


### PR DESCRIPTION
Destroying RemoteInspectorHTTPServer with on different thread that it was created on causes RELEASE_ASSERT to be triggered (via ~RemoteInspectorClient -> ~TimerBase).

Such case happens when main UIProcess loop doesn't run in the main thread (like WPE WebKitBrowser plugin scenario)