### PR TITLE
[WPE] Always call glBindAttribLocation before glLinkProgram

### DIFF
--- a/Source/WebKit/UIProcess/API/wpe/qt/WPEQtViewBackend.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/qt/WPEQtViewBackend.cpp
@@ -106,10 +106,11 @@ WPEQtViewBackend::WPEQtViewBackend(const QSizeF& size, EGLDisplay display, EGLCo
     m_program = glFunctions->glCreateProgram();
     glFunctions->glAttachShader(m_program, vertexShader);
     glFunctions->glAttachShader(m_program, fragmentShader);
-    glFunctions->glLinkProgram(m_program);
 
     glFunctions->glBindAttribLocation(m_program, 0, "pos");
     glFunctions->glBindAttribLocation(m_program, 1, "texture");
+
+    glFunctions->glLinkProgram(m_program);
     m_textureUniform = glFunctions->glGetUniformLocation(m_program, "u_texture");
 
     static struct wpe_view_backend_exportable_fdo_egl_client exportableClient = {

--- a/Tools/wpe/backends/WindowViewBackend.cpp
+++ b/Tools/wpe/backends/WindowViewBackend.cpp
@@ -599,10 +599,11 @@ WindowViewBackend::WindowViewBackend(uint32_t width, uint32_t height)
         m_program = glCreateProgram();
         glAttachShader(m_program, vertexShader);
         glAttachShader(m_program, fragmentShader);
-        glLinkProgram(m_program);
 
         glBindAttribLocation(m_program, 0, "pos");
         glBindAttribLocation(m_program, 1, "texture");
+
+        glLinkProgram(m_program);
         m_textureUniform = glGetUniformLocation(m_program, "u_texture");
     }
 


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=255006

Reviewed by Don Olmstead.

Reorder glBindAttribLocation() calls to be done before glLinkProgram(). While existing code worked with many GL implementations, that behavior shall not be relied upon: the specification indicates that attribute bindings go into effect after calling glLinkProgram().

Thanks to user "mizmar" for reporting the issue and outlining the solution.

* Source/WebKit/UIProcess/API/wpe/qt/WPEQtViewBackend.cpp:
(WPEQtViewBackend::WPEQtViewBackend): Reorder GL calls.
* Tools/wpe/backends/fdo/WindowViewBackend.cpp:
(WPEToolingBackends::WindowViewBackend::WindowViewBackend): Ditto.

Canonical link: https://commits.webkit.org/262592@main