### PR TITLE
[ThreadedRendering] Enable feature on non development builds

### DIFF
--- a/Source/WebCore/platform/graphics/nicosia/NicosiaPaintingEngine.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaPaintingEngine.cpp
@@ -36,7 +36,7 @@ namespace Nicosia {
 
 std::unique_ptr<PaintingEngine> PaintingEngine::create()
 {
-#if (ENABLE(DEVELOPER_MODE) && PLATFORM(WPE)) || USE(GTK4)
+#if PLATFORM(WPE) || USE(GTK4)
 #if USE(GTK4)
     unsigned numThreads = 4;
 #else


### PR DESCRIPTION
This fix bases on change from wpe 2.28 branch:
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/c12f4aeaddbf9ac12aaecffe76d223c05f14a6d3