### PR TITLE
WebSpeech: fix a compilation

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -348,10 +348,6 @@ void registerWebKitGStreamerElements()
         gst_element_register(nullptr, "webkitmediasrc", GST_RANK_PRIMARY, WEBKIT_TYPE_MEDIA_SRC);
 #endif
 
-#if ENABLE(SPEECH_SYNTHESIS)
-        gst_element_register(nullptr, "webkitflitesrc", GST_RANK_NONE, WEBKIT_TYPE_FLITE_SRC);
-#endif
-
 #if ENABLE(VIDEO)
         gst_element_register(0, "webkitwebsrc", GST_RANK_PRIMARY + 100, WEBKIT_TYPE_WEB_SRC);
         gst_element_register(0, "webkitdmabufvideosink", GST_RANK_NONE, WEBKIT_TYPE_DMABUF_VIDEO_SINK);


### PR DESCRIPTION
With ENABLE_SPEECH_SYNTHESIS compilation of the WPE is not possible due to the error: 
```
Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:352:72: error: ‘WEBKIT_TYPE_FLITE_SRC’ was not declared in this scope; did you mean ‘WEBKIT_TYPE_MEDIA_SRC’?
  352 |         gst_element_register(nullptr, "webkitflitesrc", GST_RANK_NONE, WEBKIT_TYPE_FLITE_SRC);
```
The problem was introduced by:
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/086dc8f2b7cc738beecde2e20bb27b3b4ab078e3

To fix it the registration of the 'webkitflitesrc' has to be removed - flite is not supported in this version of WPE.