### PR TITLE
Fix MediaPlayerPrivateHolePunch:setSize() method name

### DIFF
--- a/Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunch.h
+++ b/Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunch.h
@@ -83,7 +83,7 @@ public:
 
     bool didLoadingProgress() const final { return false; };
 
-    void setSize(const IntSize& size) final { m_size = size; };
+    void setPresentationSize(const IntSize& size) final { m_size = size; };
 
     void paint(GraphicsContext&, const FloatRect&) final { };
 


### PR DESCRIPTION
setSize() was renamed to setPresentationSize() with 19b01bb4cdc078f1f9b0777ed9734aca92420d65