### PR TITLE
LLAMA-7992: Fix startup in suspended state

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
@@ -77,6 +77,12 @@ DrawingAreaCoordinatedGraphics::DrawingAreaCoordinatedGraphics(WebPage& webPage,
             m_supportsAsyncScrolling = false;
     }
 #endif
+
+    // we're assuming ActivityState::IsInWindow is on by default
+    // thus if it's not - we need to trigger suspend immediately
+    if (!parameters.activityState.contains(ActivityState::IsInWindow)) {
+        activityStateDidChange(ActivityState::IsInWindow, -1, {});
+    }
 }
 
 DrawingAreaCoordinatedGraphics::~DrawingAreaCoordinatedGraphics() = default;


### PR DESCRIPTION
If the `WebPage` happens to be created without `in-window` flag (suspended state), the `DrawingAreaCoordinatedGraphics` is being created in non-suspended (default) state and thus is out of sync. And since the `in-window` flag toggles state in `DrawingAreaCoordinatedGraphics` it will never become in-sync. Thus e.g. adding `in-window` flag will result in suspending etc.

This PR introduces simple mechanism for bringing `DrawingAreaCoordinatedGraphics` to the correct state upon creation.