### PR TITLE
[WPE2.22] [Backport] Fix SameSite cookie attribute presentation in Web Inspector

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Models/Cookie.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Cookie.js
@@ -116,18 +116,19 @@ WI.Cookie = class Cookie
         }
     }
 
-    // Derived from <https://tools.ietf.org/html/draft-west-first-party-cookies-06#section-3.2>.
     static parseSameSiteAttributeValue(attributeValue)
     {
         if (!attributeValue)
-            return WI.Cookie.SameSiteType.Strict;
+            return WI.Cookie.SameSiteType.None;
+
         switch (attributeValue.toLowerCase()) {
         case "lax":
             return WI.Cookie.SameSiteType.Lax;
         case "strict":
-        default:
             return WI.Cookie.SameSiteType.Strict;
         }
+
+        return WI.Cookie.SameSiteType.None;
     }
 
     static parseSetCookieResponseHeader(header)


### PR DESCRIPTION
In Web Inspector, in Network tab SameSite attribute is shown as Strict even when attribute was set to None.
This issue is causing misleading among web developers.

Issue can be reproduce with this testcase: https://a1c339d1-7320-428e-98c7-2a65bea6f031.mock.pstmn.io/samesite

![network_tab](https://user-images.githubusercontent.com/42027818/196244371-d4a9b277-7eaf-43a4-a1ce-4ece41a51bfd.png)

On other Web Inspector tabs (Resources, Storage) SameSite attribute has correct value:
![resources_tab](https://user-images.githubusercontent.com/42027818/196244402-fc3ed4fd-f93e-45f8-b326-993d3a0ffa71.png)

![storage_tab](https://user-images.githubusercontent.com/42027818/196244420-e116cc1a-9f88-4933-b7f8-b9369dab35c2.png)

Fix is based on upstream PR:
https://github.com/WebKit/WebKit/commit/644049b6feb