### PR TITLE
WebInspectorUI: Fix right button context menu

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Base/BrowserInspectorFrontendHost.js
+++ b/Source/WebInspectorUI/UserInterface/Base/BrowserInspectorFrontendHost.js
@@ -250,7 +250,7 @@ if (!window.InspectorFrontendHost) {
 
         showContextMenu(event, items)
         {
-            this._contextMenu = WI.SoftContextMenu(items);
+            this._contextMenu = new WI.SoftContextMenu(items);
             this._contextMenu.show(event);
         }
 


### PR DESCRIPTION
JS error:
"Class constructor SoftContextMenu cannot be invoked without 'new'"