### PR TITLE
[GSTMediaPlayer] Don't update video duration at the end of playback

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -2739,7 +2739,7 @@ void MediaPlayerPrivateGStreamer::didEnd()
     // position is not always reported as 0 for instance.
     m_lastQueryTime.reset();
     MediaTime now = currentMediaTime();
-    if (now > MediaTime::zeroTime() && !m_isSeeking) {
+    if (now > MediaTime::zeroTime() && !m_isSeeking && !durationMediaTime().isFinite()) {
         m_cachedDuration = now;
         m_player->durationChanged();
     }


### PR DESCRIPTION
Playback position reported from GStreamer pipeline after EOS received is not always the same as expected video duration (~200ms diff sometimes). As a result the last 'timeupdate' event is triggered with a value that is not equal to inital duraiton that is confusing to advertisers expecting a video to play e.g. 10sec but at the end it's only 9.8sec.

Update video duration only if not set already. Playback position querry will notice m_isEndReached(true) and will use duration as current playback position.

Partial backport of ebfcb3b0757d41d55ce80fd731be7c83eea93078 https://bugs.webkit.org/show_bug.cgi?id=224237