### PR TITLE
Build fix after 160450@main by guarding showRenderTree

### DIFF
--- a/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
@@ -273,7 +273,7 @@ void LocalFrameViewLayoutContext::performLayout()
 #endif
         clearSubtreeLayoutRoot();
 
-#if !LOG_DISABLED
+#if !LOG_DISABLED && ENABLE(TREE_DEBUGGING)
         auto layoutLogEnabled = [] {
             return LogLayout.state == WTFLogChannelState::On;
         };


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=260702

Unreviewed build fix.

Where LOG_DISABLED is disabled, the build fails due to missing showRenderTree(). The showRenderTree() is guarded by ENABLE(TREE_DEBUGGING).

* Source/WebCore/page/LocalFrameViewLayoutContext.cpp: (WebCore::LocalFrameViewLayoutContext::performLayout):

Canonical link: https://commits.webkit.org/267268@main
