### PR TITLE
Feature file changes for 2.28 branch

### DIFF
--- a/Source/JavaScriptCore/features.json
+++ b/Source/JavaScriptCore/features.json
@@ -2,7 +2,7 @@
     "specification": [
     {
         "name": "ES6",
-        "url": "http://wiki.ecmascript.org/doku.php?id=harmony:specification_drafts",
+        "url": "https://262.ecma-international.org/6.0/",
         "keywords": ["es6", "es2015", "ecmascript"],
         "status": {
             "status": "Supported"
@@ -21,12 +21,12 @@
     },
     {
         "name": "ES7",
-        "url": "https://github.com/tc39/ecma262",
+        "url": "https://262.ecma-international.org/7.0/",
         "keywords": ["es7", "ecmascript"]
     },
     {
         "name": "ESNext",
-        "url": "https://github.com/tc39/ecma262",
+        "url": "https://tc39.es/ecma262/",
         "keywords": ["esnext", "ecmascript"]
     },
     {
@@ -45,7 +45,7 @@
         "status": {
             "status": "Supported"
         },
-        "url": "http://webassembly.github.io",
+        "url": "https://webassembly.github.io/spec/",
         "webkit-url": "https://bugs.webkit.org/show_bug.cgi?id=146064",
         "description": "WebAssembly is a new format for native programs on the web. It aims to support everything that asm.js supports, but allows the VM to sidestep the JS parsing and profiling pipeline entirely.",
         "keywords": ["webassembly", "wasm", "webassy"],
@@ -64,7 +64,7 @@
             "status": "Supported",
             "enabled-by-default": true
         },
-        "url": "https://people.mozilla.org/~jorendorff/es6-draft.html#sec-array.prototype.copywithin",
+        "url": "https://262.ecma-international.org/6.0/#sec-array.prototype.copywithin",
         "documentation-url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/copyWithin",
         "webkit-url": "https://bugs.webkit.org/show_bug.cgi?id=145107",
         "specification": "ES6",
@@ -79,7 +79,7 @@
             "status": "Supported",
             "enabled-by-default": true
         },
-        "url": "https://github.com/tc39/Array.prototype.includes",
+        "url": "https://262.ecma-international.org/7.0/#sec-array.prototype.includes",
         "documentation-url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes",
         "webkit-url": "https://bugs.webkit.org/show_bug.cgi?id=142707",
         "specification": "ES7"
@@ -162,11 +162,11 @@
             "status": "Supported",
             "enabled-by-default": true
         },
-        "url": "https://tc39.github.io/ecma262/#prod-ExponentiationExpression",
+        "url": "https://262.ecma-international.org/7.0/#sec-exp-operator",
         "specification": "ES7",
         "description": "Exponentiation syntax (like x ** y) provides the syntax suger for exponentiation.",
         "webkit-url": "https://bugs.webkit.org/show_bug.cgi?id=159969",
-        "documentation-url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Exponentiation_(**)",
+        "documentation-url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Exponentiation",
         "contact": {
             "name": "Yusuke Suzuki",
             "twitter": "@Constellation",
@@ -196,7 +196,7 @@
             "status": "Supported",
             "enabled-by-default": true
         },
-        "url": "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-map-constructor",
+        "url": "hhttp://www.ecma-international.org/ecma-262/6.0/index.html#sec-map-objects",
         "documentation-url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map",
         "webkit-url": "https://bugs.webkit.org/show_bug.cgi?id=120333",
         "description": "Map provides an <a href=\"https://en.wikipedia.org/wiki/Associative_array\">associative array data</a> structure that maps keys to values.",
@@ -220,7 +220,7 @@
             "status": "Supported",
             "enabled-by-default": true
         },
-        "url": "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-number-objects",
+        "url": "http://www.ecma-international.org/ecma-262/6.0/index.html#sec-number-objects",
         "documentation-url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
         "webkit-url": "https://bugs.webkit.org/show_bug.cgi?id=131707",
         "specification": "ES6",
@@ -232,7 +232,7 @@
             "status": "Supported",
             "enabled-by-default": true
         },
-        "url": "https://github.com/tc39/proposal-object-rest-spread",
+        "url": "https://tc39.es/proposal-object-rest-spread/",
         "documentation-url": "http://2ality.com/2016/10/rest-spread-properties.html",
         "specification": "ESNext",
         "description": "New syntax for gathering the rest of an object's properties when using destructuring."
@@ -243,7 +243,7 @@
             "status": "Supported",
             "enabled-by-default": true
         },
-        "url": "https://people.mozilla.org/~jorendorff/es6-draft.html#sec-literals-numeric-literals",
+        "url": "https://262.ecma-international.org/6.0/#sec-literals-numeric-literals",
         "webkit-url": "https://bugs.webkit.org/show_bug.cgi?id=142681",
         "specification": "ES6",
         "description": "New syntax for number literals. Numbers can be provided as binary (e.g. 0b001001) or octal (e.g. 0o24)."
@@ -255,7 +255,7 @@
             "enabled-by-default": true,
             "shipped": ["ios8-safari", "osx-safari-7.1"]
         },
-        "url": "https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects",
+        "url": "https://262.ecma-international.org/6.0/#sec-promise-objects",
         "documentation-url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise",
         "webkit-url": "https://bugs.webkit.org/show_bug.cgi?id=120260",
         "specification": "ES6"
@@ -266,6 +266,7 @@
             "status": "Supported"
         },
         "url": "http://www.ecma-international.org/ecma-262/6.0/index.html#sec-proxy-objects",
+        "documentation-url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy",
         "webkit-url": "https://bugs.webkit.org/show_bug.cgi?id=35731",
         "specification": "ES6",
         "description": "An intermediary object that defines custom basic behaviors of another object such as property lookup, assignment, enumeration.",
@@ -308,7 +309,7 @@
             "status": "Supported",
             "enabled-by-default": true
         },
-        "url": "https://people.mozilla.org/~jorendorff/es6-draft.html#sec-set-constructor",
+        "url": "https://262.ecma-international.org/6.0/#sec-set-constructor",
         "documentation-url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set",
         "webkit-url": "https://bugs.webkit.org/show_bug.cgi?id=120549",
         "description": "Set is a collection of unique objects.",
@@ -320,7 +321,7 @@
             "status": "Supported",
             "enabled-by-default": true
         },
-        "url": "https://people.mozilla.org/~jorendorff/es6-draft.html#sec-symbol-objects",
+        "url": "https://262.ecma-international.org/6.0/#sec-symbol-objects",
         "documentation-url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol",
         "webkit-url": "https://bugs.webkit.org/show_bug.cgi?id=140435",
         "specification": "ES6",
@@ -335,7 +336,7 @@
             "status": "Supported",
             "enabled-by-default": true
         },
-        "url": "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-tagged-templates",
+        "url": "https://262.ecma-international.org/6.0/#sec-tagged-templates",
         "documentation-url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/template_strings",
         "webkit-url": "https://bugs.webkit.org/show_bug.cgi?id=143183",
         "description": "The tagged-templates (like String.raw`Hello ${World}`) provides a way to modify the produced string from a given template-literals with a function.",
@@ -362,7 +363,7 @@
             "status": "Supported",
             "enabled-by-default": true
         },
-        "url": "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-template-literals",
+        "url": "https://262.ecma-international.org/6.0/#sec-template-literals",
         "documentation-url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/template_strings",
         "webkit-url": "https://bugs.webkit.org/show_bug.cgi?id=142691",
         "description": "The template-literals (like `Hello ${World}`) provides string interpolation feature. Line terminators are also allowed in the template-literals.",
@@ -378,7 +379,7 @@
             "status": "Supported",
             "enabled-by-default": true
         },
-        "url": "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-weakmap-objects",
+        "url": "https://262.ecma-international.org/6.0/#sec-weakmap-objects",
         "documentation-url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap",
         "webkit-url": "https://bugs.webkit.org/show_bug.cgi?id=120912",
         "description": "WeakMap provides an <a href=\"https://en.wikipedia.org/wiki/Associative_array\">associative array data</a> structure that maps keys to values. WeakMap's keys must be objects.",
@@ -390,7 +391,7 @@
             "status": "Supported",
             "enabled-by-default": true
         },
-        "url": "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-weakset-objects",
+        "url": "https://262.ecma-international.org/6.0/#sec-weakset-objects",
         "documentation-url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakSet",
         "webkit-url": "https://bugs.webkit.org/show_bug.cgi?id=142408",
         "description": "WeakSet is a collection of unique objects. Keys stored in WeakSet are referenced weakly.",
@@ -422,7 +423,7 @@
             "status": "Supported",
             "enabled-by-default": true
         },
-        "url": "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-for-in-and-for-of-statements",
+        "url": "https://262.ecma-international.org/6.0/#sec-for-in-and-for-of-statements",
         "documentation-url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of",
         "description": "The for...of loops iterate over the values provided by the iterator of the target object.",
         "specification": "ES6",

--- a/Source/WebCore/features.json
+++ b/Source/WebCore/features.json
@@ -1160,12 +1160,12 @@
     {
         "name": "Payment Request",
         "status": {
-            "status": "Supported"
+            "status": "Not Considering"
         },
         "url": "https://www.w3.org/TR/payment-request/",
         "webkit-url": "https://bugs.webkit.org/show_bug.cgi?id=174796",
         "keywords": ["web payments", "payment request", "apple pay"],
-        "description": "An API for merchants to request payments from users."
+        "description": "An API for merchants to request payments from users. Not supported in WPE WebKit."
     },
     {
         "name": "Picture element",
@@ -1429,12 +1429,12 @@
     {
         "name": "Web Share",
         "status": {
-            "status": "Supported"
+            "status": "Not Considering"
         },
         "url": "https://github.com/WICG/web-share/blob/master/docs/interface.md",
         "webkit-url": "https://bugs.webkit.org/show_bug.cgi?id=171100",
         "keywords": ["sharing"],
-        "description": "An API to allow content from the page to be exposed to platform sharing APIs."
+        "description": "An API to allow content from the page to be exposed to platform sharing APIs. Not supported by WPEWebKit."
     },
     {
         "name": "WebUSB",

--- a/Source/WebCore/features.json
+++ b/Source/WebCore/features.json
@@ -19,6 +19,7 @@
         "url": "https://www.w3.org/TR/clipboard-apis/#async-clipboard-api",
         "category": "webapps",
         "description": "An API that allows reading from and writing to the system clipboard.",
+        "webkit-url": "webkit.org/b/211979",
         "contact": {
             "name": "Wenson Hsieh",
             "email": "wenson_hsieh@apple.com",
@@ -219,11 +220,12 @@
     {
         "name": "CSS Scroll Snap Points Module Level 1",
         "status": {
-            "status": "Supported",
-            "enabled-by-default": true
+            "status": "In development",
+            "enabled-by-default": false
         },
         "url": "http://dev.w3.org/csswg/css-snappoints/",
-        "webkit-url": "https://bugs.webkit.org/show_bug.cgi?id=134283",
+        "description": "Supported first in WPE 2.34.",
+        "webkit-url": "https://bugs.webkit.org/show_bug.cgi?id=203684",
         "keywords": ["css scroll snap points", "scroll snap", "snap points"],
         "category": "css",
         "contact": {
@@ -352,9 +354,10 @@
     {
         "name": "DeviceOrientation Events",
         "status": {
-            "status": "Supported",
-            "enabled-by-default": true
+            "status": "In Development",
+            "enabled-by-default": false
         },
+        "webkit-url": "https://bugs.webkit.org/show_bug.cgi?id=242637",
         "description": "DOM events that provide information about the physical orientation and motion of a hosting device.",
         "url": "https://w3c.github.io/deviceorientation/spec-source-orientation.html",
         "keywords": ["device orientation", "devicemotion", "acceleration", "rotation"],
@@ -401,13 +404,13 @@
     {
         "name": "Gamepad",
         "status": {
-            "status": "Supported"
+            "status": "In development"
         },
         "url": "https://www.w3.org/TR/gamepad/",
-        "webkit-url": "https://webkit.org/b/134076",
+        "webkit-url": "https://github.com/WebKit/WebKit/commit/ab0e24752e11bbdb584662dcd5369ce17f4da1de",
         "keywords": ["gamepad", "gaming", "games", "controller"],
         "category": "webapps",
-        "description": "An interface for accessing and responding to game controller device state.",
+        "description": "An interface for accessing and responding to game controller device state. Support enabled in upstream WPE main branch.",
         "contact": {
             "name": "Jonathan Davis",
             "email": "web-evangelist@apple.com",
@@ -474,7 +477,7 @@
         "status": {
             "status": "Supported"
         },
-        "url": "https://wicg.github.io/IntersectionObserver/",
+        "url": "https://www.w3.org/TR/intersection-observer/",
         "webkit-url": "https://bugs.webkit.org/show_bug.cgi?id=159475",
         "keywords": ["intersection", "intersection observer", "intersectionobserver"],
         "description": "An API that can be used to understand the visibility and position of DOM elements relative to a containing element or to the top-level viewport."
@@ -541,10 +544,10 @@
     {
         "name": "Pointer Lock",
         "status": {
-            "status": "Supported"
+            "status": "In development"
         },
         "url": "https://www.w3.org/TR/pointerlock/",
-        "webkit-url": "https://bugs.webkit.org/show_bug.cgi?id=164652",
+        "webkit-url": "https://bugs.webkit.org/show_bug.cgi?id=204001",
         "keywords": ["pointer", "pointer lock"],
         "description": "Provides scripted access to raw mouse movement data while locking the target of mouse events to a single element and removing the cursor from view."
     },


### PR DESCRIPTION
- Backport of upstream changes
- AsyncClipboard - Not yet supported
- CSS Scroll snap - Supported in WPE 2.34
- Device orientation API - Not yet supported
- Gamepad API - Landed in upstream main after 2.38 branched
- Pointer lock - Not yet supported

Remaining bits: "features" list of `Source/WebCore/features.json` for the more CSS-specific bits