### PR TITLE
ImageBufferCairo: Make sure all drawing is done on swapBuffers

### DIFF
--- a/Source/WebCore/platform/graphics/cairo/ImageBufferCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/ImageBufferCairo.cpp
@@ -183,6 +183,9 @@ void ImageBufferData::swapBuffersIfNeeded()
     cairo_set_operator(m_compositorCr.get(), CAIRO_OPERATOR_SOURCE);
     cairo_paint(m_compositorCr.get());
 
+    // Flush all pending drawing operations as compositor uses GL texture directly, outside of Cairo
+    cairo_surface_flush(m_compositorSurface.get());
+
     if (previousActiveContext)
         previousActiveContext->makeContextCurrent();
 }


### PR DESCRIPTION
Flush compositor surface to make sure all drawings are stored inside backing GL texture. Compositor uses GL texture directly, outside of cairo ecosystem so Cairo doesn't know if the data is accessed.

This fixes HTML canvas issue on both 2.22 and 2.28 that canvas renders previous image insted of current one. If this is the very first drawing then some trashes are displayed (empty, parts of some previous graphics, etc).

Happens with accelerated 2D canvas enabled only