### PR TITLE
Fixed pressure handler when using swap memory on Linux platform

### DIFF
--- a/Source/WTF/wtf/linux/MemoryPressureHandlerLinux.cpp
+++ b/Source/WTF/wtf/linux/MemoryPressureHandlerLinux.cpp
@@ -248,13 +248,14 @@ MemoryPressureHandler::MemoryUsagePoller::MemoryUsagePoller()
             bool critical = false;
             bool synchronous = false;
             size_t value = 0;
+            size_t value_swap = 0;
 
             if (s_pollMaximumProcessMemoryCriticalLimit) {
-                if (readToken(s_processStatus, "VmRSS:", KB, value)) {
-                    if (value > s_pollMaximumProcessMemoryNonCriticalLimit) {
+                if (readToken(s_processStatus, "VmRSS:", KB, value) && readToken(s_processStatus, "VmSwap:", KB, value_swap)) {
+                    if (value + value_swap > s_pollMaximumProcessMemoryNonCriticalLimit) {
                         underMemoryPressure = true;
-                        critical = value > s_pollMaximumProcessMemoryCriticalLimit;
-                        synchronous = value > s_pollMaximumProcessMemoryCriticalLimit * 1.05;
+                        critical = value + value_swap > s_pollMaximumProcessMemoryCriticalLimit;
+                        synchronous = value + value_swap > s_pollMaximumProcessMemoryCriticalLimit * 1.05;
                     }
                 }
             }


### PR DESCRIPTION
In an environment where swap memory (HDD swap, ZRAM, etc.) is used, memory pressure should be applied considering VmSwap value as well as VmRSS.