### PR TITLE
XIONE-10223: Fix buffering completion corner case

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -2487,6 +2487,8 @@ void MediaPlayerPrivateGStreamer::updateStates()
                     gboolean isBuffering = m_isBuffering;
                     gst_query_parse_buffering_percent(query.get(), &isBuffering, nullptr);
                     m_isBuffering = isBuffering;
+                } else if (m_bufferingPercentage == 100) {
+                    m_isBuffering = false;
                 }
 
                 if (!m_isBuffering) {


### PR DESCRIPTION
In one of comcast devices `gst_element_query(m_pipeline.get(), query.get())` fails and thus if `m_bufferingPercentage == 100` the `m_isBuffering` will keep on being `true` and hence buffering won't complete.

This PR fixes that.

CC @eocanha 