### PR TITLE
[MSE][GStreamer]: Fix artifacts on STV at the end of the movie

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -252,8 +252,9 @@ AppendPipeline::AppendPipeline(Ref<MediaSourceClientGStreamerMSE> mediaSourceCli
     gst_app_sink_set_emit_signals(GST_APP_SINK(m_appsink.get()), TRUE);
     gst_base_sink_set_sync(GST_BASE_SINK(m_appsink.get()), FALSE);
     gst_base_sink_set_last_sample_enabled(GST_BASE_SINK(m_appsink.get()), FALSE);
+#if GST_CHECK_VERSION(1, 12, 0)
     gst_base_sink_set_drop_out_of_segment(GST_BASE_SINK(m_appsink.get()), FALSE);
-
+#endif
     GRefPtr<GstPad> appsinkPad = adoptGRef(gst_element_get_static_pad(m_appsink.get(), "sink"));
     g_signal_connect(appsinkPad.get(), "notify::caps", G_CALLBACK(appendPipelineAppsinkCapsChanged), this);
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -252,6 +252,7 @@ AppendPipeline::AppendPipeline(Ref<MediaSourceClientGStreamerMSE> mediaSourceCli
     gst_app_sink_set_emit_signals(GST_APP_SINK(m_appsink.get()), TRUE);
     gst_base_sink_set_sync(GST_BASE_SINK(m_appsink.get()), FALSE);
     gst_base_sink_set_last_sample_enabled(GST_BASE_SINK(m_appsink.get()), FALSE);
+    gst_base_sink_set_drop_out_of_segment(GST_BASE_SINK(m_appsink.get()), FALSE);
 
     GRefPtr<GstPad> appsinkPad = adoptGRef(gst_element_get_static_pad(m_appsink.get(), "sink"));
     g_signal_connect(appsinkPad.get(), "notify::caps", G_CALLBACK(appendPipelineAppsinkCapsChanged), this);


### PR DESCRIPTION
Configure sink to not drop buffers which are outside the current segment. This way we do not lost video frames which are valid.

Example of currently dropped buffer:
- gst segment stop time: 1:30:00.00
- gst buffer dts: 1:29:59.80, pts: 1:30:00.04

Current buffer is dropped because pts (1:30:00.04) is higher then gst stop time (1:30:00.00). This condition is too strict for STV content. We don't see also that strict requirement in Dash specification.

Issue is reproducing during end of STV movies (when in stream we have dynamically injected ads).
STV URL: https://virginmedia.player.stv.tv
UK VPN is required for playback. 

This is a backport of WPE 2.28 fix:
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/6d8594c9a4cc9bb7036754fb13461c0fa4d1091d