### PR TITLE
[WebAudio][Amlogic] Play webaudio as system sound

### DIFF
--- a/Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp
@@ -44,11 +44,13 @@ gboolean messageCallback(GstBus*, GstMessage* message, AudioDestinationGStreamer
     return destination->handleMessage(message);
 }
 
+#if !PLATFORM(AMLOGIC)
 static void autoAudioSinkChildAddedCallback(GstChildProxy*, GObject* object, gchar*, gpointer)
 {
     if (GST_IS_AUDIO_BASE_SINK(object))
         g_object_set(GST_AUDIO_BASE_SINK(object), "buffer-time", static_cast<gint64>(100000), nullptr);
 }
+#endif
 
 std::unique_ptr<AudioDestination> AudioDestination::create(AudioIOCallback& callback, const String&, unsigned numberOfInputChannels, unsigned numberOfOutputChannels, float sampleRate)
 {
@@ -95,15 +97,27 @@ AudioDestinationGStreamer::AudioDestinationGStreamer(AudioIOCallback& callback, 
                                                                             "provider", &m_callback,
                                                                             "frames", framesToPull, nullptr));
 
+#if PLATFORM(AMLOGIC)
+    // autoaudiosink changes child element state to READY internally in auto detection phase
+    // that causes resource acquisition in some cases interrupting any playback already running.
+    // On Amlogic we need to set direct-mode=false prop before changeing state to READY
+    // but this is not possible with autoaudiosink.
+    GRefPtr<GstElement> audioSink = gst_element_factory_make("amlhalasink", nullptr);
+    if (!audioSink) {
+        LOG_ERROR("Failed to create GStreamer amlhalasink element");
+        return;
+    }
+    g_object_set(audioSink.get(), "direct-mode", FALSE, nullptr);
+#else
     GRefPtr<GstElement> audioSink = gst_element_factory_make("autoaudiosink", nullptr);
-    m_audioSinkAvailable = audioSink;
     if (!audioSink) {
         LOG_ERROR("Failed to create GStreamer autoaudiosink element");
         return;
     }
-
     g_signal_connect(audioSink.get(), "child-added", G_CALLBACK(autoAudioSinkChildAddedCallback), nullptr);
+#endif
 
+    m_audioSinkAvailable = audioSink;
     // Autoaudiosink does the real sink detection in the GST_STATE_NULL->READY transition
     // so it's best to roll it to READY as soon as possible to ensure the underlying platform
     // audiosink was loaded correctly.


### PR DESCRIPTION
Set Amlogic audio sink property direct-mode=false so webaudio is treated as system sound and won't collide with other kind of audio playbacks (main, text to speech)