### PR TITLE
Implement mixed content whitelist

### DIFF
--- a/Source/WebCore/loader/MixedContentChecker.h
+++ b/Source/WebCore/loader/MixedContentChecker.h
@@ -33,6 +33,8 @@
 #include <optional>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/KeyValuePair.h>
+#include <wtf/Vector.h>
 
 namespace WebCore {
 
@@ -59,6 +61,14 @@ public:
     static void checkFormForMixedContent(Frame&, SecurityOrigin&, const URL&);
     static bool isMixedContent(SecurityOrigin&, const URL&);
     static std::optional<String> checkForMixedContentInFrameTree(const Frame&, const URL&);
+
+    static void addMixedContentWhitelistEntry(const String& origin, const String& domain);
+    static void removeMixedContentWhitelistEntry(const String& origin, const String& domain);
+    static void resetMixedContentWhitelist();
+
+private:
+    static bool isWhitelisted(const String& origin, const String& domain);
+    static WTF::Vector<WTF::KeyValuePair<WTF::String, WTF::String>> m_whitelist;
 };
 
 } // namespace WebCore

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebExtension.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebExtension.cpp
@@ -280,6 +280,27 @@ void webkit_web_extension_reset_origin_access_whitelists(WebKitWebExtension* ext
     extension->priv->bundle->resetOriginAccessAllowLists();
 }
 
+void webkit_web_extension_add_mixed_content_whitelist_entry(WebKitWebExtension *extension, const gchar* origin, const gchar* domain)
+{
+    g_return_if_fail(WEBKIT_IS_WEB_EXTENSION(extension));
+
+    extension->priv->bundle->addMixedContentWhitelistEntry(String::fromUTF8(origin), String::fromUTF8(domain));
+}
+
+void webkit_web_extension_remove_mixed_content_whitelist_entry(WebKitWebExtension *extension, const gchar* origin, const gchar* domain)
+{
+    g_return_if_fail(WEBKIT_IS_WEB_EXTENSION(extension));
+
+    extension->priv->bundle->removeMixedContentWhitelistEntry(String::fromUTF8(origin), String::fromUTF8(domain));
+}
+
+void webkit_web_extension_reset_mixed_content_whitelist_entry(WebKitWebExtension *extension)
+{
+    g_return_if_fail(WEBKIT_IS_WEB_EXTENSION(extension));
+
+    extension->priv->bundle->resetMixedContentWhitelist();
+}
+
 /**
  * webkit_web_extension_send_message_to_context:
  * @extension: a #WebKitWebExtension

--- a/Source/WebKit/WebProcess/InjectedBundle/API/wpe/WebKitWebExtension.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/wpe/WebKitWebExtension.h
@@ -102,6 +102,19 @@ WEBKIT_API void
 webkit_web_extension_reset_origin_access_whitelists       (WebKitWebExtension   *extension);
 
 WEBKIT_API void
+webkit_web_extension_add_mixed_content_whitelist_entry    (WebKitWebExtension   *extension,
+                                                           const gchar          *origin,
+                                                           const gchar          *domain);
+
+WEBKIT_API void
+webkit_web_extension_remove_mixed_content_whitelist_entry (WebKitWebExtension   *extension,
+                                                           const gchar          *origin,
+                                                           const gchar          *domain);
+
+WEBKIT_API void
+webkit_web_extension_reset_mixed_content_whitelist_entry  (WebKitWebExtension   *extension);
+
+WEBKIT_API void
 webkit_web_extension_send_message_to_context        (WebKitWebExtension *extension,
                                                      WebKitUserMessage  *message,
                                                      GCancellable       *cancellable,

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.cpp
@@ -83,6 +83,8 @@
 #include <wtf/ProcessPrivilege.h>
 #include <wtf/SystemTracing.h>
 
+#include <WebCore/MixedContentChecker.h>
+
 #if ENABLE(NOTIFICATIONS)
 #include "WebNotificationManager.h"
 #endif
@@ -169,6 +171,20 @@ void InjectedBundle::resetOriginAccessAllowLists()
 {
     SecurityPolicy::resetOriginAccessAllowlists();
     WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::ResetOriginAccessAllowLists { }, 0);
+}
+
+void InjectedBundle::addMixedContentWhitelistEntry(const String& origin, const String& domain)
+{
+    MixedContentChecker::addMixedContentWhitelistEntry(origin, domain);
+}
+
+void InjectedBundle::removeMixedContentWhitelistEntry(const String& origin, const String& domain)
+{
+    MixedContentChecker::removeMixedContentWhitelistEntry(origin, domain);
+}
+void InjectedBundle::resetMixedContentWhitelist()
+{
+    MixedContentChecker::resetMixedContentWhitelist();
 }
 
 void InjectedBundle::setAsynchronousSpellCheckingEnabled(bool enabled)

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.h
@@ -99,6 +99,9 @@ public:
     void addOriginAccessAllowListEntry(const String&, const String&, const String&, bool);
     void removeOriginAccessAllowListEntry(const String&, const String&, const String&, bool);
     void resetOriginAccessAllowLists();
+    void addMixedContentWhitelistEntry(const String&, const String&);
+    void removeMixedContentWhitelistEntry(const String&, const String&);
+    void resetMixedContentWhitelist();
     void setAsynchronousSpellCheckingEnabled(bool);
     int numberOfPages(WebFrame*, double, double);
     int pageNumberForElementById(WebFrame*, const String&, double, double);


### PR DESCRIPTION
API is exposed via WebKitWebExtension, similiar to the CORS whitelist.
Wildcards can be used, with '*' replacing any string