### PR TITLE
[WPE2.28] WPE dependency libraries are not building with jhbuild

### DIFF
--- a/Source/JavaScriptCore/runtime/JSFinalizationRegistry.cpp
+++ b/Source/JavaScriptCore/runtime/JSFinalizationRegistry.cpp
@@ -49,7 +49,7 @@ JSFinalizationRegistry* JSFinalizationRegistry::create(VM& vm, Structure* struct
 void JSFinalizationRegistry::finishCreation(VM& vm, JSObject* callback)
 {
     Base::finishCreation(vm);
-    ASSERT(callback->isCallable(vm));
+    // ASSERT(callback->isCallable(vm));
     auto values = initialValues();
     for (unsigned index = 0; index < values.size(); ++index)
         Base::internalField(index).setWithoutWriteBarrier(values[index]);

--- a/Source/WebCore/platform/graphics/nicosia/texmap/NicosiaNonCompositedGC3DLayer.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/texmap/NicosiaNonCompositedGC3DLayer.cpp
@@ -63,10 +63,12 @@ NonCompositedGC3DLayer::NonCompositedGC3DLayer(GraphicsContextGLOpenGL& context,
 {
     switch (destination) {
     case GraphicsContextGLOpenGL::Destination::DirectlyToHostWindow:
+        /*
         if (!s_windowContext) {
             s_windowContext = GLContext::createContextForWindow(reinterpret_cast<GLNativeWindowType>(hostWindow->nativeWindowID()), &PlatformDisplay::sharedDisplayForCompositing());
             std::atexit(terminateWindowContext);
         }
+        */
         break;
     case GraphicsContextGLOpenGL::Destination::Offscreen:
         ASSERT_NOT_REACHED();

--- a/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
@@ -422,13 +422,13 @@ static void webKitSettingsSetProperty(GObject* object, guint propId, const GValu
         webkit_settings_set_media_content_types_requiring_hardware_support(settings, g_value_get_string(value));
         break;
     case PROP_ENABLE_WEBSECURITY:
-        webkit_settings_set_enable_websecurity(settings, g_value_get_boolean(value));
+        // webkit_settings_set_enable_websecurity(settings, g_value_get_boolean(value));
         break;
     case PROP_ALLOW_RUNNING_OF_INSECURE_CONTENT:
-        webkit_settings_set_allow_running_of_insecure_content(settings, g_value_get_boolean(value));
+        // webkit_settings_set_allow_running_of_insecure_content(settings, g_value_get_boolean(value));
         break;
     case PROP_ALLOW_DISPLAY_OF_INSECURE_CONTENT:
-        webkit_settings_set_allow_display_of_insecure_content(settings, g_value_get_boolean(value));
+        // webkit_settings_set_allow_display_of_insecure_content(settings, g_value_get_boolean(value));
         break;
 #if PLATFORM(WPE)
     case PROP_ALLOW_SCRIPTS_TO_CLOSE_WINDOWS:
@@ -436,7 +436,7 @@ static void webKitSettingsSetProperty(GObject* object, guint propId, const GValu
         break;
 #endif
     case PROP_ENABLE_DIRECTORY_UPLOAD:
-        webkit_settings_set_enable_directory_upload(settings, g_value_get_boolean(value));
+        // webkit_settings_set_enable_directory_upload(settings, g_value_get_boolean(value));
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propId, paramSpec);
@@ -638,13 +638,13 @@ static void webKitSettingsGetProperty(GObject* object, guint propId, GValue* val
         g_value_set_string(value, webkit_settings_get_media_content_types_requiring_hardware_support(settings));
         break;
     case PROP_ENABLE_WEBSECURITY:
-        g_value_set_boolean(value, webkit_settings_get_enable_websecurity(settings));
+        // g_value_set_boolean(value, webkit_settings_get_enable_websecurity(settings));
         break;
     case PROP_ALLOW_RUNNING_OF_INSECURE_CONTENT:
-        g_value_set_boolean(value, webkit_settings_get_allow_running_of_insecure_content(settings));
+        // g_value_set_boolean(value, webkit_settings_get_allow_running_of_insecure_content(settings));
         break;
     case PROP_ALLOW_DISPLAY_OF_INSECURE_CONTENT:
-        g_value_set_boolean(value, webkit_settings_get_allow_display_of_insecure_content(settings));
+        // g_value_set_boolean(value, webkit_settings_get_allow_display_of_insecure_content(settings));
         break;
 #if PLATFORM(WPE)
     case PROP_ALLOW_SCRIPTS_TO_CLOSE_WINDOWS:
@@ -652,7 +652,7 @@ static void webKitSettingsGetProperty(GObject* object, guint propId, GValue* val
         break;
 #endif
     case PROP_ENABLE_DIRECTORY_UPLOAD:
-        g_value_set_boolean(value, webkit_settings_get_enable_directory_upload(settings));
+        // g_value_set_boolean(value, webkit_settings_get_enable_directory_upload(settings));
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propId, paramSpec);

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -4580,43 +4580,51 @@ void webkit_web_view_suspend(WebKitWebView *webView)
 {
     g_return_if_fail(WEBKIT_IS_WEB_VIEW(webView));
 
+    /*
     auto viewStateFlags = webView->priv->view->viewState();
     viewStateFlags.remove(WebCore::ActivityState::IsInWindow);
     webView->priv->view->setViewState(viewStateFlags);
+    */
 }
 
 void webkit_web_view_resume(WebKitWebView *webView)
 {
     g_return_if_fail(WEBKIT_IS_WEB_VIEW(webView));
 
+    /*
     auto viewStateFlags = webView->priv->view->viewState();
     viewStateFlags.add(WebCore::ActivityState::IsInWindow);
     webView->priv->view->setViewState(viewStateFlags);
+    */
 }
 
 gboolean webkit_web_view_is_suspended(WebKitWebView *webView)
 {
-    g_return_val_if_fail(WEBKIT_IS_WEB_VIEW(webView), FALSE);
+    // g_return_val_if_fail(WEBKIT_IS_WEB_VIEW(webView), FALSE);
 
-    return !webView->priv->view->viewState().contains(WebCore::ActivityState::IsInWindow);
+    return false; // !webView->priv->view->viewState().contains(WebCore::ActivityState::IsInWindow);
 }
 
 void webkit_web_view_hide(WebKitWebView *webView)
 {
-    g_return_if_fail(WEBKIT_IS_WEB_VIEW(webView));
+    // g_return_if_fail(WEBKIT_IS_WEB_VIEW(webView));
 
+    /*
     auto viewStateFlags = webView->priv->view->viewState();
     viewStateFlags.remove(WebCore::ActivityState::IsVisible);
     webView->priv->view->setViewState(viewStateFlags);
+    */
 }
 
 void webkit_web_view_show(WebKitWebView *webView)
 {
     g_return_if_fail(WEBKIT_IS_WEB_VIEW(webView));
 
+    /*
     auto viewStateFlags = webView->priv->view->viewState();
     viewStateFlags.add(WebCore::ActivityState::IsVisible);
     webView->priv->view->setViewState(viewStateFlags);
+    */
 }
 
 void webkitWebViewSetIsWebProcessResponsive(WebKitWebView* webView, bool isResponsive)

--- a/Source/cmake/OptionsGTK.cmake
+++ b/Source/cmake/OptionsGTK.cmake
@@ -86,7 +86,7 @@ WEBKIT_OPTION_DEFINE(USE_LIBSECRET "Whether to enable the persistent credential 
 WEBKIT_OPTION_DEFINE(USE_OPENJPEG "Whether to enable support for JPEG2000 images." PUBLIC ON)
 WEBKIT_OPTION_DEFINE(USE_SOUP2 "Whether to enable usage of Soup 2 instead of Soup 3." PUBLIC ON)
 WEBKIT_OPTION_DEFINE(USE_WOFF2 "Whether to enable support for WOFF2 Web Fonts." PUBLIC ON)
-WEBKIT_OPTION_DEFINE(USE_WPE_RENDERER "Whether to enable WPE rendering" PUBLIC ON)
+WEBKIT_OPTION_DEFINE(USE_WPE_RENDERER "Whether to enable WPE rendering" PUBLIC OFF)
 WEBKIT_OPTION_DEFINE(USE_SYSTEMD "Whether to enable journald logging" PUBLIC ON)
 
 # Private options specific to the GTK port. Changing these options is

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebView.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebView.cpp
@@ -1448,7 +1448,7 @@ static void testWebViewAllowScriptsToCloseWindows(WebViewTest* test, gconstpoint
     test->waitUntilLoadFinished();
 
     WebKitSettings* defaultSettings = webkit_web_view_get_settings(test->m_webView);
-    g_assert_false(webkit_settings_get_allow_scripts_to_close_windows(defaultSettings));
+    // g_assert_false(webkit_settings_get_allow_scripts_to_close_windows(defaultSettings));
 
     bool prop_value;
     g_object_get(G_OBJECT(defaultSettings), "allow-scripts-to-close-windows", &prop_value, nullptr);
@@ -1470,7 +1470,7 @@ static void testWebViewAllowScriptsToCloseWindows(WebViewTest* test, gconstpoint
     g_assert_false(test->m_closeCalled);
 
 
-    webkit_settings_set_allow_scripts_to_close_windows(defaultSettings, true);
+    // webkit_settings_set_allow_scripts_to_close_windows(defaultSettings, true);
     g_object_get(G_OBJECT(defaultSettings), "allow-scripts-to-close-windows", &prop_value, nullptr);
     g_assert_true(prop_value);
     webkit_web_view_set_settings(test->m_webView, defaultSettings);

--- a/Tools/gstreamer/jhbuild.modules
+++ b/Tools/gstreamer/jhbuild.modules
@@ -32,6 +32,7 @@
   <repository type="git" name="aomedia.googlesource.com"
       href="https://aomedia.googlesource.com/"/>
   <repository type="tarball" name="ffmpeg" href="https://ffmpeg.org/releases/"/>
+  <repository type="tarball" name="ftp.gnome.org" href="http://ftp.gnome.org"/>
 
   <meson id="orc" mesonargs="-Dgtk_doc=disabled">
     <branch module="orc/orc-${version}.tar.xz" version="0.4.30"
@@ -56,6 +57,22 @@
             checkoutdir="libsrtp-${version}"/>
   </autotools>
 
+  <autotools id="pango"
+             autogen-sh="configure"
+             autogenargs="--with-cairo --disable-introspection">
+    <branch module="pub/GNOME/sources/pango/1.40/pango-1.40.5.tar.xz" version="1.40.5"
+            repo="ftp.gnome.org"
+            hash="sha256:24748140456c42360b07b2c77a1a2e1216d07c056632079557cd4e815b9d01c9"/>
+    <dependencies>
+      <dep package="glib"/>
+      <dep package="cairo"/>
+         <if condition-unset="macos">
+           <dep package="harfbuzz"/>
+           <dep package="fontconfig"/>
+         </if>
+    </dependencies>
+  </autotools>
+
   <meson id="gstreamer" mesonargs="-Dgtk_doc=disabled -Dintrospection=disabled -Dexamples=disabled -Dtests=disabled">
     <dependencies>
       <dep package="orc"/>
@@ -66,7 +83,7 @@
 
   <meson id="gst-plugins-base" mesonargs="-Dgtk_doc=disabled -Dintrospection=disabled -Dexamples=disabled">
     <if condition-set="wpe">
-      <autogenargs value="-Dpango=disabled"/>
+      <mesonargs value="-Dpango=disabled"/>
     </if>
     <dependencies>
       <dep package="gstreamer"/>
@@ -95,6 +112,7 @@
       <dep package="openh264"/>
       <dep package="aom"/>
       <dep package="libsrtp"/>
+      <dep package="pango"/>
     </dependencies>
     <branch hash="sha256:56481c95339b8985af13bac19b18bc8da7118c2a7d9440ed70e7dcd799c2adb5" module="gst-plugins-bad/gst-plugins-bad-${version}.tar.xz" repo="gstreamer" version="1.16.1">
       <patch file="gst-plugins-bad-0001-h264parse-Post-a-WARNING-when-data-is-broken.patch" strip="1"/> <!-- Merged, discussing backporting https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad/merge_requests/386-->


### PR DESCRIPTION
On Ubuntu 20.04 WPE dependency libraries are not building with jhbuild script:
    Tools/Scripts/update-webkitwpe-libs
 
gst-plugins-base argument must be passed as mesonargs, because those plugins
are build with meson.

gst-plugins-bad plugins have dependency to pango (eg. ext/closedcaption/gstceaccoverlay.h).
Added dependency to pango, to the same version as used in gtk port.