### PR TITLE
Fix video playback stall at the beginning of some content

### DIFF
--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -1807,8 +1807,11 @@ void SourceBuffer::sourceBufferPrivateDidReceiveSample(MediaSample& sample)
                     break;
 
                 MediaTime highestBufferedTime = trackBuffer.buffered.maximumBufferedTime();
-                MediaTime eraseBeginTime = trackBuffer.highestPresentationTimestamp - contiguousFrameTolerance;
+                MediaTime eraseBeginTime = trackBuffer.highestPresentationTimestamp;
                 MediaTime eraseEndTime = frameEndTimestamp - contiguousFrameTolerance;
+
+                if (eraseEndTime <= eraseBeginTime)
+                    break;
 
                 PresentationOrderSampleMap::iterator_range range;
                 if (highestBufferedTime - trackBuffer.highestPresentationTimestamp < trackBuffer.lastFrameDuration)

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -494,7 +494,7 @@ void AppendPipeline::appsinkNewSample(GRefPtr<GstSample>&& sample)
         GST_TRACE_OBJECT(m_appsink.get(), "Mapped buffer to segment, PTS %" GST_TIME_FORMAT " -> %s DTS %" GST_TIME_FORMAT " -> %s",
             GST_TIME_ARGS(GST_BUFFER_PTS(buffer)), pts.toString().utf8().data(), GST_TIME_ARGS(GST_BUFFER_DTS(buffer)), dts.toString().utf8().data());
         mediaSample->setTimestamps(pts, dts);
-    } else if (!GST_BUFFER_DTS(buffer) && GST_BUFFER_PTS(buffer) > 0 && GST_BUFFER_PTS(buffer) <= 100'000'000) {
+    } else if (!GST_BUFFER_DTS(buffer) && GST_BUFFER_PTS(buffer) > 0 && GST_BUFFER_PTS(buffer) <= 100'000'000 && !GST_BUFFER_FLAG_IS_SET(buffer, GST_BUFFER_FLAG_DELTA_UNIT)) {
         // Because a track presentation time starting at some close to zero, but not exactly zero time can cause unexpected
         // results for applications, we extend the duration of this first sample to the left so that it starts at zero.
         // This is relevant for files that should have an edit list but don't, or when using GStreamer < 1.16, where


### PR DESCRIPTION
This is reproducible with apps that do transmuxing from TS to MP4 streams. In the reproduction case we can see 2 problems:

1. AppendPipeline incorrectly extending the second sample, which eventually triggers removal of the first sample (key frame):

```
  1662:Jan 23 19:47:02 hisense-a6gp WPEFramework[20041]: 0:01:15.314484225 25788 0xaba033c0 TRACE              webkitmse AppendPipeline.cpp:507:appsinkNewSample: append: trackId=V1 PTS={0/\
1000000 = 0} DTS={0/1000000 = 0} DUR={1/1000000 = 0.000001} presentationSize=640x360                                                                                                          
   1664:Jan 23 19:47:02 hisense-a6gp WPEFramework[20041]: 0:01:15.314642390 25788 0xaba033c0 TRACE              webkitmse AppendPipeline.cpp:507:appsinkNewSample: append: trackId=V1 PTS={20\
8544/1000000 = 0.208544} DTS={0/1000000 = 0} DUR={1/1000000 = 0.000001} presentationSize=640x360                                                                                              
   1668:Jan 23 19:47:02 hisense-a6gp WPEFramework[20041]: 0:01:15.315201801 25788 0xaba033c0 DEBUG              webkitmse AppendPipeline.cpp:503:appsinkNewSample: Extending first sample of \
track 'V1' to make it start at PTS=0 buffer: 0x614000, pts 0:00:00.083422222, dts 0:00:00.000000000, dur 0:00:00.041711111, size 19, offset none, offset_end none, flags 0x6000 
```

2.  Even with above fixed, SourceBuffer incorrectly removes the first sample when the duration of the sample is less than 1 ms tolerance:
```
[WPEWebKit:MediaSource:-] SourceBuffer::sourceBufferPrivateDidReceiveSample(234F0002) {"pts":{"value":0,"numerator":0,"denominator":1000000,"flags":1},"dts":{"value":0,"numerator":0,"denomi\
nator":1000000,"flags":1},"duration":{"value":0.000001,"numerator":1,"denominator":1000000,"flags":1},"flags":1,"presentationSize":{"width":1024,"height":576}}                               
[WPEWebKit:MediaSource:-] SourceBuffer::sourceBufferPrivateDidReceiveSample(234F0002) {"pts":{"value":0.208544,"numerator":208544,"denominator":1000000,"flags":1},"dts":{"value":0,"numerato\
r":0,"denominator":1000000,"flags":1},"duration":{"value":0.000001,"numerator":1,"denominator":1000000,"flags":1},"flags":0,"presentationSize":{"width":1024,"height":576}}                   
[WPEWebKit:MediaSource:-] SourceBuffer::sourceBufferPrivateDidReceiveSample(234F0002) removing sample {"pts":{"value":0,"numerator":0,"denominator":1000000,"flags":1},"dts":{"value":0,"nume\
rator":0,"denominator":1000000,"flags":1},"duration":{"value":0.000001,"numerator":1,"denominator":1000000,"flags":1},"flags":1,"presentationSize":{"width":1024,"height":576}}
``` 

This PR backports some of the changes from upstream, and disables PTS extension for non-key frames
