### PR TITLE
[wpe-2.38] Allow finishing seek on sync state change

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -377,6 +377,7 @@ protected:
     mutable std::optional<bool> m_isLiveStream;
     bool m_isPaused { true };
     float m_playbackRate { 1 };
+    bool m_isPlaybackRatePaused { false };
     GstState m_currentState { GST_STATE_NULL };
     GstState m_oldState { GST_STATE_NULL };
     GstState m_requestedState { GST_STATE_VOID_PENDING };
@@ -548,7 +549,6 @@ private:
     GRefPtr<GstElement> m_textSink;
     GUniquePtr<GstStructure> m_mediaLocations;
     int m_mediaLocationCurrentIndex { 0 };
-    bool m_isPlaybackRatePaused { false };
     MediaTime m_timeOfOverlappingSeek;
     // Last playback rate sent through a GStreamer seek.
     float m_lastPlaybackRate { 1 };

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -304,8 +304,8 @@ void MediaPlayerPrivateGStreamerMSE::propagateReadyStateToPlayer()
     GST_DEBUG("Propagating MediaSource readyState %s to player ready state (currently %s)", dumpReadyState(m_mediaSourceReadyState), dumpReadyState(m_readyState));
 
     m_readyState = m_mediaSourceReadyState;
-    updateStates(); // Set the pipeline to PLAYING or PAUSED if necessary.
     m_player->readyStateChanged();
+    updateStates(); // Set the pipeline to PLAYING or PAUSED if necessary.
 
     // The readyState change may be a result of monitorSourceBuffers() finding that currentTime == duration, which
     // should cause the video to be marked as ended. Let's have the player check that.
@@ -386,6 +386,10 @@ void MediaPlayerPrivateGStreamerMSE::updateStates()
     if (getStateResult == GST_STATE_CHANGE_SUCCESS && state >= GST_STATE_PAUSED) {
         // Update playback rate that was set before the pipeline was prerolled.
         updatePlaybackRate();
+        if (m_isSeeking && m_isWaitingForPreroll) {
+            // simulating "async" state change in case it's not supported by the pipeline
+            asyncStateChangeDone();
+        }
     }
 }
 


### PR DESCRIPTION
On some STBs audio-only pipelines don't support ASYNC state changes.

This PR is built on top of https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1132 and therefore we should wait until it gets merged before merging this one.