### PR TITLE
[WPE-2.22]: Apple TV - remove flow which generates GStreamer-CRITICAL

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -1230,9 +1230,7 @@ void AppendPipeline::disconnectDemuxerSrcPadFromAppsinkFromAnyThread(GstPad* dem
     };
 
     auto isAudioOrVideo = [](const std::string& padType) {
-        if (!padType.compare(0, 5, "audio") || !padType.compare(0, 5, "video"))
-            return true;
-        return false;
+        return !padType.compare(0, 5, "audio") || !padType.compare(0, 5, "video");
     };
 
     const char* demuxerSrcPadType = getPadType(demuxerSrcPad);

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -1229,7 +1229,15 @@ void AppendPipeline::disconnectDemuxerSrcPadFromAppsinkFromAnyThread(GstPad* dem
         return padCaps ? capsMediaType(padCaps.get()) : nullptr;
     };
 
+    auto isAudioOrVideo = [](const std::string& padType) {
+        if (!padType.compare(0, 5, "audio") || !padType.compare(0, 5, "video"))
+            return true;
+        return false;
+    };
+
     const char* demuxerSrcPadType = getPadType(demuxerSrcPad);
+    if (demuxerSrcPadType && !isAudioOrVideo(demuxerSrcPadType))
+        return;
 
     auto oldPeerPad = adoptGRef(gst_element_get_static_pad(m_appsink.get(), "sink"));
     while (gst_pad_is_linked(oldPeerPad.get())) {


### PR DESCRIPTION
Issue is seen on trickplay driven by MSE (seek without thumbnails).

In Apple TV video stream we have multiplexed closed caption content which is recognized by qtdemux plugin (x-cea-608 sink pad is created, which is connected to probe which drops all content).

During trickplay pads between demux and appsink elements are relinked:
- new video pad on demux element is added via pad-added signal (connected to probe)
- old video pad from demux element is removed via pad-removed signal
- video pad relinkage happends
- x-cea-608 pad from demux element is removed via pad-removed signal

At this point AppendPipeline is linked, and while loop which starts from appsink iterates to appsrc, and looks for appsrc sink pad, which generates GStreamer-CRITICAL error.

Fix is also valid for WPE-2-28 branch.