### PR TITLE
GST MediaPlayer: Don't emit playbackStateChanged() event after a seek

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -2559,7 +2559,7 @@ void MediaPlayerPrivateGStreamer::updateStates()
         // the media element gets a chance to enable its page sleep disabler.
         // Emitting this notification in more cases triggers unwanted code paths
         // and test timeouts.
-        if (stateReallyChanged && (m_oldState != m_currentState) && (m_oldState == GST_STATE_PAUSED && m_currentState == GST_STATE_PLAYING) && !shouldPauseForBuffering) {
+        if (stateReallyChanged && (m_oldState != m_currentState) && (m_oldState == GST_STATE_PAUSED && m_currentState == GST_STATE_PLAYING) && !shouldPauseForBuffering && !m_isSeeking) {
             GST_INFO_OBJECT(pipeline(), "Playback state changed from %s to %s. Notifying the media player client", gst_element_state_get_name(m_oldState), gst_element_state_get_name(m_currentState));
             shouldUpdatePlaybackState = true;
         }


### PR DESCRIPTION
It is not possible to pause the playback during a seek. Sink elements lose their states entering ASYNC PAUSED->PAUSED transition. Calling HTML video.pause() during a seek doesn't result in pipeline state change call as player reports it's paused already. Forcing gst_element_set_state() doesn't really help in this case as pipeline enters inconsistent state after a seek that everything is playing but sinks are paused.

In addition, triggering playbackStateChanged() at seek end causes HTMLMediaElement::playInternal() that cleans up all signs of previous pause() call.

Don't emit playbackStateChanged() at seek end so HTML won't force playInternal() and HTMLMediaElement will call pauseInternal() again after a seek (from updatePlayState()).

This fixes following scenario:
video.currentTime = x.xx
video.play();
setTimeout(()=>{ video.pause(); }, 1} // ensure async duringn a seek (video didn't pause after initial seek had finished)