### PR TITLE
Adapt speech synthesis changes from 2.28

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -321,6 +321,15 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/push-api/PushSubscriptionData.h
     Modules/push-api/PushSubscriptionIdentifier.h
 
+    Modules/speech/DOMWindowSpeechSynthesis.h
+    Modules/speech/SpeechSynthesisErrorCode.h
+    Modules/speech/SpeechSynthesisErrorEvent.h
+    Modules/speech/SpeechSynthesisErrorEventInit.h
+    Modules/speech/SpeechSynthesisEvent.h
+    Modules/speech/SpeechSynthesisEventInit.h
+    Modules/speech/SpeechSynthesis.h
+    Modules/speech/SpeechSynthesisUtterance.h
+    Modules/speech/SpeechSynthesisVoice.h
     Modules/speech/SpeechRecognitionCaptureSource.h
     Modules/speech/SpeechRecognitionCaptureSourceImpl.h
     Modules/speech/SpeechRecognitionConnection.h

--- a/Source/WebCore/Modules/speech/SpeechSynthesis.h
+++ b/Source/WebCore/Modules/speech/SpeechSynthesis.h
@@ -74,7 +74,7 @@ private:
     void didPauseSpeaking(PlatformSpeechSynthesisUtterance&) override;
     void didResumeSpeaking(PlatformSpeechSynthesisUtterance&) override;
     void didFinishSpeaking(PlatformSpeechSynthesisUtterance&) override;
-    void speakingErrorOccurred(PlatformSpeechSynthesisUtterance&) override;
+    void speakingErrorOccurred(PlatformSpeechSynthesisUtterance&, std::optional<SpeechSynthesisErrorCode>) override;
     void boundaryEventOccurred(PlatformSpeechSynthesisUtterance&, SpeechBoundary, unsigned charIndex, unsigned charLength) override;
 
     // SpeechSynthesisClient override methods
@@ -82,12 +82,12 @@ private:
     void didFinishSpeaking() override;
     void didPauseSpeaking() override;
     void didResumeSpeaking() override;
-    void speakingErrorOccurred() override;
+    void speakingErrorOccurred(std::optional<SpeechSynthesisErrorCode>) override;
     void boundaryEventOccurred(bool wordBoundary, unsigned charIndex, unsigned charLength) override;
     void voicesChanged() override;
     
     void startSpeakingImmediately(SpeechSynthesisUtterance&);
-    void handleSpeakingCompleted(SpeechSynthesisUtterance&, bool errorOccurred);
+    void handleSpeakingCompleted(SpeechSynthesisUtterance&, std::optional<SpeechSynthesisErrorCode>);
     void fireEvent(const AtomString& type, SpeechSynthesisUtterance&, unsigned long charIndex, unsigned long charLength, const String& name) const;
     void fireErrorEvent(const AtomString& type, SpeechSynthesisUtterance&, SpeechSynthesisErrorCode) const;
 

--- a/Source/WebCore/Modules/speech/SpeechSynthesisErrorCode.h
+++ b/Source/WebCore/Modules/speech/SpeechSynthesisErrorCode.h
@@ -28,7 +28,7 @@
 
 namespace WebCore {
 
-enum class SpeechSynthesisErrorCode {
+enum class SpeechSynthesisErrorCode : uint8_t {
     Canceled,
     Interrupted,
     AudioBusy,

--- a/Source/WebCore/Modules/speech/SpeechSynthesisErrorEventInit.h
+++ b/Source/WebCore/Modules/speech/SpeechSynthesisErrorEventInit.h
@@ -28,6 +28,7 @@
 #if ENABLE(SPEECH_SYNTHESIS)
 
 #include "SpeechSynthesisEventInit.h"
+#include "SpeechSynthesisErrorCode.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/page/SpeechSynthesisClient.h
+++ b/Source/WebCore/page/SpeechSynthesisClient.h
@@ -34,6 +34,7 @@ namespace WebCore {
 class PlatformSpeechSynthesisUtterance;
 class SpeechSynthesisClientObserver;
 class PlatformSpeechSynthesisVoice;
+enum class SpeechSynthesisErrorCode : uint8_t;
     
 class SpeechSynthesisClient : public CanMakeWeakPtr<SpeechSynthesisClient> {
 public:
@@ -59,7 +60,7 @@ public:
     virtual void didFinishSpeaking() = 0;
     virtual void didPauseSpeaking() = 0;
     virtual void didResumeSpeaking() = 0;
-    virtual void speakingErrorOccurred() = 0;
+    virtual void speakingErrorOccurred(std::optional<SpeechSynthesisErrorCode>) = 0;
     virtual void boundaryEventOccurred(bool wordBoundary, unsigned charIndex, unsigned charLength) = 0;
     virtual void voicesChanged() = 0;
 };

--- a/Source/WebCore/platform/PlatformSpeechSynthesizer.h
+++ b/Source/WebCore/platform/PlatformSpeechSynthesizer.h
@@ -29,6 +29,8 @@
 #if ENABLE(SPEECH_SYNTHESIS)
 
 #include "PlatformSpeechSynthesisVoice.h"
+#include "SpeechSynthesisErrorCode.h"
+#include <optional>
 #include <wtf/Vector.h>
 
 #if PLATFORM(COCOA)
@@ -51,7 +53,7 @@ public:
     virtual void didFinishSpeaking(PlatformSpeechSynthesisUtterance&) = 0;
     virtual void didPauseSpeaking(PlatformSpeechSynthesisUtterance&) = 0;
     virtual void didResumeSpeaking(PlatformSpeechSynthesisUtterance&) = 0;
-    virtual void speakingErrorOccurred(PlatformSpeechSynthesisUtterance&) = 0;
+    virtual void speakingErrorOccurred(PlatformSpeechSynthesisUtterance&, std::optional<SpeechSynthesisErrorCode>) = 0;
     virtual void boundaryEventOccurred(PlatformSpeechSynthesisUtterance&, SpeechBoundary, unsigned charIndex, unsigned charLength) = 0;
     virtual void voicesDidChange() = 0;
 protected:

--- a/Source/WebCore/platform/mock/PlatformSpeechSynthesizerMock.cpp
+++ b/Source/WebCore/platform/mock/PlatformSpeechSynthesizerMock.cpp
@@ -75,7 +75,7 @@ void PlatformSpeechSynthesizerMock::cancel()
         return;
 
     m_speakingFinishedTimer.stop();
-    client()->speakingErrorOccurred(*m_utterance);
+    client()->speakingErrorOccurred(*m_utterance, SpeechSynthesisErrorCode::Canceled);
     m_utterance = nullptr;
 }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -11032,6 +11032,48 @@ void WebPageProxy::speechSynthesisResume(CompletionHandler<void()>&& completionH
     speechSynthesisData().speakingResumedCompletionHandler = WTFMove(completionHandler);
     speechSynthesisData().synthesizer->resume();
 }
+
+void WebPageProxy::didStartSpeaking(WebCore::PlatformSpeechSynthesisUtterance&)
+{
+    if (speechSynthesisData().speakingStartedCompletionHandler)
+        speechSynthesisData().speakingStartedCompletionHandler();
+}
+
+void WebPageProxy::didFinishSpeaking(WebCore::PlatformSpeechSynthesisUtterance&)
+{
+    if (speechSynthesisData().speakingFinishedCompletionHandler)
+        speechSynthesisData().speakingFinishedCompletionHandler();
+}
+
+void WebPageProxy::didPauseSpeaking(WebCore::PlatformSpeechSynthesisUtterance&)
+{
+    if (speechSynthesisData().speakingPausedCompletionHandler)
+        speechSynthesisData().speakingPausedCompletionHandler();
+}
+
+void WebPageProxy::didResumeSpeaking(WebCore::PlatformSpeechSynthesisUtterance&)
+{
+    if (speechSynthesisData().speakingResumedCompletionHandler)
+        speechSynthesisData().speakingResumedCompletionHandler();
+}
+
+void WebPageProxy::speakingErrorOccurred(WebCore::PlatformSpeechSynthesisUtterance&, std::optional<WebCore::SpeechSynthesisErrorCode> error)
+{
+    if (!error)
+        send(Messages::WebPage::SpeakingErrorOccurred(std::nullopt));
+    else
+        send(Messages::WebPage::SpeakingErrorOccurred(static_cast<uint8_t>(*error)));
+}
+
+void WebPageProxy::boundaryEventOccurred(WebCore::PlatformSpeechSynthesisUtterance&, WebCore::SpeechBoundary speechBoundary, unsigned charIndex, unsigned charLength)
+{
+    send(Messages::WebPage::BoundaryEventOccurred(speechBoundary == WebCore::SpeechBoundary::SpeechWordBoundary, charIndex, charLength));
+}
+
+void WebPageProxy::voicesDidChange()
+{
+    send(Messages::WebPage::VoicesDidChange());
+}
 #endif // ENABLE(SPEECH_SYNTHESIS)
 
 #if !PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2662,7 +2662,7 @@ private:
     void didFinishSpeaking(WebCore::PlatformSpeechSynthesisUtterance&) final;
     void didPauseSpeaking(WebCore::PlatformSpeechSynthesisUtterance&) final;
     void didResumeSpeaking(WebCore::PlatformSpeechSynthesisUtterance&) final;
-    void speakingErrorOccurred(WebCore::PlatformSpeechSynthesisUtterance&) final;
+    void speakingErrorOccurred(WebCore::PlatformSpeechSynthesisUtterance&, std::optional<WebCore::SpeechSynthesisErrorCode>) final;
     void boundaryEventOccurred(WebCore::PlatformSpeechSynthesisUtterance&, WebCore::SpeechBoundary, unsigned charIndex, unsigned charLength) final;
     void voicesDidChange() final;
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -221,6 +221,7 @@
 #include <WebCore/PingLoader.h>
 #include <WebCore/PlatformKeyboardEvent.h>
 #include <WebCore/PlatformMediaSessionManager.h>
+#include <WebCore/PlatformSpeechSynthesizer.h>
 #include <WebCore/PlatformStrategies.h>
 #include <WebCore/PluginDocument.h>
 #include <WebCore/PointerCaptureController.h>
@@ -7481,10 +7482,12 @@ void WebPage::systemPreviewActionTriggered(WebCore::SystemPreviewInfo previewInf
 #endif
 
 #if ENABLE(SPEECH_SYNTHESIS)
-void WebPage::speakingErrorOccurred()
+void WebPage::speakingErrorOccurred(std::optional<uint8_t> error)
 {
     if (auto observer = corePage()->speechSynthesisClient()->observer())
-        observer->speakingErrorOccurred();
+        observer->speakingErrorOccurred(!error
+                                        ? std::nullopt
+                                        : std::make_optional(static_cast<WebCore::SpeechSynthesisErrorCode>(*error)));
 }
 
 void WebPage::boundaryEventOccurred(bool wordBoundary, unsigned charIndex, unsigned charLength)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1974,7 +1974,7 @@ private:
 #endif
 
 #if ENABLE(SPEECH_SYNTHESIS)
-    void speakingErrorOccurred();
+    void speakingErrorOccurred(std::optional<uint8_t> error);
     void boundaryEventOccurred(bool wordBoundary, unsigned charIndex, unsigned charLength);
     void voicesDidChange();
 #endif

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -629,7 +629,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
     SimulateDeviceOrientationChange(double alpha, double beta, double gamma)
 
 #if ENABLE(SPEECH_SYNTHESIS)
-    SpeakingErrorOccurred()
+    SpeakingErrorOccurred(std::optional<uint8_t> error)
     BoundaryEventOccurred(bool wordBoundary, unsigned charIndex, unsigned charLength)
     VoicesDidChange()
 #endif


### PR DESCRIPTION
- Add missing functions
- Add proper error handling (similar to #823 with optional as in #875) for both UIProcess and WebProcess