### PR TITLE
Fix removal of samples being replaced

### DIFF
--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -1848,7 +1848,7 @@ void SourceBuffer::sourceBufferPrivateDidReceiveSample(MediaSample& sample)
 
                 MediaTime highestBufferedTime = trackBuffer.buffered.maximumBufferedTime();
                 MediaTime eraseBeginTime = trackBuffer.highestPresentationTimestamp;
-                MediaTime eraseEndTime = frameEndTimestamp - contiguousFrameTolerance;
+                MediaTime eraseEndTime = frameEndTimestamp;
 
                 if (eraseEndTime <= eraseBeginTime)
                     break;
@@ -1860,6 +1860,18 @@ void SourceBuffer::sourceBufferPrivateDidReceiveSample(MediaSample& sample)
                 else
                     // In any other case, perform a binary search (O(log(n)).
                     range = trackBuffer.samples.presentationOrder().findSamplesBetweenPresentationTimes(eraseBeginTime, eraseEndTime);
+
+                if (range.second != trackBuffer.samples.presentationOrder().end() && !sample.isSync()) {
+                    auto eraseEndTimeMinusTolerance = frameEndTimestamp - contiguousFrameTolerance;
+                    while (range.first != range.second) {
+                        auto& oldSample = *((range.second)->second);
+                        if (oldSample.isSync())
+                            break;
+                        if (eraseEndTimeMinusTolerance > oldSample.presentationTime())
+                            break;
+                        --range.second;
+                    }
+                }
 
                 if (range.first != trackBuffer.samples.presentationOrder().end())
                     erasedSamples.addRange(range.first, range.second);


### PR DESCRIPTION
During replacement of buffered range, SourceBuffer may fail to remove some samples if its PTS falls in "contiguousFrameTolerance" gap introduced in https://bugs.webkit.org/show_bug.cgi?id=190085.

The problem can be seen with this test https://emutavchi.github.io/tests/mse/mse_sample_replacement_test.html and instrumentation on WebKit side that logs the append number for each sample: https://github.com/emutavchi/WebKitForWayland/commit/8d272af173a4ba23a0922949a02d0c7f79339158

In problematic case you should see several "old" samples left in SourceBuffer after replacement of buffered range completed.

This change tries to preserve the behavior introduced in https://bugs.webkit.org/show_bug.cgi?id=190085, and still allow sample removal for non-sync samples.


