### PR TITLE
Add missing header to avoid non-unified build issues

### DIFF
--- a/Source/WebCore/platform/encryptedmedia/CDMInstance.h
+++ b/Source/WebCore/platform/encryptedmedia/CDMInstance.h
@@ -34,6 +34,7 @@
 #include <wtf/Forward.h>
 #include <wtf/Optional.h>
 #include <wtf/RefCounted.h>
+#include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/TypeCasts.h>
 #include <wtf/Vector.h>
 


### PR DESCRIPTION
```
* Source/WebCore/platform/encryptedmedia/CDMInstance.h: Add inclusion of the wtf/ThreadSafeRefCounted.h header.
```