### PR TITLE
Implemented Web Inspector Save Function

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Base/BrowserInspectorFrontendHost.js
+++ b/Source/WebInspectorUI/UserInterface/Base/BrowserInspectorFrontendHost.js
@@ -231,13 +231,17 @@ if (!window.InspectorFrontendHost) {
 
         canSave()
         {
-            return false;
+            return true;
         }
 
         save(url, content, base64encoded, forceSaveAs)
-        {
-            // FIXME: Create a Blob from the content, get an object URL, open it to trigger a download.
-            throw "unimplemented";
+        {           
+            var a = document.createElement("a");
+            var text = JSON.stringify(JSON.parse(content));
+            var file = new Blob([text], {type: "application/json" });
+            a.href = URL.createObjectURL(file);
+            a.download = url;
+            a.click();
         }
 
         append(url, content)


### PR DESCRIPTION
Implements the save function in the remote web inspector UI to allow for the exporting of HAR files from the network tab.

Some application developers require this function to be enabled for debugging purposes.

This change will not affect any other functionality of the browser or the Web inspector UI- It only enables a previously disabled feature.