### PR TITLE
Remove FrameStateProvisional check in CachedResource::load()

### DIFF
--- a/Source/WebCore/loader/cache/CachedResource.cpp
+++ b/Source/WebCore/loader/cache/CachedResource.cpp
@@ -217,8 +217,10 @@ void CachedResource::load(CachedResourceLoader& cachedResourceLoader)
     }
 
     FrameLoader& frameLoader = frame.loader();
-    if (m_options.securityCheck == SecurityCheckPolicy::DoSecurityCheck && !shouldUsePingLoad(type()) && (frameLoader.state() == FrameStateProvisional || !frameLoader.activeDocumentLoader() || frameLoader.activeDocumentLoader()->isStopping())) {
-        if (frameLoader.state() == FrameStateProvisional)
+    const char* provisionalCheckEnv = getenv("WPE_DISABLE_PROVISIONAL_CHECK");
+    bool isProvisionalState = !(provisionalCheckEnv && provisionalCheckEnv[0] == '1') && frameLoader.state() == FrameStateProvisional;
+    if (m_options.securityCheck == SecurityCheckPolicy::DoSecurityCheck && !shouldUsePingLoad(type()) && (isProvisionalState || !frameLoader.activeDocumentLoader() || frameLoader.activeDocumentLoader()->isStopping())) {
+        if (isProvisionalState)
             RELEASE_LOG_IF_ALLOWED("load: Failed security check -- state is provisional (frame = %p)", &frame);
         else if (!frameLoader.activeDocumentLoader())
             RELEASE_LOG_IF_ALLOWED("load: Failed security check -- not active document (frame = %p)", &frame);


### PR DESCRIPTION
We're hitting the "load: Failed security check -- state is provisional" error on BBC iPlayer, and also on some other pages.

Removing this condition seems to resolve the issue - but, to be honest, we don't really understand why this check is even there, or what could go wrong if we do remove it. Can anyone familiar with this code give some detailed explanation please?