### PR TITLE
Add missing 'Coded Frame Removal' algorithm step in SourceBuffer

### DIFF
--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -918,7 +918,9 @@ void SourceBuffer::removeCodedFrames(const MediaTime& start, const MediaTime& en
     updateBufferedFromTrackBuffers();
 
     // 4. If buffer full flag equals true and this object is ready to accept more bytes, then set the buffer full flag to false.
-    // No-op
+    if (m_bufferFull && extraMemoryCost() < maximumBufferSize()) {
+        m_bufferFull = false;
+    }
 
     LOG(Media, "SourceBuffer::removeCodedFrames(%p) - buffered = %s", this, toString(m_buffered->ranges()).utf8().data());
 


### PR DESCRIPTION
Currently the scenario such as:

1. App appends data to the SourceBuffer until it hits `QuotaExceededError`
2. App removes all the data from SourceBuffer
3. App performs append again

would fail on step 3 with `QuotaExceededError` regardless the appended data size.

It happens due to the fact that last `sourceBufferPrivateAppendComplete()` call from step 1. will set `m_bufferFull = true` and no further calls within the SourceBuffer will reset that flag.

In the past (in `2.22`) it was working because of this change: https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/11727e2716b7a1be670643fc14fb245f28807483#diff-78280e252e732edbf1f9b6517bd2f98eb1475f16fc781a5f3e2e2e6bf9b2a9beR886-R891 in the `evictCodedFrames()`.

However, very likely, it was introduced before the step 4 in this part of spec (https://www.w3.org/TR/media-source/#sourcebuffer-coded-frame-removal) was added.

Therefore this time I propose to fix above scenario just by implementing missing step from _Coded Frame Removal_ algorithm from spec.