### PR TITLE
Fix failing build when building from clean state

### DIFF
--- a/Source/WebCore/PAL/pal/Logging.cpp
+++ b/Source/WebCore/PAL/pal/Logging.cpp
@@ -33,10 +33,9 @@
 #include <wtf/BlockPtr.h>
 #elif PLATFORM(WPE)
 #include <glib.h>
+#include <gio/gio.h>
 #include <wtf/FileSystem.h>
 #include <wtf/glib/GRefPtr.h>
-#include <WebCore/PlatformExportMacros.h>
-#include <WebCore/FileMonitor.h>
 #endif
 
 namespace PAL {


### PR DESCRIPTION
With changes from pull request 1039, when building from a clean state (without a successfull prior build), the build fails. This is cause by missing "PlatformExportMacros.h", which is available in "build/DerivedSources/ForwardingHeaders/WebCore/" after a successful build, but not present yet when building from a clean state.