### PR TITLE
[GStreamer][EME] Ignore case sensitive when comparing UUID

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/eme/GStreamerEMEUtilities.h
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/GStreamerEMEUtilities.h
@@ -110,10 +110,10 @@ public:
 
     static const char* uuidToKeySystem(const String& uuid)
     {
-        if (uuid == s_ClearKeyUUID)
+        if (equalIgnoringASCIICase(uuid, s_ClearKeyUUID))
             return s_ClearKeyKeySystem;
 
-        if (uuid == s_UnspecifiedUUID)
+        if (equalIgnoringASCIICase(uuid, s_UnspecifiedUUID))
 #if USE(OPENCDM)
             return s_WidevineKeySystem;
 #else
@@ -121,10 +121,10 @@ public:
 #endif
 
 #if USE(OPENCDM)
-        if (uuid == s_PlayReadyUUID)
+        if (equalIgnoringASCIICase(uuid, s_PlayReadyUUID))
             return s_PlayReadyKeySystems[0];
 
-        if (uuid == s_WidevineUUID)
+        if (equalIgnoringASCIICase(uuid, s_WidevineUUID))
             return s_WidevineKeySystem;
 #endif
 


### PR DESCRIPTION
PR is fixing this crash on WPE-2.22:
```
#0  WTF::StringImpl::rawHash () at /usr/src/debug/wpe-webkit/1_2.22.1+git-r0/build/DerivedSources/ForwardingHeaders/wtf/text/StringImpl.h:304
#1  WTF::StringImpl::hasHash () at /usr/src/debug/wpe-webkit/1_2.22.1+git-r0/build/DerivedSources/ForwardingHeaders/wtf/text/StringImpl.h:307
#2  WTF::StringImpl::hash () at /usr/src/debug/wpe-webkit/1_2.22.1+git-r0/build/DerivedSources/ForwardingHeaders/wtf/text/StringImpl.h:310
#3  WTF::StringHash::hash () at /usr/src/debug/wpe-webkit/1_2.22.1+git-r0/build/DerivedSources/ForwardingHeaders/wtf/text/StringHash.h:73
#4  WTF::HashMapTranslator<WTF::HashMap<WTF::String, WTF::String, WTF::StringHash, WTF::HashTraits<WTF::String>, WTF::HashTraits<WTF::String> >::KeyValuePairTraits, WTF::StringHash>::hash<WTF::String> ()
    at /usr/src/debug/wpe-webkit/1_2.22.1+git-r0/build/DerivedSources/ForwardingHeaders/wtf/HashMap.h:190
#5  WTF::HashTable<WTF::String, WTF::KeyValuePair<WTF::String, WTF::String>, WTF::KeyValuePairKeyExtractor<WTF::KeyValuePair<WTF::String, WTF::String> >, WTF::StringHash, WTF::HashMap<WTF::String, WTF::String, WTF::StringHash, WTF::HashTraits<WTF::String>, WTF::HashTraits<WTF::String> >::KeyValuePairTraits, WTF::HashTraits<WTF::String> >::add<WTF::HashMapTranslator<WTF::HashMap<WTF::String, WTF::String, WTF::StringHash, WTF::HashTraits<WTF::String>, WTF::HashTraits<WTF::String> >::KeyValuePairTraits, WTF::StringHash>, WTF::String, WTF::String&> ()
    at /usr/src/debug/wpe-webkit/1_2.22.1+git-r0/build/DerivedSources/ForwardingHeaders/wtf/HashTable.h:878
#6  WTF::HashMap<WTF::String, WTF::String, WTF::StringHash, WTF::HashTraits<WTF::String>, WTF::HashTraits<WTF::String> >::inlineAdd<WTF::String, WTF::String&> () at /usr/src/debug/wpe-webkit/1_2.22.1+git-r0/build/DerivedSources/ForwardingHeaders/wtf/HashMap.h:346
#7  WTF::HashMap<WTF::String, WTF::String, WTF::StringHash, WTF::HashTraits<WTF::String>, WTF::HashTraits<WTF::String> >::inlineSet<WTF::String, WTF::String&> () at /usr/src/debug/wpe-webkit/1_2.22.1+git-r0/build/DerivedSources/ForwardingHeaders/wtf/HashMap.h:334
#8  0xb5c7e282 in WTF::HashMap<WTF::String, WTF::String, WTF::StringHash, WTF::HashTraits<WTF::String>, WTF::HashTraits<WTF::String> >::set<WTF::String&> () at /usr/src/debug/wpe-webkit/1_2.22.1+git-r0/build/DerivedSources/ForwardingHeaders/wtf/HashMap.h:367
#9  webkitMediaCommonEncryptionDecryptProcessProtectionEvents () at /usr/src/debug/wpe-webkit/1_2.22.1+git-r0/git/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp:501
#10 webkitMediaCommonEncryptionDecryptTransformInPlace () at /usr/src/debug/wpe-webkit/1_2.22.1+git-r0/git/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp:276
```

Fix applies only for WPE-2.22. Not upstreamable to WPE-2.28.