### PR TITLE
Load failure in HTMLMediaElement results in crash

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -1663,9 +1663,8 @@ void HTMLMediaElement::loadResource(const URL& initialURL, ContentType& contentT
     if (m_mediaSource) {
         loadAttempted = true;
         if (!m_mediaSource->attachToElement(*this) || !m_player->load(url, contentType, m_mediaSource.get())) {
-            // Forget our reference to the MediaSource, so we leave it alone
-            // while processing remainder of load failure.
-            m_mediaSource = nullptr;
+            // Detach MediaSource 
+            detachMediaSource();
             mediaLoadingFailed(MediaPlayer::FormatError);
         }
     }


### PR DESCRIPTION
During the playbacks in web apps, load resource can fail causing the HTMLMediaElement resetting the MediaSource reference. By some means, if the player is destructed, the  HTMLMediaElement object is destructed. However, the MediaSource pointing to the destructed HTMLMediaElement when has to stop, it calls for the detaching. During the detachment call MediaSource is referring some stale pointer of HTMLMediaElement. This stale HTMLMediaElement happens to refer some bogus MediaSource. This bogus MediaSource start participating in the process of detachment, leading to the access of some of its undefined attributes/functions which sometimes causes wpe-webprocess crash.

[CallStack.txt](https://github.com/WebPlatformForEmbedded/WPEWebKit/files/10499734/CallStack.txt)

The logs are collected describing the same behavior:

For some Asset playback in Paramount+:

**HTMLMediaELement Constructed**
`2023 Jan 20 15:06:35.818536 runAppManager.sh[4755]:  RAJAN-DBG [4544, 4544]: WebCore::HTMLMediaElement::HTMLMediaElement(const WebCore::QualifiedName&, WebCore::Document&, bool): HTMLMediaElement(0xafb06000) `
**MediaSource Object Constructed:**
`2023 Jan 20 15:06:37.713529 runAppManager.sh[4755]:  RAJAN-DBG [4544, 4544]: WebCore::MediaSource::MediaSource(WebCore::ScriptExecutionContext&): MediaSource(0xa1949c80)`
**HTMLMediaElement Objected attached to MediaSouce Object:**
`2023 Jan 20 15:06:37.725066 runAppManager.sh[4755]:  RAJAN-DBG [4544, 4544]: bool WebCore::MediaSource::attachToElement(WebCore::HTMLMediaElement&)->MediaSource:(0xa1949c80) attaching to HTMLMediaElement:(0xafb06000) `
**Player Constructed:**
`2023 Jan 20 15:06:37.725693 runAppManager.sh[4755]:  HTML5 video: Player constructed [0xa098a340] `
**MediaSource State Changed:**
`2023 Jan 20 15:06:37.726582 runAppManager.sh[4755]:  RAJAN-DBG [4544, 4544]:void WebCore::MediaSource::setReadyState(WebCore::MediaSource::ReadyState) MediaSource(0xa1949c80)::setReadyState : closed -> open
2023 Jan 20 15:06:37.727047 runAppManager.sh[4755]:  RAJAN-DBG [4544, 4544]: void WebCore::MediaSource::onReadyStateChange(WebCore::MediaSource::ReadyState, WebCore::MediaSource::ReadyState) (0xa1949c80)`
**Playback Failed:**
`2023 Jan 20 15:06:43.413160 runAppManager.sh[4755]:  0:05:21.375243168 [333m 4544[00m 0xb0e038a0 [31;01mERROR  [00m [00m   webkitmediaplayer MediaPlayerPrivateGStreamer.cpp:1387:handleMessage:[00m Error 1: GStreamer encountered a general supporting library error. (url=mediasourceblob:https://www.paramountplus.com/f0eb08e0-cf5f-452a-a62f-b35392c4a00c) `
**HTMLMediaElement Resetting Reference for MediaSource to nullptr**
`2023 Jan 20 15:07:44.719774 runAppManager.sh[4755]:  RAJAN-DBG [4544, 4544]: void WebCore::HTMLMediaElement::loadResource(const WebCore::URL&, WebCore::ContentType&, const WTF::String&)->HTMLMediaElement(0xafb06000) Forgetting MediaSource:(0xa1949c80)
2023 Jan 20 15:07:44.720225 runAppManager.sh[4755]:  RAJAN-DBG [4544, 4544]: void WebCore::HTMLMediaElement::loadResource(const WebCore::URL&, WebCore::ContentType&, const WTF::String&)->HTMLMediaElement(0xafb06000) Forgotten MediaSource`
**Code:**
`if (!m_mediaSource->attachToElement(*this) || !m_player->load(url, contentType, m_mediaSource.get())) {             
// Forget our reference to the MediaSource, so we leave it alone             
// while processing remainder of load failure.
    printf("RAJAN-DBG [%d, %ld]: %s->HTMLMediaElement(%p) Forgetting MediaSource:(%p)\n",getpid(),syscall(__NR_gettid),__PRETTY_FUNCTION__,this,m_mediaSource.get());fflush(stdout);             
    m_mediaSource = nullptr;
    mediaLoadingFailed(MediaPlayer::FormatError);
    printf("RAJAN-DBG [%d, %ld]: %s->HTMLMediaElement(%p) Forgotten MediaSource\n",getpid(),syscall(__NR_gettid),__PRETTY_FUNCTION__,this);fflush(stdout);        
} `
**Player Destroyed:**
`2023 Jan 20 15:07:44.810514 runAppManager.sh[4755]:  HTML5 video: Player Destroyed [0xa098a340] `
**HTMLMediaElement Destruction:**
`2023 Jan 20 15:08:39.350105 runAppManager.sh[4755]:  RAJAN-DBG [4544, 4544]: virtual WebCore::HTMLMediaElement::~HTMLMediaElement(): HTMLMediaElement(0xafb06000) Destruction done`
**Paramount+ App Exited:**
`2023 Jan 20 15:14:35.380001 Receiver[6400]:   Thread-6400 [RDKBrowserHtmlViewItem] - The chariot application that is getting destroyed is https://www.paramountplus.com/smart-console-apps/comcast/?launchpoint=&query=&assetId=&assetType=&entityId=&sectionName=&contentUrl=&lmt=0&us_privacy=1-N- `
**ActiveDOMObject(MediaSource) Getting stopped:**
`2023 Jan 20 15:14:35.904700 runAppManager.sh[4755]:  RAJAN-DBG [4544, 4544]: void WebCore::ScriptExecutionContext::forEachActiveDOMObject(const WTF::Function<WebCore::ScriptExecutionContext::ShouldContinue(WebCore::ActiveDOMObject&)>&) const->(ScriptExecutionContext:0xb0ce4a50)->(activeDOMObjectName:MediaSource)
2023 Jan 20 15:14:35.905214 runAppManager.sh[4755]:  RAJAN-DBG [4544, 4544]: virtual void WebCore::MediaSource::stop() (0xa1949c80)`
**MediaSource Object Referring Garbage HTMLMediaElement:**
`2023 Jan 20 15:14:35.905862 runAppManager.sh[4755]:  RAJAN-DBG [4544, 4544]: void WebCore::HTMLMediaElement::detachMediaSource() (0xafb06000)
2023 Jan 20 15:14:35.906363 runAppManager.sh[4755]:  RAJAN-DBG [4544, 4544]: void WebCore::HTMLMediaElement::detachMediaSource()->(HTMLMediaElement:0xafb06000 being detached from (MediaSource:0xb0c4f268))
2023 Jan 20 15:14:35.906874 runAppManager.sh[4755]:  RAJAN-DBG [4544, 4544]: void WebCore::MediaSource::detachFromElement(WebCore::HTMLMediaElement&)->(MediaSource:0xb0c4f268) detaching From (HTMLMediaElement:(nil)))
2023 Jan 20 15:14:35.907382 runAppManager.sh[4755]:  RAJAN-DBG [4544, 4544]:void WebCore::MediaSource::setReadyState(WebCore::MediaSource::ReadyState) MediaSource(0xb0c4f268)::setReadyState : (unknown) -> closed
2023 Jan 20 15:14:35.907919 runAppManager.sh[4755]:  RAJAN-DBG [4544, 4544]: void WebCore::MediaSource::onReadyStateChange(WebCore::MediaSource::ReadyState, WebCore::MediaSource::ReadyState) (0xb0c4f268)
 `
_We can see MediaSource (0xa1949c80) is holding the pointer of stale HTMLMediaElement(0xafb06000). HTMLMediaElement (0xafb06000) is holding the bogus reference   of MediaSource (0xb0c4f268). The MediaSource (0xb0c4f268) starts making further calls on the behalf of MediaSource (0xa1949c80). Since, the state of MediaSource (0xb0c4f268) is undefined/ unallocated. This leads to the Crash._

**Wpe-WebProcess crashed:**
`2023 Jan 20 15:14:37.569482 Receiver[6400]:   Thread-6400 [RDKBrowserPluginFactory] - Cached plugin crashed: event='RDKBROWSER_RENDER_PROCESS_CRASHED' description='WebProcess crashed (crash-id: 3924a1e8-ea41-089d-08071aa9-2f784989)' `

Same can be visualized by 
![setReadyState](https://user-images.githubusercontent.com/88700790/214583080-dc20fa94-2863-41eb-9440-ed975a392f97.jpg)

Hence, instead of just setting reference of MediaSource to nullptr, proper detach should be called to avoid MediaSource accessing stale HTMLMediaElement.