### PR TITLE
Control on-disk cache size with env var WPE_DISK_CACHE_SIZE

### DIFF
--- a/Source/WebKit/Shared/CacheModel.cpp
+++ b/Source/WebKit/Shared/CacheModel.cpp
@@ -30,6 +30,8 @@
 #include <wtf/RAMSize.h>
 #include <wtf/Seconds.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/text/WTFString.h>
+#include <wtf/text/StringToIntegerConversion.h>
 
 namespace WebKit {
 
@@ -169,6 +171,21 @@ uint64_t calculateURLCacheDiskCapacity(CacheModel cacheModel, uint64_t diskFreeS
     default:
         ASSERT_NOT_REACHED();
     };
+
+    auto s = String::fromLatin1(getenv("WPE_DISK_CACHE_SIZE"));
+    if (!s.isEmpty()) {
+        String value = s.stripWhiteSpace().convertToLowercaseWithoutLocale();
+        size_t units = 1;
+        if (value.endsWith('k'))
+            units = KB;
+        else if (value.endsWith('m'))
+            units = MB;
+        if (units != 1)
+            value = value.substring(0, value.length()-1);
+
+        size_t size = size_t(parseInteger<uint64_t>(s).value_or(1) * units);
+        urlCacheDiskCapacity = (unsigned long)(size);
+    }
 
     return urlCacheDiskCapacity;
 }


### PR DESCRIPTION
This is ported from 2.28 from https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/837
- also incorporates 4dcfad3b879963a8c46ce910571fed30b5078f84 followup commit

Testing:

- usage of rpi3 can involve large-ish cache files (for example `/home/.cache/WebKitCache/` subdirs on rpi);
- setting env var to different values (`WPE_DISK_CACHE_SIZE=900`, `WPE_DISK_CACHE_SIZE=1k`), run Cog browser on rpi -> on disk cache files are much smaller in size and fewer in number, as expected
- you can use printfs to see (same) expected value of env var in `capacity` in `NetworkCache.cpp -> Cache::open()` and `CacheModel.cpp -> calculateURLCacheSizes()`
- unset env var, note that same `WebKitCache` dir has many more cached resources for same origin when contraints removed, as expected