### PR TITLE
[wpe-2.28] Expose API for sending memory pressure events

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -4619,6 +4619,13 @@ void webkit_web_view_show(WebKitWebView *webView)
     webView->priv->view->setViewState(viewStateFlags);
 }
 
+void webkit_web_view_send_memory_pressure_event(WebKitWebView *webView, gboolean critical)
+{
+    g_return_if_fail(WEBKIT_IS_WEB_VIEW(webView));
+
+    getPage(webView).sendMemoryPressureEvent(critical);
+}
+
 void webkitWebViewSetIsWebProcessResponsive(WebKitWebView* webView, bool isResponsive)
 {
     if (webView->priv->isWebProcessResponsive == isResponsive)

--- a/Source/WebKit/UIProcess/API/wpe/WebKitWebView.h
+++ b/Source/WebKit/UIProcess/API/wpe/WebKitWebView.h
@@ -571,6 +571,10 @@ webkit_web_view_hide                                 (WebKitWebView             
 WEBKIT_API void
 webkit_web_view_show                                 (WebKitWebView               *web_view);
 
+WEBKIT_API void
+webkit_web_view_send_memory_pressure_event           (WebKitWebView               *web_view,
+                                                      gboolean                    critical);
+
 WEBKIT_API gboolean
 webkit_web_view_get_is_web_process_responsive        (WebKitWebView             *web_view);
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -2670,6 +2670,12 @@ const NativeWebKeyboardEvent& WebPageProxy::firstQueuedKeyEvent() const
     return m_keyEventQueue.first();
 }
 
+void WebPageProxy::sendMemoryPressureEvent(bool critical) const
+{
+    for (auto* processPool : WebProcessPool::allProcessPools())
+        processPool->sendMemoryPressureEvent(critical);
+}
+
 void WebPageProxy::handleKeyboardEvent(const NativeWebKeyboardEvent& event)
 {
     if (!hasRunningProcess())

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1689,6 +1689,8 @@ public:
     void revokeAccessToAssetServices();
 #endif
 
+    void sendMemoryPressureEvent(bool critical) const;
+
 private:
     WebPageProxy(PageClient&, WebProcessProxy&, Ref<API::PageConfiguration>&&);
     void platformInitialize();


### PR DESCRIPTION
This PR brings a simple API that enables browsers to save some memory by sending pressure events.
It may be useful in cases when browser is hidden/suspended (background state).