### PR TITLE
Fix crash in TextureMapperPlatformLayerProxyGL::invalidate

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyGL.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyGL.cpp
@@ -108,7 +108,7 @@ void TextureMapperPlatformLayerProxyGL::invalidate()
         // To avoid this, don't remove the current buffer on invalidation if it's a holepunch buffer. It will be
         // released when the proxy gets destroyed instead. Holepunch buffers don't really hold any GL asset, so
         // we're not in a hurry to free them anyway.
-        if (!m_currentBuffer->isHolePunchBuffer())
+        if (m_currentBuffer && !m_currentBuffer->isHolePunchBuffer())
             m_currentBuffer = nullptr;
         m_pendingBuffer = nullptr;
         m_releaseUnusedBuffersTimer = nullptr;


### PR DESCRIPTION
It is crashing when trying to call isHolePunchBuffer with null current buffer.

Here is callstack for the crashed thread:

```
Thread 14 "eadedCompositor" received signal SIGSEGV, Segmentation fault.                                                                                                                                          
[Switching to LWP 142072]                                                                                                                                                                                         
0x00007f18743e3872 in WebCore::TextureMapperPlatformLayerBuffer::isHolePunchBuffer() () from target:/app/webkit/WebKitBuild/Release/lib/libWPEWebKit-1.0.so.3                                                     
(gdb) bt                                                                                                                                                                                                          
#0  0x00007f18743e3872 in WebCore::TextureMapperPlatformLayerBuffer::isHolePunchBuffer() () from target:/app/webkit/WebKitBuild/Release/lib/libWPEWebKit-1.0.so.3                                                 
#1  0x00007f18743e3bad in WebCore::TextureMapperPlatformLayerProxyGL::invalidate() () from target:/app/webkit/WebKitBuild/Release/lib/libWPEWebKit-1.0.so.3                                                       
#2  0x00007f1872b24415 in WebKit::removeLayer(Nicosia::CompositionLayer&) () from target:/app/webkit/WebKitBuild/Release/lib/libWPEWebKit-1.0.so.3                                                                
#3  0x00007f1872b26edc in WebKit::CoordinatedGraphicsScene::updateSceneState()::{lambda(Nicosia::Scene::State&)#1}::operator()(Nicosia::Scene::State&) const ()                                                   
   from target:/app/webkit/WebKitBuild/Release/lib/libWPEWebKit-1.0.so.3                                                                                                                                          
#4  0x00007f1872b29181 in WebKit::CoordinatedGraphicsScene::updateSceneState() () from target:/app/webkit/WebKitBuild/Release/lib/libWPEWebKit-1.0.so.3                                                           
#5  0x00007f1872b2a385 in WebKit::CoordinatedGraphicsScene::paintToCurrentGLContext(WebCore::TransformationMatrix const&, WebCore::FloatRect const&, unsigned int) ()                                             
   from target:/app/webkit/WebKitBuild/Release/lib/libWPEWebKit-1.0.so.3                                                                                                                                          
#6  0x00007f1872b2d41b in WebKit::ThreadedCompositor::renderLayerTree() () from target:/app/webkit/WebKitBuild/Release/lib/libWPEWebKit-1.0.so.3                                                                  
#7  0x00007f187427a575 in WTF::RunLoop::TimerBase::TimerBase(WTF::RunLoop&)::{lambda(void*)#1}::_FUN(void*) () from target:/app/webkit/WebKitBuild/Release/lib/libWPEWebKit-1.0.so.3                              
#8  0x00007f187427adaf in WTF::RunLoop::{lambda(_GSource*, int (*)(void*), void*)#1}::_FUN(_GSource*, int (*)(void*), void*) () from target:/app/webkit/WebKitBuild/Release/lib/libWPEWebKit-1.0.so.3             
#9  0x00007f1870463294 in g_main_dispatch (context=0x7effe4000b60) at ../glib/gmain.c:3381                                                                                                                        
#10 g_main_context_dispatch (context=0x7effe4000b60) at ../glib/gmain.c:4099                                                                                                                                      
#11 0x00007f1870463638 in g_main_context_iterate (context=0x7effe4000b60, block=block@entry=1, dispatch=dispatch@entry=1, self=<optimized out>) at ../glib/gmain.c:4175                                           
#12 0x00007f1870463943 in g_main_loop_run (loop=0x7effe4003e60) at ../glib/gmain.c:4373                                                                                                                           
#13 0x00007f187427af40 in WTF::RunLoop::run() () from target:/app/webkit/WebKitBuild/Release/lib/libWPEWebKit-1.0.so.3                                                                                            
#14 0x00007f187420797a in WTF::Thread::entryPoint(WTF::Thread::NewThreadContext*) () from target:/app/webkit/WebKitBuild/Release/lib/libWPEWebKit-1.0.so.3                                                        
#15 0x00007f187427e1e9 in WTF::wtfThreadEntryPoint(void*) () from target:/app/webkit/WebKitBuild/Release/lib/libWPEWebKit-1.0.so.3                                                                                
#16 0x00007f186da633ba in start_thread () from target:/usr/lib/x86_64-linux-gnu/libpthread.so.0                                                                                                                   
#17 0x00007f186fd5c7a3 in clone () from target:/usr/lib/x86_64-linux-gnu/libc.so.6      
```