### PR TITLE
[GST][MSE] Fix YT loop playback tests

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -2750,7 +2750,7 @@ void MediaPlayerPrivateGStreamer::didEnd()
     // until we get the initial STREAMS_SELECTED message one more time.
     m_waitingForStreamsSelectedEvent = true;
 
-    if (!m_player->isLooping()) {
+    if (!m_player->isLooping() && !isMediaSource()) {
         m_isPaused = true;
         changePipelineState(GST_STATE_READY);
         m_didDownloadFinish = false;

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -511,12 +511,13 @@ void MediaPlayerPrivateGStreamerMSE::updateStates()
     if (UNLIKELY(!m_pipeline || m_didErrorOccur))
         return;
 
+    const bool mseBuffering = !isTimeBuffered(currentMediaTime());
+
     MediaPlayer::NetworkState oldNetworkState = m_networkState;
     MediaPlayer::ReadyState oldReadyState = m_readyState;
     GstState state, pending;
 
     GstStateChangeReturn getStateResult = gst_element_get_state(m_pipeline.get(), &state, &pending, 250 * GST_NSECOND);
-    const bool mseBuffering = !isTimeBuffered(currentMediaTime());
 
     bool shouldUpdatePlaybackState = false;
     switch (getStateResult) {


### PR DESCRIPTION
This change fixes 2 problems:

 - inconsistent readyState in HTMLMediaElement and MediaPlayerPrivateGStreamerMSE. This happens when currentMediaTime() triggers a seek to 0 position for looping video (from within the updateStates). seek internally changes the readyState to HaveMetadata, causing the wrong value to be captured at the begining of updateStates(), and later a failure to finishSeek in HtmlMediaElement.

 - seek to 0 after EOS with looping disabled. MSE player cannot recover after transition to READY state.

Tests: https://ytlr-cert.appspot.com/2021/main.html?&test_type=msecodec-test&tests=55,56,57