### PR TITLE
WebInspectorUI: Fix console warning/error icon for Chromium browser

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/ButtonNavigationItem.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ButtonNavigationItem.css
@@ -91,11 +91,6 @@
     color: var(--glyph-color-disabled);
 }
 
-.navigation-bar .item.button > img {
-    width: 100%;
-    height: 100%;
-}
-
 .navigation-bar .item.button.disabled > img {
     opacity: 0.3;
 }

--- a/Source/WebInspectorUI/UserInterface/Views/ButtonNavigationItem.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ButtonNavigationItem.js
@@ -226,6 +226,8 @@ WI.ButtonNavigationItem = class ButtonNavigationItem extends WI.NavigationItem
 
             case WI.ButtonNavigationItem.ImageType.IMG: {
                 let img = this.element.appendChild(document.createElement("img"));
+                img.style.width = this._imageWidth + "px";
+                img.style.height = this._imageHeight + "px";
                 img.src = this._image;
                 break;
             }


### PR DESCRIPTION
With Chromium browser both icons are displayed 300x300px while expected size is 16x16. This brakes the rest of top navigation bar

Directly set image size from JS in the same way as it is done for SVG glyphs

# Pull Request Template

## File a Bug

All changes should be associated with a bug. The WebKit project is currently using [Bugzilla](https://bugs.webkit.org) as our bug tracker. Note that multiple changes may be associated with a single bug.

## Provided Tooling

The WebKit Project strongly recommends contributors use [`Tools/Scripts/git-webkit`](https://github.com/WebKit/WebKit/tree/main/Tools/Scripts/git-webkit) to generate pull requests. See [Setup](https://github.com/WebKit/WebKit/wiki/Contributing#setup) and [Contributing Code](https://github.com/WebKit/WebKit/wiki/Contributing#contributing-code) for how to do this.

## Template

If a contributor wishes to file a pull request manually, the template is below. Manually-filed pull requests should contain their commit message as the pull request description, and their commit message should be formatted like the template below.

Additionally, the pull request should be mentioned on [Bugzilla](https://bugs.webkit.org), labels applied to the pull request matching the component and version of the [Bugzilla](https://bugs.webkit.org) associated with the pull request and the pull request assigned to its author.

<pre>
< bug title >
<a href="https://bugs.webkit.org/enter_bug.cgi">https://bugs.webkit.org/show_bug.cgi?id=#####</a>

Reviewed by NOBODY (OOPS!).

* path/changed.ext:
(function):
(class.function):

</pre>
