### PR TITLE
Convert features data to lowercase before checking support in GstreamerRegistryScanner

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
@@ -386,7 +386,7 @@ bool GStreamerRegistryScanner::supportsFeatures(const String& features) const
 {
     // Apple TV requires this one for DD+.
     constexpr auto dolbyDigitalPlusJOC = "joc";
-    if (features == dolbyDigitalPlusJOC)
+    if (features.convertToASCIILowercase() == dolbyDigitalPlusJOC)
         return true;
 
     return false;

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -753,8 +753,14 @@ std::unique_ptr<PlatformTimeRanges> MediaPlayerPrivateGStreamer::buffered() cons
     // Fallback to the more general maxTimeLoaded() if no range has been found.
     if (!timeRanges->length()) {
         MediaTime loaded = maxTimeLoaded();
-        if (loaded.isValid() && loaded)
+        // Checking maxTimeLoaded is a non-zero value and re-calculating if it is
+        // (This can occur when buffering completes before the duration is known).
+        if (loaded == MediaTime::zeroTime()) {
+            loaded = MediaTime(m_bufferingPercentage * static_cast<double>(toGstUnsigned64Time(mediaDuration)) / 100, GST_SECOND);
+        }
+        if (loaded.isValid() && loaded) {
             timeRanges->add(MediaTime::zeroTime(), loaded);
+        }
     }
 
     return timeRanges;


### PR DESCRIPTION
Features sent alongside codecs in order to check support can be received in both upper and lowercase, but check was previously only supporting lowercase.
This change converts all features data to lowercase before checking the support.