### PR TITLE
Add web extensions API to allowlist access to a security origin

### DIFF
--- a/Source/WebCore/page/SecurityOrigin.cpp
+++ b/Source/WebCore/page/SecurityOrigin.cpp
@@ -313,6 +313,8 @@ bool SecurityOrigin::isSameOriginDomain(const SecurityOrigin& other) const
     if (canAccess && isLocal())
         canAccess = passesFileCheck(other);
 
+    canAccess |= SecurityPolicy::isAccessAllowed(*this, other, other.toURL());
+
     return canAccess;
 }
 

--- a/Source/WebKit/UIProcess/API/wpe/WebKitSecurityOrigin.h
+++ b/Source/WebKit/UIProcess/API/wpe/WebKitSecurityOrigin.h
@@ -17,7 +17,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#if !defined(__WEBKIT_H_INSIDE__) && !defined(WEBKIT2_COMPILATION)
+#if !defined(__WEBKIT_H_INSIDE__) && !defined(WEBKIT2_COMPILATION) && !defined(__WEBKIT_WEB_EXTENSION_H_INSIDE__)
 #error "Only <wpe/webkit.h> can be included directly."
 #endif
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebExtension.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebExtension.cpp
@@ -23,6 +23,7 @@
 #include "APIDictionary.h"
 #include "APIInjectedBundleBundleClient.h"
 #include "APIString.h"
+#include "WebKitSecurityOriginPrivate.h"
 #include "WebKitUserMessagePrivate.h"
 #include "WebKitWebExtensionPrivate.h"
 #include "WebKitWebPagePrivate.h"
@@ -122,6 +123,7 @@ enum {
 typedef HashMap<WebPage*, GRefPtr<WebKitWebPage> > WebPageMap;
 
 struct _WebKitWebExtensionPrivate {
+    RefPtr<InjectedBundle> bundle;
     WebPageMap pages;
 #if ENABLE(DEVELOPER_MODE)
     bool garbageCollectOnPageDestroy;
@@ -211,6 +213,7 @@ private:
 WebKitWebExtension* webkitWebExtensionCreate(InjectedBundle* bundle)
 {
     WebKitWebExtension* extension = WEBKIT_WEB_EXTENSION(g_object_new(WEBKIT_TYPE_WEB_EXTENSION, NULL));
+    extension->priv->bundle = bundle;
     bundle->setClient(makeUnique<WebExtensionInjectedBundleClient>(extension));
     return extension;
 }
@@ -250,6 +253,31 @@ WebKitWebPage* webkit_web_extension_get_page(WebKitWebExtension* extension, guin
             return it->value.get();
 
     return 0;
+}
+
+void webkit_web_extension_add_origin_access_whitelist_entry(WebKitWebExtension* extension, WebKitSecurityOrigin* origin, const char* protocol, const char* host, gboolean allowSubdomains)
+{
+    g_return_if_fail(WEBKIT_IS_WEB_EXTENSION(extension));
+    g_return_if_fail(origin);
+    g_return_if_fail(protocol);
+
+    extension->priv->bundle->addOriginAccessAllowListEntry(webkitSecurityOriginGetSecurityOriginData(origin).toString(), String::fromUTF8(protocol), String::fromUTF8(host), host ? allowSubdomains : true);
+}
+
+void webkit_web_extension_remove_origin_access_whitelist_entry(WebKitWebExtension* extension, WebKitSecurityOrigin* origin, const char* protocol, const char* host, gboolean allowSubdomains)
+{
+    g_return_if_fail(WEBKIT_IS_WEB_EXTENSION(extension));
+    g_return_if_fail(origin);
+    g_return_if_fail(protocol);
+
+    extension->priv->bundle->removeOriginAccessAllowListEntry(webkitSecurityOriginGetSecurityOriginData(origin).toString(), String::fromUTF8(protocol), String::fromUTF8(host), host ? allowSubdomains : true);
+}
+
+void webkit_web_extension_reset_origin_access_whitelists(WebKitWebExtension* extension)
+{
+    g_return_if_fail(WEBKIT_IS_WEB_EXTENSION(extension));
+
+    extension->priv->bundle->resetOriginAccessAllowLists();
 }
 
 /**

--- a/Source/WebKit/WebProcess/InjectedBundle/API/wpe/WebKitWebExtension.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/wpe/WebKitWebExtension.h
@@ -26,6 +26,7 @@
 
 #include <glib-object.h>
 #include <wpe/WebKitDefines.h>
+#include <wpe/WebKitSecurityOrigin.h>
 #include <wpe/WebKitUserMessage.h>
 #include <wpe/WebKitWebPage.h>
 
@@ -82,6 +83,23 @@ webkit_web_extension_get_type                       (void);
 WEBKIT_API WebKitWebPage *
 webkit_web_extension_get_page                       (WebKitWebExtension *extension,
                                                      guint64             page_id);
+
+WEBKIT_API void
+webkit_web_extension_add_origin_access_whitelist_entry    (WebKitWebExtension   *extension,
+                                                           WebKitSecurityOrigin *origin,
+                                                           const gchar          *protocol,
+                                                           const gchar          *host,
+                                                           gboolean              allow_subdomains);
+
+WEBKIT_API void
+webkit_web_extension_remove_origin_access_whitelist_entry (WebKitWebExtension   *extension,
+                                                           WebKitSecurityOrigin *origin,
+                                                           const gchar          *protocol,
+                                                           const gchar          *host,
+                                                           gboolean              allow_subdomains);
+
+WEBKIT_API void
+webkit_web_extension_reset_origin_access_whitelists       (WebKitWebExtension   *extension);
 
 WEBKIT_API void
 webkit_web_extension_send_message_to_context        (WebKitWebExtension *extension,

--- a/Source/WebKit/WebProcess/InjectedBundle/API/wpe/webkit-web-extension.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/wpe/webkit-web-extension.h
@@ -32,6 +32,7 @@
 #include <wpe/WebKitContextMenuItem.h>
 #include <wpe/WebKitFrame.h>
 #include <wpe/WebKitScriptWorld.h>
+#include <wpe/WebKitSecurityOrigin.h>
 #include <wpe/WebKitURIRequest.h>
 #include <wpe/WebKitURIResponse.h>
 #include <wpe/WebKitUserMessage.h>


### PR DESCRIPTION
This fix bases on change from wpe-2.28:
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/a279cbbc6a883a4f1fd6963b52b9aa93e0559fe0