### PR TITLE
provision wal_autocheckpoint to prevent the log file growing to large size

### DIFF
--- a/Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.cpp
+++ b/Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.cpp
@@ -174,6 +174,8 @@ bool SQLiteStorageArea::prepareDatabase(ShouldCreateIfNotExists shouldCreateIfNo
     // We will never access the database from different threads simultaneously.
     m_database->disableThreadingChecks();
 
+    m_database->enableAutomaticWALTruncation();
+
     if (!createTableIfNecessary()) {
         m_database = nullptr;
         return false;


### PR DESCRIPTION
This fix is ported from: 876e5e39e0f431b53d6924695dbdce927552bfd5 - PR 829 2.28