### PR TITLE
Hard exit WebProcess with _exit() to skip exit handlers

### DIFF
--- a/Source/WebKit/Shared/AuxiliaryProcess.cpp
+++ b/Source/WebKit/Shared/AuxiliaryProcess.cpp
@@ -62,13 +62,7 @@ AuxiliaryProcess::~AuxiliaryProcess()
 
 void AuxiliaryProcess::didClose(IPC::Connection&)
 {
-// Stop the run loop for GTK and WPE to ensure a normal exit, since we need
-// atexit handlers to be called to cleanup resources like EGL displays.
-#if PLATFORM(GTK) || PLATFORM(WPE)
-    stopRunLoop();
-#else
     _exit(EXIT_SUCCESS);
-#endif
 }
 
 void AuxiliaryProcess::initialize(const AuxiliaryProcessInitializationParameters& parameters)

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -274,17 +274,6 @@ NO_RETURN static void callExit(IPC::Connection*)
 #endif
 }
 
-#if PLATFORM(GTK) || PLATFORM(WPE)
-static void callExitSoon(IPC::Connection*)
-{
-    // If the connection has been closed and we haven't responded in the main thread for 10 seconds the process will exit forcibly.
-    static const auto watchdogDelay = 10_s;
-    WorkQueue::create("WebKit.WebProcess.WatchDogQueue")->dispatchAfter(watchdogDelay, [] {
-        callExit(nullptr);
-    });
-}
-#endif
-
 WebProcess& WebProcess::singleton()
 {
     static WebProcess& process = *new WebProcess;
@@ -382,17 +371,9 @@ void WebProcess::initializeConnection(IPC::Connection* connection)
 {
     AuxiliaryProcess::initializeConnection(connection);
 
-// Do not call exit in background queue for GTK and WPE because we need to ensure
-// atexit handlers are called in the main thread to cleanup resources like EGL displays.
-// Unless the main thread doesn't exit after 10 senconds to avoid leaking the process.
-#if PLATFORM(GTK) || PLATFORM(WPE)
-    IPC::Connection::DidCloseOnConnectionWorkQueueCallback callExitCallback = callExitSoon;
-#else
     // We call _exit() directly from the background queue in case the main thread is unresponsive
     // and AuxiliaryProcess::didClose() does not get called.
-    IPC::Connection::DidCloseOnConnectionWorkQueueCallback callExitCallback = callExit;
-#endif
-    connection->setDidCloseOnConnectionWorkQueueCallback(callExitCallback);
+    connection->setDidCloseOnConnectionWorkQueueCallback(callExit);
 
 #if !PLATFORM(GTK) && !PLATFORM(WPE) && !ENABLE(IPC_TESTING_API)
     connection->setShouldExitOnSyncMessageSendFailure(true);

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -496,7 +496,7 @@ private:
     bool shouldTerminate() override;
     void terminate() override;
 
-#if USE(APPKIT) || PLATFORM(GTK) || PLATFORM(WPE)
+#if USE(APPKIT)
     void stopRunLoop() override;
 #endif
 

--- a/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
+++ b/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
@@ -77,20 +77,6 @@ namespace WebKit {
 
 using namespace WebCore;
 
-void WebProcess::stopRunLoop()
-{
-    // Pages are normally closed after Close message is received from the UI
-    // process, but it can happen that the connection is closed before the
-    // Close message is processed because the UI process close the socket
-    // right after sending the Close message. Close here any pending page to
-    // ensure the threaded compositor is invalidated and GL resources
-    // released (see https://bugs.webkit.org/show_bug.cgi?id=217655).
-    for (auto& webPage : copyToVector(m_pageMap.values()))
-        webPage->close();
-
-    AuxiliaryProcess::stopRunLoop();
-}
-
 void WebProcess::platformSetCacheModel(CacheModel cacheModel)
 {
     WebCore::MemoryCache::singleton().setDisabled(cacheModel == CacheModel::DocumentViewer);


### PR DESCRIPTION
There is a change in 2.38 that makes WebProcess exit cleaner by calling exit handlers (registered with atexit()) instead of using _exit() that skips handlers execution.
Unfortunately this causes a crash inside NicosiaGCGLLayer.cpp:
```
terminateWindowContext()
~GLContextEGL():

    if (m_surface)
        eglDestroySurface(display, m_surface);
```
Surface destruction crashes as WPE compositor and native window are closed because UIProcess exited already.

This revert brings back wpe-2.28 behavior.

But there is another part of this issue. How to make sure that at the point of the UIProcess exit  WebProcess (all child processes basically) are closed so it is safe to close compositor and clean up native parts? Currently we use g_clear_object(view) that destroys WebKitWebView obj but WebProcess seems to be running still
https://github.com/rdkcentral/rdkservices/blob/sprint/23Q3/WebKitBrowser/WebKitImplementation.cpp#L2963

Do you have any suggestion here?