### PR TITLE
[WPE2.28] Fix debug WPE compilation with jhbuild

### DIFF
--- a/Source/JavaScriptCore/runtime/JSFinalizationRegistry.cpp
+++ b/Source/JavaScriptCore/runtime/JSFinalizationRegistry.cpp
@@ -49,7 +49,6 @@ JSFinalizationRegistry* JSFinalizationRegistry::create(VM& vm, Structure* struct
 void JSFinalizationRegistry::finishCreation(VM& vm, JSObject* callback)
 {
     Base::finishCreation(vm);
-    ASSERT(callback->isCallable(vm));
     auto values = initialValues();
     for (unsigned index = 0; index < values.size(); ++index)
         Base::internalField(index).setWithoutWriteBarrier(values[index]);

--- a/Source/cmake/OptionsWPE.cmake
+++ b/Source/cmake/OptionsWPE.cmake
@@ -83,7 +83,7 @@ WEBKIT_OPTION_DEFINE(USE_WOFF2 "Whether to enable support for WOFF2 Web Fonts." 
 WEBKIT_OPTION_DEFINE(ENABLE_WPE_QT_API "Whether to enable support for the Qt5/QML plugin" PUBLIC OFF)
 WEBKIT_OPTION_DEFINE(USE_SYSTEMD "Whether to enable journald logging" PUBLIC OFF)
 WEBKIT_OPTION_DEFINE(ENABLE_BREAKPAD "Whether or not enable breakpad minidump support." PUBLIC OFF)
-WEBKIT_OPTION_DEFINE(USE_SOUP2 "Whether to enable usage of Soup 2 instead of Soup 3." PUBLIC OFF)
+WEBKIT_OPTION_DEFINE(USE_SOUP2 "Whether to enable usage of Soup 2 instead of Soup 3." PUBLIC ON)
 
 # Private options specific to the WPE port.
 WEBKIT_OPTION_DEFINE(USE_GSTREAMER_HOLEPUNCH "Whether to enable GStreamer holepunch" PRIVATE OFF)


### PR DESCRIPTION
jhbuild is using libsoup in version 2.69.90 (Tools/wpe/jhbuild.modules), so we are using soup2.

callback->isCallable(vm) call has to few required arguments. Code is compiling on release build (with disabled ASSERT_ENABLED flag) because it's translated there to (void)0

Compilation platform: ubuntu 20.04 / gcc 9.4