### PR TITLE
Use static port for internal webinspector communication

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitInitialize.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitInitialize.cpp
@@ -34,6 +34,7 @@
 #include <mutex>
 #include <wtf/glib/GRefPtr.h>
 #include <wtf/glib/GUniquePtr.h>
+#include <wtf/text/StringToIntegerConversion.h>
 
 namespace WebKit {
 
@@ -75,8 +76,11 @@ static void initializeRemoteInspectorServer()
 
     auto inspectorHTTPAddress = parseAddress(httpAddress);
     GRefPtr<GSocketAddress> inspectorAddress;
-    if (inspectorHTTPAddress)
-        inspectorAddress = adoptGRef(G_SOCKET_ADDRESS(g_inet_socket_address_new(g_inet_socket_address_get_address(G_INET_SOCKET_ADDRESS(inspectorHTTPAddress.get())), 0)));
+    if (inspectorHTTPAddress) {
+        String envVar = String::fromLatin1(getenv("WEBKIT_INSPECTOR_PORT"));
+        auto port = parseInteger<uint16_t>(envVar).value_or(0);
+        inspectorAddress = adoptGRef(G_SOCKET_ADDRESS(g_inet_socket_address_new(g_inet_socket_address_get_address(G_INET_SOCKET_ADDRESS(inspectorHTTPAddress.get())), port)));
+    }
     else
         inspectorAddress = parseAddress(address);
     if (!inspectorHTTPAddress && !inspectorAddress) {


### PR DESCRIPTION
With this port being dynamic, it's not possible to add specific iptables rules allowing this traffic - and with restrictive rules this traffic may be blocked. Allow selecting the port - controlled by WEBKIT_INSPECTOR_PORT env