### PR TITLE
[Linux] Web Inspector: add memory usage of images in memory timeline

### DIFF
--- a/Source/WebCore/page/linux/ResourceUsageThreadLinux.cpp
+++ b/Source/WebCore/page/linux/ResourceUsageThreadLinux.cpp
@@ -29,6 +29,7 @@
 
 #if ENABLE(RESOURCE_USAGE) && OS(LINUX)
 
+#include "MemoryCache.h"
 #include "WorkerThread.h"
 #include <JavaScriptCore/GCActivityCallback.h>
 #include <JavaScriptCore/SamplingProfiler.h>
@@ -312,6 +313,13 @@ void ResourceUsageThread::platformCollectMemoryData(JSC::VM* vm, ResourceUsageDa
     data.categories[MemoryCategory::GCHeap].dirtySize = currentGCHeapCapacity;
     data.categories[MemoryCategory::GCOwned].dirtySize = currentGCOwnedExtra - currentGCOwnedExternal;
     data.categories[MemoryCategory::GCOwned].externalSize = currentGCOwnedExternal;
+
+    int imagesDecodedSize = 0;
+    callOnMainThreadAndWait([&imagesDecodedSize] {
+        imagesDecodedSize = MemoryCache::singleton().getStatistics().images.decodedSize;
+    });
+    data.categories[MemoryCategory::Images].dirtySize = imagesDecodedSize;
+
     size_t categoriesTotalSize = 0;
     for (auto& category : data.categories)
         categoriesTotalSize += category.totalSize();


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=253873

Reviewed by Carlos Garcia Campos.

This fix extends what is reported in memory timeline(web inspector) of memory usage with data for images(only for linux).

* Source/WebCore/page/ResourceUsageThread.cpp: (WebCore::ResourceUsageThread::setTotalLayerInfo):
* Source/WebCore/page/ResourceUsageThread.h:
* Source/WebCore/page/linux/ResourceUsageThreadLinux.cpp: (WebCore::ResourceUsageThread::platformCollectMemoryData):
* Source/WebCore/rendering/RenderLayerCompositor.cpp: (WebCore::RenderLayerCompositor::updateCompositingLayers):

Canonical link: https://commits.webkit.org/263230@main