### PR TITLE
Low delay mode for realtek

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -3981,11 +3981,17 @@ void MediaPlayerPrivateGStreamer::configureElement(GstElement* element)
         g_object_set(G_OBJECT(element), "high-watermark", 0.10, nullptr);
 
 #if ENABLE(MEDIA_STREAM) && PLATFORM(REALTEK)
-    if (m_streamPrivate != nullptr && g_object_class_find_property (G_OBJECT_GET_CLASS (element), "media-tunnel")) {
-        GST_INFO("Enable 'immediate-output' in rtkaudiosink");
-        g_object_set (G_OBJECT(element), "media-tunnel", FALSE, nullptr);
-        g_object_set (G_OBJECT(element), "audio-service", TRUE, nullptr);
-        g_object_set (G_OBJECT(element), "lowdelay-sync-mode", TRUE, nullptr);
+    if (m_streamPrivate != nullptr) {
+        if (g_object_class_find_property (G_OBJECT_GET_CLASS (element), "media-tunnel")) {
+            GST_INFO("Enable 'immediate-output' in rtkaudiosink");
+            g_object_set (G_OBJECT(element), "media-tunnel", FALSE, nullptr);
+            g_object_set (G_OBJECT(element), "audio-service", TRUE, nullptr);
+            g_object_set (G_OBJECT(element), "lowdelay-sync-mode", TRUE, nullptr);
+        }
+        if (g_object_class_find_property (G_OBJECT_GET_CLASS (element), "lowdelay-mode")) {
+            GST_INFO("Enable 'lowdelay-mode' in rtk omx decoder");
+            g_object_set (G_OBJECT(element), "lowdelay-mode", TRUE, nullptr);
+        }
     }
 #endif
 }

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -3986,6 +3986,13 @@ void MediaPlayerPrivateGStreamer::configureElement(GstElement* element)
         g_object_set (G_OBJECT(element), "media-tunnel", FALSE, nullptr);
         g_object_set (G_OBJECT(element), "audio-service", TRUE, nullptr);
         g_object_set (G_OBJECT(element), "lowdelay-sync-mode", TRUE, nullptr);
+    if (g_str_has_prefix(GST_ELEMENT_NAME(element), "omx")) {
+        GST_INFO("omx name: %s, have lowdelay-mode=%d, m_streamPrivate=%p", GST_ELEMENT_NAME(element), g_object_class_find_property (G_OBJECT_GET_CLASS (element), "lowdelay-mode"), m_streamPrivate);
+    }
+    if (m_streamPrivate != nullptr && g_object_class_find_property (G_OBJECT_GET_CLASS (element), "lowdelay-mode")) {
+        GST_INFO("Enable 'lowdelay-mode' in rtk omx decoder");
+        g_object_set (G_OBJECT(element), "lowdelay-mode", TRUE, nullptr);
+    }
     }
 #endif
 }


### PR DESCRIPTION
low-delay mode for video decoder will force decoder decode frame one by one without hold reference frame.