### PR TITLE
Fix flushing with 0 playback rate

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/PlaybackPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/PlaybackPipeline.cpp
@@ -355,6 +355,8 @@ void PlaybackPipeline::flush(AtomString trackId)
 
 #if ENABLE(INSTANT_RATE_CHANGE)
     rate = m_webKitMediaSrc->priv->mediaPlayerPrivate->rate();
+    if (!rate)
+        rate = 1.0;
 #endif
 
     GST_DEBUG_OBJECT(appsrc, "segment: [%" GST_TIME_FORMAT ", %" GST_TIME_FORMAT "], rate: %f",


### PR DESCRIPTION
Some applications set playback rate to 0 to pause, then try replacing sample in sourcebuffer. This could lead to incorrect segment sent during playback pipeline flush.