### PR TITLE
[Network] Add TCPKeepAlive option

### DIFF
--- a/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.h
+++ b/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.h
@@ -149,10 +149,8 @@ private:
 
     void didFail(const WebCore::ResourceError&);
 
-#if USE(SOUP2)
     static void networkEventCallback(SoupMessage*, GSocketClientEvent, GIOStream*, NetworkDataTaskSoup*);
     void networkEvent(GSocketClientEvent, GIOStream*);
-#endif
 
 #if SOUP_CHECK_VERSION(2, 49, 91)
     static void startingCallback(SoupMessage*, NetworkDataTaskSoup*);


### PR DESCRIPTION
It bases on change from wpe-2.28:
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/41781a3160236a669de0050c5530fdcf2e7d27a6

It needs some modification because of using libsoup3 in wpe-2.38.

TCPKeepAlive can be turn on in case of two versions of libsoup - 2.x and 3.x