### PR TITLE
XIONE-10264: Fix prolonged buffering during progressive live playback

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -3871,6 +3871,9 @@ void MediaPlayerPrivateGStreamer::elementSetupCallback(MediaPlayerPrivateGStream
     }
 #endif
 
+    if (g_strcmp0(G_OBJECT_TYPE_NAME(G_OBJECT(element)), "GstQueue2") == 0)
+        g_object_set(G_OBJECT(element), "high-watermark", 0.10, nullptr);
+
 #if USE(WESTEROS_SINK)
     static GstCaps *westerosSinkCaps = nullptr;
     static GType westerosSinkType = G_TYPE_INVALID;


### PR DESCRIPTION
On one of the Comcast devices we observe prolonged buffering in some apps where live assets are using progressive player.

This PR reduces the [high threshold](https://gstreamer.freedesktop.org/data/doc/gstreamer/head/gstreamer-plugins/html/gstreamer-plugins-queue2.html#GstQueue2--high-watermark) of queue element so that buffering can finish much faster.