### PR TITLE
EME Gstreamer: Break key waiting on PAUSED->READY state change

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp
@@ -44,7 +44,7 @@ public:
         : m_decryptor(decryptor) { }
     virtual bool isAborting()
     {
-        return webKitMediaCommonEncryptionDecryptIsFlushing(m_decryptor);
+        return webKitMediaCommonEncryptionDecryptIsAborting(m_decryptor);
     }
     virtual ~CDMProxyDecryptionClientImplementation() = default;
 private:
@@ -66,6 +66,7 @@ struct _WebKitMediaCommonEncryptionDecryptPrivate {
     Condition condition;
 
     bool isFlushing { false };
+    bool isStopped { true };
     std::unique_ptr<CDMProxyDecryptionClientImplementation> cdmProxyDecryptionClientImplementation;
     enum DecryptionState decryptionState { DecryptionState::Idle };
 };
@@ -240,12 +241,16 @@ static GstFlowReturn transformInPlace(GstBaseTransform* base, GstBuffer* buffer)
     if (!priv->cdmProxy) {
         GST_DEBUG_OBJECT(self, "CDM not available, going to wait for it");
         priv->condition.waitFor(priv->mutex, MaxSecondsToWaitForCDMProxy, [priv] {
-            return priv->isFlushing || priv->cdmProxy;
+            return priv->isFlushing || priv->cdmProxy || priv->isStopped;
         });
         // Note that waitFor() releases the mutex lock internally while it waits, so isFlushing may have been changed.
         if (priv->isFlushing) {
             GST_DEBUG_OBJECT(self, "Decryption aborted because of flush");
             return GST_FLOW_FLUSHING;
+        }
+        if (priv->isStopped) {
+            GST_DEBUG_OBJECT(self, "Element is closing");
+            return GST_FLOW_OK;
         }
         if (!priv->cdmProxy) {
             GST_ELEMENT_ERROR(self, STREAM, FAILED, ("CDMProxy was not retrieved in time"), (nullptr));
@@ -464,11 +469,15 @@ static gboolean sinkEventHandler(GstBaseTransform* trans, GstEvent* event)
     return GST_BASE_TRANSFORM_CLASS(parent_class)->sink_event(trans, event);
 }
 
-bool webKitMediaCommonEncryptionDecryptIsFlushing(WebKitMediaCommonEncryptionDecrypt* self)
+bool webKitMediaCommonEncryptionDecryptIsAborting(WebKitMediaCommonEncryptionDecrypt* self)
 {
     WebKitMediaCommonEncryptionDecryptPrivate* priv = WEBKIT_MEDIA_CENC_DECRYPT_GET_PRIVATE(self);
     LockHolder locker(priv->mutex);
-    return priv->isFlushing;
+    if (priv->isFlushing || priv->isStopped) {
+        return true;
+    }
+
+    return false;
 }
 
 WeakPtr<WebCore::CDMProxyDecryptionClient> webKitMediaCommonEncryptionDecryptGetCDMProxyDecryptionClient(WebKitMediaCommonEncryptionDecrypt* self)
@@ -483,10 +492,24 @@ static GstStateChangeReturn changeState(GstElement* element, GstStateChange tran
     WebKitMediaCommonEncryptionDecryptPrivate* priv = WEBKIT_MEDIA_CENC_DECRYPT_GET_PRIVATE(self);
 
     switch (transition) {
-    case GST_STATE_CHANGE_PAUSED_TO_READY:
-        GST_DEBUG_OBJECT(self, "PAUSED->READY");
-        priv->condition.notifyOne();
+    case GST_STATE_CHANGE_READY_TO_PAUSED: {
+        GST_DEBUG_OBJECT(self, "READY->PAUSED");
+
+        LockHolder locker(priv->mutex);
+        priv->isStopped = false;
         break;
+    }
+    case GST_STATE_CHANGE_PAUSED_TO_READY: {
+        GST_DEBUG_OBJECT(self, "PAUSED->READY");
+
+        LockHolder locker(priv->mutex);
+        priv->isStopped = true;
+        priv->condition.notifyOne();
+        if (priv->cdmProxy) {
+            priv->cdmProxy->abortWaitingForKey();
+        }
+        break;
+    }
     default:
         break;
     }

--- a/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.h
@@ -46,7 +46,7 @@ typedef struct _WebKitMediaCommonEncryptionDecryptPrivate WebKitMediaCommonEncry
 
 GType webkit_media_common_encryption_decrypt_get_type(void);
 
-bool webKitMediaCommonEncryptionDecryptIsFlushing(WebKitMediaCommonEncryptionDecrypt*);
+bool webKitMediaCommonEncryptionDecryptIsAborting(WebKitMediaCommonEncryptionDecrypt*);
 
 struct _WebKitMediaCommonEncryptionDecrypt {
     GstBaseTransform parent;


### PR DESCRIPTION
Changeing a state can't be completed when decryptor is waiting for a key. This can block main thread for max 7sec.

1) Signal key waiting cond to return when decryptor is closing.
2) Return waiting for CDMProxy for the same case.