### PR TITLE
Create WebKitFrameWrapper if it doesn't exist

### DIFF
--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPage.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPage.cpp
@@ -195,10 +195,7 @@ private:
 
     void didStartProvisionalLoadForFrame(WebPage&, WebFrame& frame, RefPtr<API::Object>&) override
     {
-        auto* webKitFrame = webkitFrameGet(&frame);
-        if (!webKitFrame && !frame.isMainFrame())
-            return;
-
+        auto* webKitFrame = webkitFrameGetOrCreate(&frame);
         const auto uri = getDocumentLoaderURL(frame.coreFrame()->loader().provisionalDocumentLoader());
 
         if (webKitFrame)


### PR DESCRIPTION
We see that with wpe-2.38 (07fdc0799c), when the browser instance is created a warning message as below is logged

> gboolean webkit_frame_is_main_frame(WebKitFrame*): assertion 'WEBKIT_IS_FRAME(frame)' failed 

On further check it is observed that, post https://github.com/WebKit/WebKit/commit/4a9e02aa3418af0c2117db77f0e7edd70955fa23 commit, it is possible to emit DID_START_PROVISIONAL_LOAD_FOR_FRAME signal with a null "webKitFrame" from https://github.com/WebPlatformForEmbedded/WPEWebKit/blob/wpe-2.38/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPage.cpp#L198 (because at that moment webkitFrameGet() could return nullptr).

Replacing webkitFrameGet() with webkitFrameGetOrCreate() to be in sync with wpe-2.28 and to correctly emit signal with a valid frame.