### PR TITLE
Remove samples (including any immediate  next sync sample) if out-of-order sample is received

### DIFF
--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -1818,9 +1818,6 @@ void SourceBuffer::sourceBufferPrivateDidReceiveSample(MediaSample& sample)
             if (nextSampleInDecodeOrder == trackBuffer.samples.decodeOrder().end())
                 break;
 
-            if (nextSampleInDecodeOrder->second->isSync())
-                break;
-
             auto nextSyncSample = trackBuffer.samples.decodeOrder().findSyncSampleAfterDecodeIterator(nextSampleInDecodeOrder);
             INFO_LOG(LOGIDENTIFIER, "Discovered out-of-order frames, from: ", *nextSampleInDecodeOrder->second, " to: ", (nextSyncSample == trackBuffer.samples.decodeOrder().end() ? "[end]"_s : toString(*nextSyncSample->second)));
             erasedSamples.addRange(nextSampleInDecodeOrder, nextSyncSample);


### PR DESCRIPTION
**Problem:**
Macro blocks were observed in Paramount+ asset (Detroiters) after the display of Comedy Central Logo (~ 6 seconds through the playback). This was observed on Broadcom based Comcast STBs.

**WebKit version** : wpe-2.28 (de0da7581e2d)

**Sequence of operations:**
* App appends ~ 6 seconds of data corresponding to Logo
* Sets SourceBuffer timestampOffset (to 6.089)
* Appends data corresponding to the actual asset (First samples PTS starts with 0.08341 and the sample has Edit List)
* PTS & DTS of all the new samples are offset based on Edit List & timestampOffset.
* This results in first sample's DTS fall inbetween last few samples for Logo (out-of-order sample)
* In SourceBuffer::sourceBufferPrivateDidReceiveSample, when this sample is encountered, we check if the next sample is a sync sample, if so we skip removing (in turn replacing) any samples

```
L1 : 2023 Sep 13 11:07:18.271861 xre-webkit-logging[23738]:  [WPEWebKit:MediaSource:-] SourceBuffer::sourceBufferPrivateDidReceiveSample(3F410002-V1) 1{"pts":{"value":5.922588,"numerator":5922588,"denominator":1000000,"flags":1},"dts":{"value":5.922588,"numerator":5922588,"denominator":1000000,"flags":1},"duration":{"value":0.0417,"numerator":41700,"denominator":1000000,"flags":1},"flags":0,"presentationSize":{"width":640,"height":360}}
L2 : 2023 Sep 13 11:07:18.272029 xre-webkit-logging[23738]:  [WPEWebKit:MediaSource:-] SourceBuffer::sourceBufferPrivateDidReceiveSample(3F410002-V1) 1{"pts":{"value":5.964288,"numerator":5964288,"denominator":1000000,"flags":1},"dts":{"value":5.964288,"numerator":5964288,"denominator":1000000,"flags":1},"duration":{"value":0.041711,"numerator":41711,"denominator":1000000,"flags":1},"flags":0,"presentationSize":{"width":640,"height":360}}
L3 : 2023 Sep 13 11:07:18.272181 xre-webkit-logging[23738]:  [WPEWebKit:MediaSource:-] SourceBuffer::sourceBufferPrivateDidReceiveSample(3F410002-V1) 1{"pts":{"value":6.006,"numerator":6006000,"denominator":1000000,"flags":1},"dts":{"value":6.006,"numerator":6006000,"denominator":1000000,"flags":1},"duration":{"value":0.041711,"numerator":41711,"denominator":1000000,"flags":1},"flags":1,"presentationSize":{"width":640,"height":360}}
L4 : 2023 Sep 13 11:07:18.272368 xre-webkit-logging[23738]:  [WPEWebKit:MediaSource:-] SourceBuffer::sourceBufferPrivateDidReceiveSample(3F410002-V1) 1{"pts":{"value":6.047711,"numerator":6047711,"denominator":1000000,"flags":1},"dts":{"value":6.047711,"numerator":6047711,"denominator":1000000,"flags":1},"duration":{"value":0.041711,"numerator":41711,"denominator":1000000,"flags":1},"flags":0,"presentationSize":{"width":640,"height":360}}

     2023 Sep 13 11:07:18.293974 xre-webkit-logging[23738]:  VIVEK-DBG [23752,23752]: SourceBuffer::setTimestampOffset (0x93ae10a0), offset=6.089000, newOffset={6.089000}

     2023 Sep 13 11:07:20.467729 xre-webkit-logging[23738]:  0:00:54.105152149 23752 0xadc038a0 TRACE              webkitmse AppendPipeline.cpp:552:appsinkNewSample:<appsink1> Mapped buffer to segment, PTS 0:00:00.083416666 -> {0/1000000000 = 0} DTS 0:00:00.000000000 -> {-83416666/1000000000 = -0.083416666}
     2023 Sep 13 11:07:20.468027 xre-webkit-logging[23738]:  VIVEK-DBG [23752,23752]: SourceBuffer::sourceBufferPrivateDidReceiveSample (0x93ae10a0), m_timeStampOffset={6.089000}, roundedOffset={6089000000/1000000000 = 6.089000}, mode=0
     2023 Sep 13 11:07:20.468152 xre-webkit-logging[23738]:  VIVEK-DBG [23752,23752]: SourceBuffer::sourceBufferPrivateDidReceiveSample (0x93ae10a0), lastDecodeTimeStamp={6047711/1000000 = 6.047711}, decodeTimeStammp={6005583334/1000000000 = 6.005583}
A1 : 2023 Sep 13 11:07:20.468382 xre-webkit-logging[23738]:  [WPEWebKit:MediaSource:-] SourceBuffer::sourceBufferPrivateDidReceiveSample(3F410002-V1) 1{"pts":{"value":6.089,"numerator":6089000000,"denominator":1000000000,"flags":1},"dts":{"value":6.005583334,"numerator":6005583334,"denominator":1000000000,"flags":1},"duration":{"value":0.041708,"numerator":41708,"denominator":1000000,"flags":1},"flags":1,"presentationSize":{"width":960,"height":540}}
     2023 Sep 13 11:07:20.468831 xre-webkit-logging[23738]:  0:00:54.105543093 23752 0xadc038a0 TRACE              webkitmse AppendPipeline.cpp:552:appsinkNewSample:<appsink1> Mapped buffer to segment, PTS 0:00:00.250250000 -> {166833334/1000000000 = 0.166833334} DTS 0:00:00.041708333 -> {-41708333/1000000000 = -0.041708333}
A2 : 2023 Sep 13 11:07:20.469182 xre-webkit-logging[23738]:  [WPEWebKit:MediaSource:-] SourceBuffer::sourceBufferPrivateDidReceiveSample(3F410002-V1) 1{"pts":{"value":6.255833334,"numerator":6255833334,"denominator":1000000000,"flags":1},"dts":{"value":6.047291667,"numerator":6047291667,"denominator":1000000000,"flags":1},"duration":{"value":0.041708,"numerator":41708,"denominator":1000000,"flags":1},"flags":0,"presentationSize":{"width":960,"height":540}}
     2023 Sep 13 11:07:20.469384 xre-webkit-logging[23738]:  0:00:54.105783993 23752 0xadc038a0 TRACE              webkitmse AppendPipeline.cpp:552:appsinkNewSample:<appsink1> Mapped buffer to segment, PTS 0:00:00.166833333 -> {83416667/1000000000 = 0.083416667} DTS 0:00:00.083416666 -> {0/1000000000 = 0}
A3 : 2023 Sep 13 11:07:20.469769 xre-webkit-logging[23738]:  [WPEWebKit:MediaSource:-] SourceBuffer::sourceBufferPrivateDidReceiveSample(3F410002-V1) 1{"pts":{"value":6.172416667,"numerator":6172416667,"denominator":1000000000,"flags":1},"dts":{"value":6.089,"numerator":6089000000,"denominator":1000000000,"flags":1},"duration":{"value":0.041708,"numerator":41708,"denominator":1000000,"flags":1},"flags":0,"presentationSize":{"width":960,"height":540}}
     2023 Sep 13 11:07:20.470166 xre-webkit-logging[23738]:  0:00:54.106008484 23752 0xadc038a0 TRACE              webkitmse AppendPipeline.cpp:552:appsinkNewSample:<appsink1> Mapped buffer to segment, PTS 0:00:00.125125000 -> {41708334/1000000000 = 0.041708334} DTS 0:00:00.125125000 -> {41708334/1000000000 = 0.041708334}
A4 : 2023 Sep 13 11:07:20.470572 xre-webkit-logging[23738]:  [WPEWebKit:MediaSource:-] SourceBuffer::sourceBufferPrivateDidReceiveSample(3F410002-V1) 1{"pts":{"value":6.130708334,"numerator":6130708334,"denominator":1000000000,"flags":1},"dts":{"value":6.130708334,"numerator":6130708334,"denominator":1000000000,"flags":1},"duration":{"value":0.041708,"numerator":41708,"denominator":1000000,"flags":1},"flags":0,"presentationSize":{"width":960,"height":540}}
     2023 Sep 13 11:07:20.470894 xre-webkit-logging[23738]:  0:00:54.106382761 23752 0xadc038a0 TRACE              webkitmse AppendPipeline.cpp:552:appsinkNewSample:<appsink1> Mapped buffer to segment, PTS 0:00:00.208541666 -> {125125000/1000000000 = 0.125125} DTS 0:00:00.166833333 -> {83416667/1000000000 = 0.083416667}
A5 : 2023 Sep 13 11:07:20.471273 xre-webkit-logging[23738]:  [WPEWebKit:MediaSource:-] SourceBuffer::sourceBufferPrivateDidReceiveSample(3F410002-V1) 1{"pts":{"value":6.214125,"numerator":6214125000,"denominator":1000000000,"flags":1},"dts":{"value":6.172416667,"numerator":6172416667,"denominator":1000000000,"flags":1},"duration":{"value":0.041708,"numerator":41708,"denominator":1000000,"flags":1},"flags":0,"presentationSize":{"width":960,"height":540}}

Samples in decoding order
L1 : 2023 Sep 13 11:07:18.271861 xre-webkit-logging[23738]:  [WPEWebKit:MediaSource:-] SourceBuffer::sourceBufferPrivateDidReceiveSample(3F410002-V1) 1{"pts":{"value":5.922588,"numerator":5922588,"denominator":1000000,"flags":1},           "dts":{"value":5.922588,"numerator":5922588,"denominator":1000000,"flags":1},"duration":{"value":0.0417,"numerator":41700,"denominator":1000000,"flags":1},"flags":0,"presentationSize":{"width":640,"height":360}}
L2 : 2023 Sep 13 11:07:18.272029 xre-webkit-logging[23738]:  [WPEWebKit:MediaSource:-] SourceBuffer::sourceBufferPrivateDidReceiveSample(3F410002-V1) 1{"pts":{"value":5.964288,"numerator":5964288,"denominator":1000000,"flags":1},           "dts":{"value":5.964288,"numerator":5964288,"denominator":1000000,"flags":1},"duration":{"value":0.041711,"numerator":41711,"denominator":1000000,"flags":1},"flags":0,"presentationSize":{"width":640,"height":360}}
A1 : 2023 Sep 13 11:07:20.468382 xre-webkit-logging[23738]:  [WPEWebKit:MediaSource:-] SourceBuffer::sourceBufferPrivateDidReceiveSample(3F410002-V1) 1{"pts":{"value":6.089,"numerator":6089000000,"denominator":1000000000,"flags":1},        "dts":{"value":6.005583334,"numerator":6005583334,"denominator":1000000000,"flags":1},"duration":{"value":0.041708,"numerator":41708,"denominator":1000000,"flags":1},"flags":1,"presentationSize":{"width":960,"height":540}}
L3 : 2023 Sep 13 11:07:18.272181 xre-webkit-logging[23738]:  [WPEWebKit:MediaSource:-] SourceBuffer::sourceBufferPrivateDidReceiveSample(3F410002-V1) 1{"pts":{"value":6.006,"numerator":6006000,"denominator":1000000,"flags":1},              "dts":{"value":6.006,"numerator":6006000,"denominator":1000000,"flags":1},"duration":{"value":0.041711,"numerator":41711,"denominator":1000000,"flags":1},"flags":1,"presentationSize":{"width":640,"height":360}}
A2 : 2023 Sep 13 11:07:20.469182 xre-webkit-logging[23738]:  [WPEWebKit:MediaSource:-] SourceBuffer::sourceBufferPrivateDidReceiveSample(3F410002-V1) 1{"pts":{"value":6.255833334,"numerator":6255833334,"denominator":1000000000,"flags":1},  "dts":{"value":6.047291667,"numerator":6047291667,"denominator":1000000000,"flags":1},"duration":{"value":0.041708,"numerator":41708,"denominator":1000000,"flags":1},"flags":0,"presentationSize":{"width":960,"height":540}}
L4 : 2023 Sep 13 11:07:18.272368 xre-webkit-logging[23738]:  [WPEWebKit:MediaSource:-] SourceBuffer::sourceBufferPrivateDidReceiveSample(3F410002-V1) 1{"pts":{"value":6.047711,"numerator":6047711,"denominator":1000000,"flags":1},           "dts":{"value":6.047711,"numerator":6047711,"denominator":1000000,"flags":1},"duration":{"value":0.041711,"numerator":41711,"denominator":1000000,"flags":1},"flags":0,"presentationSize":{"width":640,"height":360
A3 : 2023 Sep 13 11:07:20.469769 xre-webkit-logging[23738]:  [WPEWebKit:MediaSource:-] SourceBuffer::sourceBufferPrivateDidReceiveSample(3F410002-V1) 1{"pts":{"value":6.172416667,"numerator":6172416667,"denominator":1000000000,"flags":1},  "dts":{"value":6.089,"numerator":6089000000,"denominator":1000000000,"flags":1},"duration":{"value":0.041708,"numerator":41708,"denominator":1000000,"flags":1},"flags":0,"presentationSize":{"width":960,"height":540}}
A4 : 2023 Sep 13 11:07:20.470572 xre-webkit-logging[23738]:  [WPEWebKit:MediaSource:-] SourceBuffer::sourceBufferPrivateDidReceiveSample(3F410002-V1) 1{"pts":{"value":6.130708334,"numerator":6130708334,"denominator":1000000000,"flags":1},  "dts":{"value":6.130708334,"numerator":6130708334,"denominator":1000000000,"flags":1},"duration":{"value":0.041708,"numerator":41708,"denominator":1000000,"flags":1},"flags":0,"presentationSize":{"width":960,"height":540}}
A5 : 2023 Sep 13 11:07:20.471273 xre-webkit-logging[23738]:  [WPEWebKit:MediaSource:-] SourceBuffer::sourceBufferPrivateDidReceiveSample(3F410002-V1) 1{"pts":{"value":6.214125,"numerator":6214125000,"denominator":1000000000,"flags":1},     "dts":{"value":6.172416667,"numerator":6172416667,"denominator":1000000000,"flags":1},"duration":{"value":0.041708,"numerator":41708,"denominator":1000000,"flags":1},"flags":0,"presentationSize":{"width":960,"height":540}}

2023 Sep 13 11:07:20.943155 xre-webkit-logging[23738]:  [WPEWebKit:MediaSource:-] SourceBuffer::seekToTime(3F410002-V1) {"value":6.834644443999999}

Samples are enqueued in decoding order (samples from Logo & Asset are mixed here). Note the dimension & the I-Frame are also collapsed
2023 Sep 13 11:07:20.943306 xre-webkit-logging[23738]:  0:00:54.582244802 23752 0xadc038a0 TRACE              webkitmse PlaybackPipeline.cpp:450:enqueueSample: enqueing sample trackId=V1 PTS={6006000/1000000 = 6.006} presentationSize=640x360 at 0:00:06.006000000 duration: 0:00:00.041711000
2023 Sep 13 11:07:20.943460 xre-webkit-logging[23738]:  0:00:54.582366993 23752 0xadc038a0 TRACE              webkitmse PlaybackPipeline.cpp:450:enqueueSample: enqueing sample trackId=V1 PTS={6255833/1000000 = 6.255833} presentationSize=960x540 at 0:00:06.255833000 duration: 0:00:00.041708000
2023 Sep 13 11:07:20.943533 xre-webkit-logging[23738]:  0:00:54.582446033 23752 0xadc038a0 TRACE              webkitmse PlaybackPipeline.cpp:450:enqueueSample: enqueing sample trackId=V1 PTS={6047711/1000000 = 6.047711} presentationSize=640x360 at 0:00:06.047711000 duration: 0:00:00.041711000
2023 Sep 13 11:07:20.943736 xre-webkit-logging[23738]:  0:00:54.582512592 23752 0xadc038a0 TRACE              webkitmse PlaybackPipeline.cpp:450:enqueueSample: enqueing sample trackId=V1 PTS={6172416/1000000 = 6.172416} presentationSize=960x540 at 0:00:06.172416000 duration: 0:00:00.041708000
2023 Sep 13 11:07:20.943920 xre-webkit-logging[23738]:  0:00:54.582583706 23752 0xadc038a0 TRACE              webkitmse PlaybackPipeline.cpp:450:enqueueSample: enqueing sample trackId=V1 PTS={6130708/1000000 = 6.130708} presentationSize=960x540 at 0:00:06.130708000 duration: 0:00:00.041708000
```