### PR TITLE
Enable 'immediate-output' on streaming through westerossink

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -2303,6 +2303,17 @@ void MediaPlayerPrivateGStreamer::configureElementPlatformQuirks(GstElement* ele
 #endif
 #endif
 
+#if USE(WESTEROS_SINK)
+    if (!g_strcmp0(G_OBJECT_TYPE_NAME(G_OBJECT(element)), "GstWesterosSink")) {
+#if ENABLE(MEDIA_STREAM)
+        if (m_streamPrivate && gstObjectHasProperty(element, "immediate-output")) {
+            GST_DEBUG_OBJECT(pipeline(), "Enable 'immediate-output' in WesterosSink");
+            g_object_set(G_OBJECT(element), "immediate-output", TRUE, nullptr);
+        }
+#endif
+    }
+#endif
+
 #if ENABLE(MEDIA_STREAM) && PLATFORM(REALTEK)
     if (m_streamPrivate) {
         if (gstObjectHasProperty(element, "media-tunnel")) {


### PR DESCRIPTION
This commit brings back (part of) the change originally made in f9377b1a7478c2b78d5fc64e65614f8ed4edf94d but removed inadvertently by 0035d13e0c9136ac14d8bd779c75f3d3efede365