### PR TITLE
XIONE-10367: Fix readyState calculations

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -1418,6 +1418,7 @@ GstElement* MediaPlayerPrivateGStreamer::createAudioSink()
     GstElement* audioSinkBin = gst_bin_new("audio-sink");
     ensureAudioSourceProvider();
     m_audioSourceProvider->configureAudioBin(audioSinkBin, nullptr);
+    m_autoAudioSink = audioSinkBin;
     return audioSinkBin;
 #else
     return m_autoAudioSink.get();
@@ -2494,9 +2495,10 @@ void MediaPlayerPrivateGStreamer::updateStates()
                 GRefPtr<GstQuery> query = adoptGRef(gst_query_new_buffering(GST_FORMAT_PERCENT));
 
                 m_isBuffering = m_bufferingPercentage < 100;
-                if (gst_element_query(m_pipeline.get(), query.get())) {
+                if ((m_autoAudioSink && gst_element_query(m_autoAudioSink.get(), query.get())) || (m_videoSink && gst_element_query(m_videoSink.get(), query.get()))) {
                     gboolean isBuffering = m_isBuffering;
                     gst_query_parse_buffering_percent(query.get(), &isBuffering, nullptr);
+                    GST_TRACE_OBJECT(pipeline(), "[Buffering] m_isBuffering forcefully updated from %d to %d", m_isBuffering, isBuffering);
                     m_isBuffering = isBuffering;
                 }
 


### PR DESCRIPTION
## This PR fixes:
 - the problem with unreliable `buffering` messages
 - the imprecise `buffering` query
 - `m_autoAudioSink` audio sink handle being invalid in case of `WEB_AUDIO` being enabled

### The problem with unreliable buffering messages

On some platforms we have a very interesting situation where audio sink is acting as a fake sink while the decoder fetches data from the pipeline and transfers it to the SoC drivers. In other words - the decoder consumes and removes the data from the gstreamer pipeline. What's worse, it's being done even in `READY` and `PAUSED` states.

Now, in webkit, if progressive playback player is in `READY` or `PAUSED` state, we're assuming the `queue2` element (or `multiqueue` for AV pipelines) is very much the only place which accumulates the data and thus we treat it like a reliable source of information on whether we have enough data to play or not. This is being reflected in that part of code:
https://github.com/WebPlatformForEmbedded/WPEWebKit/blob/a2a845b5e14475fc940ec5b80a71c6b7aaa91ed6/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp#L2204-L2237

The above is fine as long as the pipeline behaves just like https://gstreamer.freedesktop.org/documentation/additional/design/buffering.html?gi-language=c describes. However, on our specific platform mentioned on the very beginning it is not the case.
What happens is the following: for pipelines with very low download speed (like e.g. livestreams) we're slowly feeding the `queue2` element with data (regardless the READY/PAUSED/PLAYING state) while the decoder is consuming the data very fast from the very same `queue2` element at the same time. It means, the sequence of `buffering` messages from `queue2` element may e.g. look like `0%->10%->20%->3%->77%->0%->11%->(...)` until the SoC buffer (outside of the gstreamer pipeline) is filled or we get `100%` just by chances. So, generally speaking, in that situation (on that platform) we cannot really relay on `buffering` messages anymore - regardless the state a player is in.

Luckily enough, on that platform, the audio sink implements `buffering` query, so we can query actual information on whether we have enough data to play or not. Thus proposed fix makes sure that the query starts from audio sink.

### The imprecise buffering query

This piece of code:
https://github.com/WebPlatformForEmbedded/WPEWebKit/blob/a2a845b5e14475fc940ec5b80a71c6b7aaa91ed6/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp#L2490-L2503
was (according to the commit message in the change it originates from https://github.com/WebKit/WebKit/commit/04ef1db1be2bbc4a9dd16dba586aadc4ba8661a5) meant for specific use case where pipeline contains the `downloadbuffer` element.
Since the query is issued to the entire pipeline, on some platforms it may yield misleading results if some random element implements `buffering` query and receives that query first. Thus this fix proposes strict order of querying i.e. starting from audio sunk and then video sink.