### PR TITLE
[GStreamer] Remove unrealistic stalled events

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -1987,11 +1987,16 @@ bool MediaPlayerPrivateGStreamer::didLoadingProgress() const
     if (isLiveStream())
         return true;
 
+    // A WebKitWebSource with download paused on purpose isn't stalled because of network.
+    if (m_source && WEBKIT_IS_WEB_SRC(m_source.get()) && webKitWebSrcIsPaused(WEBKIT_WEB_SRC(m_source.get())))
+        return true;
+
     if (UNLIKELY(!m_pipeline || !durationMediaTime() || (!isMediaSource() && !totalBytes())))
         return false;
 
     MediaTime currentMaxTimeLoaded = maxTimeLoaded();
-    bool didLoadingProgress = currentMaxTimeLoaded != m_maxTimeLoadedAtLastDidLoadingProgress;
+    bool didLoadingProgress = currentMaxTimeLoaded != m_maxTimeLoadedAtLastDidLoadingProgress
+        && currentMaxTimeLoaded > m_cachedPosition;
     m_maxTimeLoadedAtLastDidLoadingProgress = currentMaxTimeLoaded;
     GST_LOG("didLoadingProgress: %s", toString(didLoadingProgress).utf8().data());
     return didLoadingProgress;

--- a/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
@@ -864,6 +864,11 @@ bool webKitSrcPassedCORSAccessCheck(WebKitWebSrc* src)
     return src->priv->didPassAccessControlCheck;
 }
 
+bool webKitWebSrcIsPaused(WebKitWebSrc* src)
+{
+    return src->priv->paused;
+}
+
 CachedResourceStreamingClient::CachedResourceStreamingClient(WebKitWebSrc* src, ResourceRequest&& request)
     : m_src(GST_ELEMENT(src))
     , m_request(WTFMove(request))

--- a/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.h
@@ -51,6 +51,7 @@ struct _WebKitWebSrcClass {
 GType webkit_web_src_get_type(void);
 void webKitWebSrcSetMediaPlayer(WebKitWebSrc*, WebCore::MediaPlayer*);
 bool webKitSrcPassedCORSAccessCheck(WebKitWebSrc*);
+bool webKitWebSrcIsPaused(WebKitWebSrc*);
 
 G_END_DECLS
 


### PR DESCRIPTION
Considering only webkit-network-statistics to evaluate network download stalls isn't very realistic. On the one hand, the download may just not progress because WebKitWebSrc may simply have decided to pause the download on purpose when it's full of data (and that doesn't mean that the network itself is stalled).

On the other hand, when trying to detect stalls only when there's an active download in progress, the download itself may be stalled, but there may be plenty of buffered content to play. Therefore it would be weird that tha webpage decided to show a spinner (because of a stalled event) when there might be a minute of video still buffered.

To avoid this, this commit adds code to keep progressing when the download is paused and while playback time hastn't reached the maximum time loaded.

This commit tries to fix https://github.com/WebPlatformForEmbedded/WPEWebKit/issues/924