### PR TITLE
MSE: limit the number of samples stored in SourceBuffer

### DIFF
--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -981,16 +981,26 @@ void SourceBuffer::evictCodedFrames(size_t newDataSize)
     if (isRemoved())
         return;
 
+    const auto hasTooManySamples = [&] {
+        const size_t evictionThreshold = m_private->platformEvictionThreshold();
+        if (!evictionThreshold)
+            return false;
+        size_t currentSize = 0;
+        for (const auto& trackBuffer : m_trackBufferMap.values())
+            currentSize += trackBuffer.samples.size();
+        return currentSize > evictionThreshold;
+    };
+
     // This algorithm is run to free up space in this source buffer when new data is appended.
     // 1. Let new data equal the data that is about to be appended to this SourceBuffer.
     // 2. If the buffer full flag equals false, then abort these steps.
-    if (!m_bufferFull)
+    if (!m_bufferFull && !hasTooManySamples())
         return;
 
     size_t maximumBufferSize = this->maximumBufferSize();
 
     // Check if app has removed enough already.
-    if (extraMemoryCost() + newDataSize < maximumBufferSize) {
+    if (m_bufferFull && extraMemoryCost() + newDataSize < maximumBufferSize) {
         m_bufferFull = false;
         return;
     }

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.h
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.h
@@ -77,6 +77,8 @@ public:
     virtual const Logger& sourceBufferLogger() const = 0;
     virtual const void* sourceBufferLogIdentifier() = 0;
 #endif
+
+    virtual size_t platformEvictionThreshold() const { return 0; }
 };
 
 }

--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
@@ -46,6 +46,7 @@
 #include "NotImplemented.h"
 #include "PlaybackPipeline.h"
 #include "WebKitMediaSourceGStreamer.h"
+#include <wtf/text/StringToIntegerConversion.h>
 
 namespace WebCore {
 
@@ -208,6 +209,22 @@ WTFLogChannel& SourceBufferPrivateGStreamer::logChannel() const
     return LogMediaSource;
 }
 #endif
+
+size_t SourceBufferPrivateGStreamer::platformEvictionThreshold() const
+{
+    static size_t evictionThreshold  = 10000;
+    static std::once_flag once;
+    std::call_once(once, []() {
+        String s(std::getenv("MSE_BUFFER_SAMPLES_EVICTION_THRESHOLD"));
+        if (!s.isEmpty()) {
+            bool ok = false;
+            size_t size = toIntegralType<size_t>(s, &ok);
+            if (ok)
+                evictionThreshold = size;
+         }
+    });
+    return evictionThreshold;
+}
 
 }
 #endif

--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h
@@ -93,6 +93,8 @@ public:
     const void* sourceBufferLogIdentifier() final { return logIdentifier(); }
 #endif
 
+    size_t platformEvictionThreshold() const final;
+
 private:
     SourceBufferPrivateGStreamer(MediaSourcePrivateGStreamer*, const ContentType&, MediaPlayerPrivateGStreamerMSE&);
 


### PR DESCRIPTION
Applications may append a lot of samples without triggereing eviction algorithm (> 500K). Which results in cleanup(on player destruction) taking too long time.

Here is an example of video where we observed such behavior: https://www.youtube.com/tv#/watch?v=6ATfcsAFFNE&list=RD-WLgxoa4BeU

This change allows at least one pass of eviction algorithm if number of samples is greater than 10K. Which should be enough to allow storing ~2-3 minutes of audio or video if size limit doesn't kick in.