### PR TITLE
[GST] disable enforcement of audio/video sink setup for certain platf…

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -1245,6 +1245,12 @@ void MediaPlayerPrivateGStreamer::loadingFailed(MediaPlayer::NetworkState networ
 
 GstElement* MediaPlayerPrivateGStreamer::createAudioSink()
 {
+#if PLATFORM(BROADCOM) || USE(WESTEROS_SINK) || PLATFORM(AMLOGIC) || PLATFORM(REALTEK)
+    // If audio is being controlled by an another pipeline, creating sink here may interfere with
+    // audio playback. Instead, check if an audio sink was setup in handleMessage and use it.
+    return nullptr;
+#endif
+
     // For platform specific audio sinks, they need to be properly upranked so that they get properly autoplugged.
 
     auto role = m_player->isVideoPlayer() ? "video"_s : "music"_s;
@@ -1295,7 +1301,7 @@ GstClockTime MediaPlayerPrivateGStreamer::gstreamerPositionFromSinks() const
         GST_TRACE_OBJECT(pipeline(), "Audio position %" GST_TIME_FORMAT, GST_TIME_ARGS(audioPosition));
         query = adoptGRef(gst_query_new_position(GST_FORMAT_TIME));
     }
-    if (m_player->isVideoPlayer() && gst_element_query(m_videoSink.get(), query.get())) {
+    if (m_player->isVideoPlayer() && m_videoSink && gst_element_query(m_videoSink.get(), query.get())) {
         gint64 videoPosition = GST_CLOCK_TIME_NONE;
         gst_query_parse_position(query.get(), 0, &videoPosition);
         GST_TRACE_OBJECT(pipeline(), "Video position %" GST_TIME_FORMAT, GST_TIME_ARGS(videoPosition));
@@ -1823,15 +1829,15 @@ void MediaPlayerPrivateGStreamer::handleMessage(GstMessage* message)
         GstState newState;
         gst_message_parse_state_changed(message, &currentState, &newState, nullptr);
 
-#if USE(GSTREAMER_HOLEPUNCH) && USE(WPEWEBKIT_PLATFORM_BCM_NEXUS)
-        if (currentState == GST_STATE_NULL && newState == GST_STATE_READY) {
+#if USE(GSTREAMER_HOLEPUNCH) && (USE(WPEWEBKIT_PLATFORM_BCM_NEXUS) || USE(WESTEROS_SINK))
+        if (currentState <= GST_STATE_READY && newState >= GST_STATE_READY) {
             // If we didn't create a video sink, store a reference to the created one.
             if (!m_videoSink) {
                 // Detect the videoSink element. Getting the video-sink property of the pipeline requires
                 // locking some elements, which may lead to deadlocks during playback. Instead, identify
                 // the videoSink based on its metadata.
                 GstElement* element = GST_ELEMENT(GST_MESSAGE_SRC(message));
-                if (GST_IS_BASE_SINK(element)) {
+                if (GST_OBJECT_FLAG_IS_SET (element, GST_ELEMENT_FLAG_SINK)) {
                     const gchar* klass_str = gst_element_get_metadata(element, "klass");
                     if (strstr(klass_str, "Sink") && strstr(klass_str, "Video")) {
                         m_videoSink = element;
@@ -1840,6 +1846,22 @@ void MediaPlayerPrivateGStreamer::handleMessage(GstMessage* message)
                         pushNextHolePunchBuffer();
                     }
                 }
+            }
+        }
+#endif
+
+#if PLATFORM(BROADCOM) || USE(WESTEROS_SINK) || PLATFORM(AMLOGIC) || PLATFORM(REALTEK)
+        if (currentState <= GST_STATE_READY && newState >= GST_STATE_READY) {
+            // If we didn't create an audio sink, store a reference to the created one.
+            if (!m_audioSink) {
+                // Detect a audio sink element
+                GstElement* element = GST_ELEMENT(GST_MESSAGE_SRC(message));
+                if (GST_OBJECT_FLAG_IS_SET (element, GST_ELEMENT_FLAG_SINK)) {
+                    const gchar* klass_str = gst_element_get_metadata(element, "klass");
+                    if (strstr(klass_str, "Sink") && strstr(klass_str, "Audio")) {
+                        m_audioSink = element;
+                    }
+                 }
             }
         }
 #endif
@@ -4001,9 +4023,16 @@ GstElement* MediaPlayerPrivateGStreamer::createHolePunchVideoSink()
     // we use a fakeVideoSink so nothing is drawn to the page.
 
 #if USE(WESTEROS_SINK)
+    AtomString val;
+    bool isPIPRequested =
+        m_player->doesHaveAttribute("pip"_s, &val) && equalLettersIgnoringASCIICase(val, "true"_s);
+    if (m_isLegacyPlaybin && !isPIPRequested)
+        return nullptr;
     // Westeros using holepunch.
     GstElement* videoSink = makeGStreamerElement("westerossink", "WesterosVideoSink");
     g_object_set(G_OBJECT(videoSink), "zorder", 0.0f, nullptr);
+    if (isPIPRequested)
+        g_object_set(G_OBJECT(videoSink), "res-usage", 0u, nullptr);
     return videoSink;
 #endif
 


### PR DESCRIPTION
…orms

This solves several cases:

- secondary (video only) playback. audio sink allocates resources in ready state (as part of auto audio sink detection), which interferes with the main playback.

- "external" playback, or playback with other sink elements. in this case we want playbin to autoplug needed elements.