### PR TITLE
[GStreamer] Also set audio track ID to stream value in regular playback

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/AudioTrackPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/AudioTrackPrivateGStreamer.h
@@ -61,6 +61,8 @@ public:
     AtomString label() const override { return m_label; }
     AtomString language() const override { return m_language; }
 
+    void setId(AtomString id) { m_id = id; }
+
 private:
     AudioTrackPrivateGStreamer(WeakPtr<MediaPlayerPrivateGStreamer>, gint index, GRefPtr<GstPad>, AtomString streamID);
     AudioTrackPrivateGStreamer(WeakPtr<MediaPlayerPrivateGStreamer>, gint index, GRefPtr<GstStream>);

--- a/Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.h
@@ -62,6 +62,8 @@ public:
     AtomString label() const override { return m_label; }
     AtomString language() const override { return m_language; }
 
+    void setId(AtomString id) { m_id = id; }
+
 private:
     VideoTrackPrivateGStreamer(WeakPtr<MediaPlayerPrivateGStreamer>, gint index, GRefPtr<GstPad>);
     VideoTrackPrivateGStreamer(WeakPtr<MediaPlayerPrivateGStreamer>, gint index, GRefPtr<GstStream>);


### PR DESCRIPTION
The proper track IDs are only actually available when the stream-start bus message is received. The tracks are updated at that moment.

An alternative way to achieve the same would be by installing a probe on the audio pads and detecting the stream-start event from there, but calling the track manipulation code from a non-main thread would be unsafe and would require deferring the manipulation to the main thread. Even in that case, there's no guarantee for the stream-start sticky event to be available when the manipulation code runs in the main thread, because that sticky event is stored after probe processing and there's a race.

Relying on the stream-start bus message on the main thread is just simpler than the alternative approach.

Co-authored by Enrique Ocaña González <eocanha@igalia.com>

See: https://github.com/WebPlatformForEmbedded/WPEWebKit/issues/1088
Previous PR: https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1104