### PR TITLE
Disable caching of XHR ArrayBuffer

### DIFF
--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -627,6 +627,12 @@ ExceptionOr<void> XMLHttpRequest::createRequest()
     options.filteringPolicy = ResponseFilteringPolicy::Enable;
     options.sniffContentEncoding = ContentEncodingSniffingPolicy::DoNotSniff;
 
+    if (responseType() == ResponseType::Arraybuffer || getenv("WPE_DISABLE_XHR_RESPONSE_CACHING")) {
+        options.dataBufferingPolicy = DataBufferingPolicy::DoNotBufferData;
+        options.cachingPolicy = CachingPolicy::DisallowCaching;
+        request.setCachePolicy(ResourceRequestCachePolicy::DoNotUseAnyCache);
+    }
+
     if (m_timeoutMilliseconds) {
         if (!m_async)
             request.setTimeoutInterval(m_timeoutMilliseconds / 1000.0);


### PR DESCRIPTION
This patch was ported from 2.28, and before that, from 2.22: bda081928823117562cd37fe4fd770d118f7a9d9
fbbd29fd70a95a8504e28342be33d4721066ea5e
6a411c634eee24ac436c526b64c581a44437d4df
... PR 877

- Disable caching of ArrayBuffer XHR.
- Setting the environment variable WPE_DISABLE_XHR_RESPONSE_CACHING disables the memory cache for xhr responses. This is useful to reduce the memory footprint when the responses are quite big and cannot be reused.