### PR TITLE
Fix incorrect (skipping flush) handling of out-of-order sample.

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -348,7 +348,7 @@ void MediaPlayerPrivateGStreamerMSE::sourceSetup(GstElement* sourceElement)
     GST_DEBUG_OBJECT(pipeline(), "Source %p setup (old was: %p)", sourceElement, m_source.get());
     m_source = sourceElement;
 
-    if (m_hasAllTracks)
+    if (hasAllTracks())
         webKitMediaSrcEmitStreams(WEBKIT_MEDIA_SRC(m_source.get()), m_tracks);
 }
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
@@ -81,7 +81,7 @@ public:
 
     void asyncStateChangeDone() override;
 
-    bool hasAllTracks() const { return m_hasAllTracks; }
+    bool hasAllTracks() const { return m_mediaSourcePrivate ? m_mediaSourcePrivate->hasAllTracks() : false; }
     void startSource(const Vector<RefPtr<MediaSourceTrackGStreamer>>& tracks);
     WebKitMediaSrc* webKitMediaSrc() { return reinterpret_cast<WebKitMediaSrc*>(m_source.get()); }
 
@@ -111,7 +111,6 @@ private:
     RefPtr<MediaSourcePrivateGStreamer> m_mediaSourcePrivate;
     MediaTime m_mediaTimeDuration { MediaTime::invalidTime() };
     bool m_isPipelinePlaying = true;
-    bool m_hasAllTracks = false;
     Vector<RefPtr<MediaSourceTrackGStreamer>> m_tracks;
 
     bool m_isWaitingForPreroll = true;

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp
@@ -84,7 +84,7 @@ MediaSourcePrivateGStreamer::AddStatus MediaSourcePrivateGStreamer::addSourceBuf
     DEBUG_LOG(LOGIDENTIFIER, contentType);
 
     // Once every SourceBuffer has had an initialization segment appended playback starts and it's too late to add new SourceBuffers.
-    if (m_playerPrivate.hasAllTracks())
+    if (hasAllTracks())
         return MediaSourcePrivateGStreamer::AddStatus::ReachedIdLimit;
 
     if (!SourceBufferPrivateGStreamer::isContentTypeSupported(contentType))

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h
@@ -75,6 +75,7 @@ public:
 
     void sourceBufferPrivateDidChangeActiveState(SourceBufferPrivateGStreamer*, bool);
     void startPlaybackIfHasAllTracks();
+    bool hasAllTracks() const { return m_hasAllTracks; }
 
     std::unique_ptr<PlatformTimeRanges> buffered();
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
@@ -142,6 +142,8 @@ void SourceBufferPrivateGStreamer::flush(const AtomString& trackId)
     ASSERT(isMainThread());
 
     // This is only for on-the-fly reenqueues after appends. When seeking, the seek will do its own flush.
+    if(m_playerPrivate.seeking())
+        return;
 
     if (!m_playerPrivate.hasAllTracks()) {
         GST_DEBUG_OBJECT(m_playerPrivate.pipeline(), "Source element has not emitted tracks yet, so we only need to clear the queue. trackId = '%s'", trackId.string().utf8().data());

--- a/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
@@ -625,7 +625,7 @@ static void webKitMediaSrcStreamFlush(Stream* stream, bool isSeekingFlush)
         DataMutexLocker streamingMembers { stream->streamingMembersDataMutex };
         streamingMembers->segment.base = 0;
         streamingMembers->segment.rate = priv->rate;
-        streamingMembers->segment.start = streamingMembers->segment.time = priv->startTime;
+        streamingMembers->segment.position = streamingMembers->segment.start = streamingMembers->segment.time = priv->startTime;
     } else {
         // In the case of non-seeking flushes we don't reset the timeline, so instead we need to increase the `base` field
         // by however running time we're starting after the flush.
@@ -645,7 +645,7 @@ static void webKitMediaSrcStreamFlush(Stream* stream, bool isSeekingFlush)
                 GST_TIME_ARGS(pipelineRunningTime), GST_TIME_ARGS(pipelineStreamTime));
             streamingMembers->segment.base = pipelineRunningTime;
 
-            streamingMembers->segment.start = streamingMembers->segment.time = static_cast<GstClockTime>(pipelineStreamTime);
+            streamingMembers->segment.position = streamingMembers->segment.start = streamingMembers->segment.time = static_cast<GstClockTime>(pipelineStreamTime);
         }
     }
 


### PR DESCRIPTION
When an out-of-order sample arrives SourceBuffer removes part of samples from Track and initiates reenqueue. During this re-enqueing, SourceBufferPrivateGStreamer::flush() checks if player has all the tracks.

This flag _**MediaPlayerPrivateGStreamerMSE::m_hasAllTracks**_ returns an incorrect value (false) as
MediaPlayerPrivateGStreamerMSE never updates this flag. Because of this pipeline flush is skipped causing some portion of the video to be played again.