### PR TITLE
wpe-2.28 flush improvements

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
@@ -128,7 +128,7 @@ void SourceBufferPrivateGStreamer::flush(const AtomString& trackId)
     ASSERT(isMainThread());
 
     // This is only for on-the-fly reenqueues after appends. When seeking, the seek will do its own flush.
-    if (!m_playerPrivate.seeking())
+    if (!m_playerPrivate.seeking() || m_playerPrivate.gstSeekCompleted())
         m_playerPrivate.playbackPipeline()->flush(trackId);
 }
 


### PR DESCRIPTION
Fix some corner cases observed on samples removal/replacement:

- segmentFixer probe can incorrectly amend the segment on rewind after flush
- repeated media data can be sent to the decoder on samples replacement after seek 
- restore the previous behavior of the flush for hole-punching configuration