### PR TITLE
[GStreamer][MSE] Fix playback rates handling for MSE

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -377,6 +377,7 @@ protected:
     mutable std::optional<bool> m_isLiveStream;
     bool m_isPaused { true };
     float m_playbackRate { 1 };
+    bool m_isPlaybackRatePaused { false };
     GstState m_currentState { GST_STATE_NULL };
     GstState m_oldState { GST_STATE_NULL };
     GstState m_requestedState { GST_STATE_VOID_PENDING };
@@ -548,7 +549,6 @@ private:
     GRefPtr<GstElement> m_textSink;
     GUniquePtr<GstStructure> m_mediaLocations;
     int m_mediaLocationCurrentIndex { 0 };
-    bool m_isPlaybackRatePaused { false };
     MediaTime m_timeOfOverlappingSeek;
     // Last playback rate sent through a GStreamer seek.
     float m_lastPlaybackRate { 1 };


### PR DESCRIPTION
Make MSE player gstreamer aware of 0 playback rate (paused). With MSE refactoring MSE player implemented custom ::play() and ::pause methods that were not checking if playback rate allows to play/pause. 1) Bring m_isPlaybackRatePaused setting to MSE player 2) Make updateStates() watch for playback rate paused 3) Don't change pipeline state during ASYNC state change but apply changes
   once transition is completed.
Trying to pause the playback during seek (ASYNC state change PAUSED->PAUSED) is overwritten by PLAYING state (target state from playbin) once transition completes. As a result pipeline is playing while MSE player thinks it's paused. Neither HTMLVideo::pause() nor HTMLVideo::play() works