### PR TITLE
[WPE2.22] Include MpegAudioParse plugin in Brcm Nexus gstreamer pipeline

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -2865,6 +2865,21 @@ void MediaPlayerPrivateGStreamer::createGSTPlayBin(const gchar* playbinName, con
 
     ASSERT(!m_pipeline);
 
+#if PLATFORM(BCM_NEXUS)
+    {
+        auto registry = gst_registry_get();
+        GRefPtr<GstPluginFeature> brcmaudfilter = gst_registry_lookup_feature(registry, "brcmaudfilter");
+        GRefPtr<GstPluginFeature> mpegaudioparse = gst_registry_lookup_feature(registry, "mpegaudioparse");
+
+        if (brcmaudfilter && mpegaudioparse) {
+            GST_INFO("overriding mpegaudioparse rank with brcmaudfilter rank + 1");
+            gst_plugin_feature_set_rank(
+                mpegaudioparse.get(),
+                gst_plugin_feature_get_rank(brcmaudfilter.get()) + 1);
+        }
+    }
+#endif
+
 #if GST_CHECK_VERSION(1, 10, 0)
     if (g_getenv("USE_PLAYBIN3"))
         playbinName = "playbin3";


### PR DESCRIPTION
MpegAudioParse plugin with ths fix is added by playbin before BrcmAudioFilter.

Without MpegAudioParse plugin we have issues is audio only progressive and shoutcast playbacks: audio stuttering, duration of progressive audio tag is always set to infinity. Root cause is because durationMediaTime() query fails

Issue was seen on those lightning apps: Deezer, Radioline, Radio paradise. URL to Radio paradise:
https://widgets.metrological.com/lightning/liberty/2e3c4fc22f0d35e3eb7fdb47eb7d4658#app:com.metrological.app.RadioParadise

Issue is reproducing on gstreamer 1.10 and 1.18 with RDK plugins from gst-plugins-soc. Issue is not seen on audio only MSE apps (eg. BBC Sounds).

Issue is not visible on non-nexus based pipelines; eg. everything works OK on RPI (which uses OpenMax) with gstreamer 1.16.3.