### PR TITLE
Improve memory pressure logging

### DIFF
--- a/Source/WTF/wtf/MemoryPressureHandler.cpp
+++ b/Source/WTF/wtf/MemoryPressureHandler.cpp
@@ -26,6 +26,9 @@
 #include "config.h"
 #include <wtf/MemoryPressureHandler.h>
 
+#if OS(LINUX)
+#include <unistd.h>
+#endif
 #include <fnmatch.h>
 #include <wtf/Logging.h>
 #include <wtf/MemoryFootprint.h>
@@ -365,14 +368,23 @@ void MemoryPressureHandler::ReliefLogger::logMemoryUsageChange()
 
     auto currentMemory = platformMemoryUsage();
     if (!currentMemory || !m_initialMemory) {
+#if OS(LINUX)
+        MEMORYPRESSURE_LOG("Memory pressure relief: pid = %d, %" PUBLIC_LOG_STRING ": (Unable to get dirty memory information for process)", getpid(), m_logString);
+#else
         MEMORYPRESSURE_LOG("Memory pressure relief: %" PUBLIC_LOG_STRING ": (Unable to get dirty memory information for process)", m_logString);
+#endif
         return;
     }
 
     long residentDiff = currentMemory->resident - m_initialMemory->resident;
     long physicalDiff = currentMemory->physical - m_initialMemory->physical;
 
+#if !OS(LINUX)
     MEMORYPRESSURE_LOG("Memory pressure relief: %" PUBLIC_LOG_STRING ": res = %zu/%zu/%ld, res+swap = %zu/%zu/%ld",
+#else
+    MEMORYPRESSURE_LOG("Memory pressure relief: pid = %d, %" PUBLIC_LOG_STRING ": res = %zu/%zu/%ld, res+swap = %zu/%zu/%ld",
+        getpid(),
+#endif
         m_logString,
         m_initialMemory->resident, currentMemory->resident, residentDiff,
         m_initialMemory->physical, currentMemory->physical, physicalDiff);


### PR DESCRIPTION
Same as https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1092 yet for `wpe-2.38`

> This PR improves memory pressure logs by adding information about PID.
Usually the log line context contains such info, however, it's not always the case. And since the logs of this kind are very important and may come from different processes, I propose to extend context in place.