### PR TITLE
Linux MemoryPressureMonitor (cgroupV1) honors memory.memsw.usage_in_b…

### DIFF
--- a/Source/WebKit/UIProcess/linux/MemoryPressureMonitor.h
+++ b/Source/WebKit/UIProcess/linux/MemoryPressureMonitor.h
@@ -72,6 +72,7 @@ private:
     CString m_cgroupMemoryControllerPath;
 
     FILE* m_cgroupMemoryMemswLimitInBytesFile;
+    FILE* m_cgroupMemoryMemswUsageInBytesFile;
     FILE* m_cgroupMemoryLimitInBytesFile;
     FILE* m_cgroupMemoryUsageInBytesFile;
 


### PR DESCRIPTION
…ytes if exist

https://bugs.webkit.org/show_bug.cgi?id=257860

Reviewed by Carlos Alberto Lopez Perez.

For systems still using cgroupV1, in case of the WK processes are associated to a cgroup with memory controller, the MemoryPressureMonitor reads the current used memory from the memory.memsw.usage_in_bytes. It fallback to the memory.usage_in_bytesin case the first choice is not available.

* Source/WebKit/UIProcess/linux/MemoryPressureMonitor.cpp: (WebKit::CGroupMemoryController::setMemoryControllerPath): (WebKit::CGroupMemoryController::disposeMemoryController): (WebKit::CGroupMemoryController::getMemoryUsageWithCgroup):

Canonical link: https://commits.webkit.org/265527@main

