### PR TITLE
Tune memory pressure settings for rapid mem usage changes

### DIFF
--- a/Source/WebKit/UIProcess/linux/MemoryPressureMonitor.cpp
+++ b/Source/WebKit/UIProcess/linux/MemoryPressureMonitor.cpp
@@ -48,8 +48,13 @@ static const Seconds s_minPollingInterval { 1_s };
 static const Seconds s_maxPollingInterval { 5_s };
 static const double s_minUsedMemoryPercentageForPolling = 50;
 static const double s_maxUsedMemoryPercentageForPolling = 85;
+#if PLATFORM(WPE)
+static const int s_memoryPresurePercentageThreshold = 80;
+static const int s_memoryPresurePercentageThresholdCritical = 85;
+#else
 static const int s_memoryPresurePercentageThreshold = 90;
 static const int s_memoryPresurePercentageThresholdCritical = 95;
+#endif
 // cgroups.7: The usual place for such mounts is under a tmpfs(5)
 // filesystem mounted at /sys/fs/cgroup.
 static const char* s_cgroupMemoryPath = "/sys/fs/cgroup/%s/%s/%s";


### PR DESCRIPTION
When playing an asset with video, frequent seek/jump operations within a short period may cause rapid memory increases. The current pressure settings may not allow (enough) memory release in time to avoid an app running in a container to be killed due it reaching the memory limits. To allow sufficient, in time, memory release, the release needs to happen with the "synchrounous" flag set to true, allowing full garbage collection cycle when reaching critical limits.

Furthermore, the critical threshold needs to be lowered as well considering that the release is not instantaneous and on embedded devices the 95% original threshold does not allow enough room for mem release on apps with lower allowed memory usage limits.

Two changes in MemoryRelease.cpp from wpe-2.28 related with garbage collection where included as well