### PR TITLE
Improving MSE performance for sparse stream. (#530)

### DIFF
--- a/Source/WebCore/platform/graphics/PlatformTimeRanges.cpp
+++ b/Source/WebCore/platform/graphics/PlatformTimeRanges.cpp
@@ -146,6 +146,36 @@ MediaTime PlatformTimeRanges::minimumBufferedTime() const
     return m_ranges[0].m_start;
 }
 
+// This function either returns the nearest index of smaller start value or returns zero
+size_t PlatformTimeRanges::getNearestSmallerStartOrZero(const MediaTime& start, const MediaTime& end) const
+{
+    ASSERT(start <= end);
+    Range range(start, end);
+    size_t first, last, middle;
+    size_t index = 0;
+
+    // if the range size is <=2 then better return 0
+    if(m_ranges.size() <= 2) {
+        return index;
+    }
+
+    first = 0;
+    last = m_ranges.size() - 1;
+    middle = first + ((last - first)/2);
+
+    while (first < last && middle > 0) {
+        if ( m_ranges[middle].isBeforeRange(range) ) {
+            index = middle;
+            first = middle + 1;
+        } else {
+            last = middle - 1;
+        }
+
+        middle = first + ((last - first)/2);
+    }
+    return index;
+}
+
 void PlatformTimeRanges::add(const MediaTime& start, const MediaTime& end)
 {
 #if !PLATFORM(MAC) // https://bugs.webkit.org/show_bug.cgi?id=180253
@@ -154,7 +184,7 @@ void PlatformTimeRanges::add(const MediaTime& start, const MediaTime& end)
 #endif
     ASSERT(start <= end);
 
-    unsigned overlappingArcIndex;
+    size_t overlappingArcIndex;
     Range addedRange(start, end);
 
     // For each present range check if we need to:
@@ -164,7 +194,8 @@ void PlatformTimeRanges::add(const MediaTime& start, const MediaTime& end)
     //
     // TODO: Given that we assume that ranges are correctly ordered, this could be optimized.
 
-    for (overlappingArcIndex = 0; overlappingArcIndex < m_ranges.size(); overlappingArcIndex++) {
+    // Assigning overlappingArcIndex = getNearestSmallerStartOrZero() considering the range is ordered
+    for (overlappingArcIndex = getNearestSmallerStartOrZero(start, end); overlappingArcIndex < m_ranges.size(); overlappingArcIndex++) {
         if (addedRange.isOverlappingRange(m_ranges[overlappingArcIndex]) || addedRange.isContiguousWithRange(m_ranges[overlappingArcIndex])) {
             // We need to merge the addedRange and that range.
             addedRange = addedRange.unionWithOverlappingOrContiguousRange(m_ranges[overlappingArcIndex]);

--- a/Source/WebCore/platform/graphics/PlatformTimeRanges.h
+++ b/Source/WebCore/platform/graphics/PlatformTimeRanges.h
@@ -142,6 +142,7 @@ private:
 
     PlatformTimeRanges(Vector<Range>&&);
 
+    size_t getNearestSmallerStartOrZero(const MediaTime& start, const MediaTime& end) const;
     Vector<Range> m_ranges;
 };
 


### PR DESCRIPTION
Cherry pick of https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/530 for wpe-2.28 branch

This is seen with some assets in Hulu app where samples are not overlapping (by 1 microsecond difference, rounding error?).
For 20k samples removed at once this reduces time taken from 40sec to 2sec.