### PR TITLE
[wpe-2.38] Expose API for sending memory pressure events

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -5071,6 +5071,13 @@ WebKitWebsitePolicies* webkit_web_view_get_website_policies(WebKitWebView* webVi
     return webView->priv->websitePolicies.get();
 }
 
+void webkit_web_view_send_memory_pressure_event(WebKitWebView *webView, gboolean critical)
+{
+    g_return_if_fail(WEBKIT_IS_WEB_VIEW(webView));
+
+    getPage(webView).sendMemoryPressureEvent(critical);
+}
+
 void webkitWebViewSetIsWebProcessResponsive(WebKitWebView* webView, bool isResponsive)
 {
     if (webView->priv->isWebProcessResponsive == isResponsive)

--- a/Source/WebKit/UIProcess/API/wpe/WebKitWebView.h
+++ b/Source/WebKit/UIProcess/API/wpe/WebKitWebView.h
@@ -558,6 +558,10 @@ webkit_web_view_get_tls_info                         (WebKitWebView             
 WEBKIT_API WebKitUserContentManager *
 webkit_web_view_get_user_content_manager             (WebKitWebView             *web_view);
 
+WEBKIT_API void
+webkit_web_view_send_memory_pressure_event           (WebKitWebView               *web_view,
+                                                      gboolean                    critical);
+
 WEBKIT_API gboolean
 webkit_web_view_is_editable                          (WebKitWebView             *web_view);
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -3098,6 +3098,12 @@ const NativeWebKeyboardEvent& WebPageProxy::firstQueuedKeyEvent() const
     return m_keyEventQueue.first();
 }
 
+void WebPageProxy::sendMemoryPressureEvent(bool critical) const
+{
+    for (auto& processPool : WebProcessPool::allProcessPools())
+        processPool->sendMemoryPressureEvent(critical);
+}
+
 bool WebPageProxy::handleKeyboardEvent(const NativeWebKeyboardEvent& event)
 {
     if (!hasRunningProcess())

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2140,6 +2140,8 @@ public:
     void clearNotificationPermissionState();
 #endif
 
+    void sendMemoryPressureEvent(bool critical) const;
+
 private:
     WebPageProxy(PageClient&, WebProcessProxy&, Ref<API::PageConfiguration>&&);
     void platformInitialize();


### PR DESCRIPTION
Cherry pick of https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1155/commits/f3561aff72cf5cc571dfea01e077c5b2b55e2af0 from https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1155 with slight modification to account for `WebProcessPool::allProcessPools()` return type change.