### PR TITLE
Limit queue high-watermark for REALTEK platform only

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -3932,8 +3932,10 @@ void MediaPlayerPrivateGStreamer::configureElement(GstElement* element)
     }
 #endif
 
+#if PLATFORM(REALTEK)
     if (!g_strcmp0(G_OBJECT_TYPE_NAME(G_OBJECT(element)), "GstQueue2"))
         g_object_set(G_OBJECT(element), "high-watermark", 0.10, nullptr);
+#endif
 }
 
 void MediaPlayerPrivateGStreamer::checkPlayingConsitency()


### PR DESCRIPTION
This narrows https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/953 to REALTEK platform only as the source of original issue.

queue2 by default uses max 2sec of buffering (estimated from input data bitrate) and setting high-watermark as 0.1 limits this to 0.2sec that shinks the buffer to be very small.

As a result queue2 is constantly sending buffering messages (especially at the begining of playback) with random values 0-100% as it's very easy for the pipeline to completely drain the queue.

REALTEK platform decoder doesn't seem to limit audio buffering enough so for audio live streams it is taking a lot of time to fill up.