### PR TITLE
Disable caching of XHR ArrayBuffer and/or env variable

### DIFF
--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -628,6 +628,12 @@ ExceptionOr<void> XMLHttpRequest::createRequest()
     options.filteringPolicy = ResponseFilteringPolicy::Enable;
     options.contentEncodingSniffingPolicy = ContentEncodingSniffingPolicy::Disable;
 
+    if (responseType() == ResponseType::Arraybuffer || getenv("WPE_DISABLE_XHR_RESPONSE_CACHING")) {
+        options.dataBufferingPolicy = DataBufferingPolicy::DoNotBufferData;
+        options.cachingPolicy = CachingPolicy::DisallowCaching;
+        request.setCachePolicy(ResourceRequestCachePolicy::DoNotUseAnyCache);
+    }
+
     if (m_timeoutMilliseconds) {
         if (!m_async)
             request.setTimeoutInterval(m_timeoutMilliseconds / 1000.0);


### PR DESCRIPTION
- Disable caching of ArrayBuffer XHR.
- Setting the environment variable WPE_DISABLE_XHR_RESPONSE_CACHING disables the memory cache for xhr responses. This is useful to reduce the memory footprint when the responses are quite big and cannot be reused.
