### PR TITLE
Disable encoded data replacement for images with async decoding

### DIFF
--- a/Source/WebCore/loader/cache/CachedImage.cpp
+++ b/Source/WebCore/loader/cache/CachedImage.cpp
@@ -747,4 +747,11 @@ bool CachedImage::isVisibleInViewport(const Document& document) const
     return false;
 }
 
+bool CachedImage::mayTryReplaceEncodedData() const {
+    if (hasImage() && is<BitmapImage>(m_image.get())) {
+        return !downcast<BitmapImage>(m_image.get())->canUseAsyncDecodingForLargeImages();
+    }
+    return true;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/loader/cache/CachedImage.h
+++ b/Source/WebCore/loader/cache/CachedImage.h
@@ -116,7 +116,7 @@ private:
     void checkShouldPaintBrokenImage();
 
     void switchClientsToRevalidatedResource() final;
-    bool mayTryReplaceEncodedData() const final { return true; }
+    bool mayTryReplaceEncodedData() const final;
 
     void didAddClient(CachedResourceClient&) final;
     void didRemoveClient(CachedResourceClient&) final;


### PR DESCRIPTION
This fix is ported from:
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/7b9f56b19c5bd006139608e37da7848b66503e05

Replacing data during async decoding causes random crashes