### PR TITLE
[API] Add webkit_web_context_garbage_collect_javascript_objects method

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp
@@ -1930,6 +1930,21 @@ const gchar* webkit_web_context_get_time_zone_override(WebKitWebContext* context
     return context->priv->timeZoneOverride.data();
 }
 
+/**
+ * webkit_web_context_garbage_collect_javascript_objects:
+ * @context: the #WebKitWebContext
+ *
+ * Requests a garbage collection of the javascript objects to all processes.
+ *
+ * Since: 2.28
+ */
+void webkit_web_context_garbage_collect_javascript_objects(WebKitWebContext* context)
+{
+    g_return_if_fail(WEBKIT_IS_WEB_CONTEXT(context));
+
+    context->priv->processPool->garbageCollectJavaScriptObjects();
+}
+
 void webkitWebContextInitializeNotificationPermissions(WebKitWebContext* context)
 {
     g_signal_emit(context, signals[INITIALIZE_NOTIFICATION_PERMISSIONS], 0);

--- a/Source/WebKit/UIProcess/API/wpe/WebKitWebContext.h
+++ b/Source/WebKit/UIProcess/API/wpe/WebKitWebContext.h
@@ -294,6 +294,11 @@ webkit_web_context_send_message_to_all_extensions   (WebKitWebContext           
 WEBKIT_API const gchar*
 webkit_web_context_get_time_zone_override           (WebKitWebContext              *context);
 
+WEBKIT_API void
+webkit_web_context_garbage_collect_javascript_objects
+                                                    (WebKitWebContext              *context);
+
+
 G_END_DECLS
 
 #endif


### PR DESCRIPTION
This patch is ported from wpe-2.28:
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/c59af439218a6354b5a79ab0ee2d661f25d55c19