### PR TITLE
DELIA-60377: Fix linux builds using USE_SYSTEM_MALLOC flag

### DIFF
--- a/Source/WTF/wtf/RAMSize.cpp
+++ b/Source/WTF/wtf/RAMSize.cpp
@@ -34,6 +34,7 @@
 #elif defined(USE_SYSTEM_MALLOC) && USE_SYSTEM_MALLOC
 #if OS(LINUX)
 #include <sys/sysinfo.h>
+#include <wtf/text/WTFString.h>
 #endif // OS(LINUX)
 #else
 #include <bmalloc/bmalloc.h>


### PR DESCRIPTION
Compilation error was seen on qemu x86 build.