### PR TITLE
Fix return of invalid playback position

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -1351,8 +1351,7 @@ MediaTime MediaPlayerPrivateGStreamer::playbackPosition() const
         m_isWaitingValidPlaybackPosition = false;
     }
     else if (m_canFallBackToLastFinishedSeekPosition) {
-        m_cachedPosition = m_seekTime;
-        m_isWaitingValidPlaybackPosition = true;
+        useSeekTimeAsPlaybackPositionUntilPipelinePositionIsValid();
     }
     else if (!m_cachedPosition) {
         // At playback start, this may have not been set yet
@@ -1366,6 +1365,12 @@ MediaTime MediaPlayerPrivateGStreamer::playbackPosition() const
         invalidateCachedPositionOnNextIteration();
     }
     return m_cachedPosition.value();
+}
+
+void MediaPlayerPrivateGStreamer::useSeekTimeAsPlaybackPositionUntilPipelinePositionIsValid() const
+{
+    m_cachedPosition = m_seekTime;
+    m_isWaitingValidPlaybackPosition = true;
 }
 
 void MediaPlayerPrivateGStreamer::updateEnabledVideoTrack()

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -666,6 +666,8 @@ private:
     // Specific to MediaStream playback.
     MediaTime m_startTime;
     MediaTime m_pausedTime;
+
+    mutable bool m_isWaitingValidPlaybackPosition { false };
 };
 
 }

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -360,6 +360,7 @@ protected:
 
     virtual bool doSeek(const MediaTime& position, float rate, GstSeekFlags);
     void invalidateCachedPosition() const;
+    void useSeekTimeAsPlaybackPositionUntilPipelinePositionIsValid() const;
 
     static void sourceSetupCallback(MediaPlayerPrivateGStreamer*, GstElement*);
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -268,6 +268,7 @@ bool MediaPlayerPrivateGStreamerMSE::doSeek(const MediaTime& position, float rat
         if (!audioSinkPerformsAsyncStateChanges) {
             // If audio-only pipeline's sink is not performing async state changes
             // we must simulate preroll right away as otherwise nothing will trigger it.
+            useSeekTimeAsPlaybackPositionUntilPipelinePositionIsValid();
             didPreroll();
         }
     }


### PR DESCRIPTION
After a seek, the gstreamer pipeline may not be able to return a valid position right away. The m_canFallBackToLastFinishedSeekPosition is reset in an async way when handleMessage() is called, so playbackPosition() might be called while we still not have a valid position from the pipeline.
