### PR TITLE
[BCM] Limit brcmaudiodecoder buffering to 1sec for live streams

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -3890,6 +3890,11 @@ void MediaPlayerPrivateGStreamer::configureElement(GstElement* element)
 #if PLATFORM(BROADCOM)
     if (g_str_has_prefix(GST_ELEMENT_NAME(element), "brcmaudiosink")) {
         g_object_set(G_OBJECT(element), "async", TRUE, nullptr);
+    } else if (g_str_has_prefix(GST_ELEMENT_NAME(element), "brcmaudiodecoder")) {
+        if (m_isLiveStream.value_or(false)) {
+            // Limit BCM audio decoder buffering to 1sec so live progressive playback can start faster
+            g_object_set(G_OBJECT(element), "limit_buffering_ms", 1000, nullptr);
+        }
     }
 #endif
 


### PR DESCRIPTION
Default limit is 3 sec that with additional queue2 2sec limit and rounding errors gives 5-7sec for audio playback to be ready.

Limit to 1sec so audio can start within 3-4 sec.