### PR TITLE
WebInspectorUI: Fix Canvas preview for Chromium browser

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Main.html
+++ b/Source/WebInspectorUI/UserInterface/Main.html
@@ -26,7 +26,7 @@
 <html>
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src * file: blob: resource:; connect-src * ws:; media-src * blob:; font-src * blob:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' data:">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src * file: blob: resource: data:; connect-src * ws:; media-src * blob:; font-src * blob:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' data:">
 
     <link rel="stylesheet" href="External/CodeMirror/codemirror.css">
 


### PR DESCRIPTION
Add "data:" sheme for image-src CSP
Original error message:
"
Refused to load the image 'data:image/png;base64,iVBORw...BJRU5ErkJggg==' because it violates the following Content Security Policy directive: "img-src * file: blob: resource:".
Note that '*' matches only URLs with network schemes ('http', 'https', 'ws', 'wss'), or URLs whose scheme matches `self`'s scheme. The scheme 'data:' must be added explicitly.
"