### PR TITLE
Adapt speech synthesis changes from 2.28

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -544,6 +544,16 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/reporting/TestReportBody.h
     Modules/reporting/ViolationReportType.h
 
+    Modules/speech/LocalDOMWindowSpeechSynthesis.h
+    Modules/speech/SpeechSynthesisErrorCode.h
+    Modules/speech/SpeechSynthesisErrorEvent.h
+    Modules/speech/SpeechSynthesisErrorEventInit.h
+    Modules/speech/SpeechSynthesisEvent.h
+    Modules/speech/SpeechSynthesisEventInit.h
+    Modules/speech/SpeechSynthesis.h
+    Modules/speech/SpeechSynthesisUtterance.h
+    Modules/speech/SpeechSynthesisVoice.h
+
     Modules/speech/SpeechRecognitionCaptureSource.h
     Modules/speech/SpeechRecognitionCaptureSourceImpl.h
     Modules/speech/SpeechRecognitionConnection.h

--- a/Source/WebCore/Modules/speech/SpeechSynthesis.cpp
+++ b/Source/WebCore/Modules/speech/SpeechSynthesis.cpp
@@ -167,7 +167,7 @@ void SpeechSynthesis::cancel()
         m_speechSynthesisClient->cancel();
         // If we wait for cancel to callback speakingErrorOccurred, then m_currentSpeechUtterance will be null
         // and the event won't be processed. Instead we process the error immediately.
-        speakingErrorOccurred();
+        speakingErrorOccurred(SpeechSynthesisErrorCode::Canceled);
         m_currentSpeechUtterance = nullptr;
     } else if (m_platformSpeechSynthesizer)
         m_platformSpeechSynthesizer->cancel();
@@ -195,18 +195,18 @@ void SpeechSynthesis::resume()
     }
 }
 
-void SpeechSynthesis::handleSpeakingCompleted(SpeechSynthesisUtterance& utterance, bool errorOccurred)
+void SpeechSynthesis::handleSpeakingCompleted(SpeechSynthesisUtterance& utterance, std::optional<SpeechSynthesisErrorCode> error)
 {
     ASSERT(m_currentSpeechUtterance);
     Ref<SpeechSynthesisUtterance> protect(utterance);
 
     m_currentSpeechUtterance = nullptr;
 
-    if (errorOccurred)
-        utterance.errorEventOccurred(eventNames().errorEvent, SpeechSynthesisErrorCode::Canceled);
+    if (error)
+        utterance.errorEventOccurred(eventNames().errorEvent, *error);
     else
         utterance.eventOccurred(eventNames().endEvent, 0, 0, String());
-    
+
     if (m_utteranceQueue.size()) {
         Ref<SpeechSynthesisUtterance> firstUtterance = m_utteranceQueue.takeFirst();
         ASSERT(&utterance == firstUtterance.ptr());
@@ -265,11 +265,11 @@ void SpeechSynthesis::didResumeSpeaking()
     didResumeSpeaking(*m_currentSpeechUtterance->platformUtterance());
 }
 
-void SpeechSynthesis::speakingErrorOccurred()
+void SpeechSynthesis::speakingErrorOccurred(std::optional<SpeechSynthesisErrorCode> error)
 {
     if (!m_currentSpeechUtterance)
         return;
-    speakingErrorOccurred(*m_currentSpeechUtterance->platformUtterance());
+    speakingErrorOccurred(*m_currentSpeechUtterance->platformUtterance(), error);
 }
 
 void SpeechSynthesis::boundaryEventOccurred(bool wordBoundary, unsigned charIndex, unsigned charLength)
@@ -307,13 +307,13 @@ void SpeechSynthesis::didResumeSpeaking(PlatformSpeechSynthesisUtterance& uttera
 void SpeechSynthesis::didFinishSpeaking(PlatformSpeechSynthesisUtterance& utterance)
 {
     if (utterance.client())
-        handleSpeakingCompleted(static_cast<SpeechSynthesisUtterance&>(*utterance.client()), false);
+        handleSpeakingCompleted(static_cast<SpeechSynthesisUtterance&>(*utterance.client()), std::nullopt);
 }
 
-void SpeechSynthesis::speakingErrorOccurred(PlatformSpeechSynthesisUtterance& utterance)
+void SpeechSynthesis::speakingErrorOccurred(PlatformSpeechSynthesisUtterance& utterance, std::optional<SpeechSynthesisErrorCode> error)
 {
     if (utterance.client())
-        handleSpeakingCompleted(static_cast<SpeechSynthesisUtterance&>(*utterance.client()), true);
+        handleSpeakingCompleted(static_cast<SpeechSynthesisUtterance&>(*utterance.client()), error);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/speech/SpeechSynthesis.h
+++ b/Source/WebCore/Modules/speech/SpeechSynthesis.h
@@ -84,7 +84,7 @@ private:
     void didPauseSpeaking(PlatformSpeechSynthesisUtterance&) override;
     void didResumeSpeaking(PlatformSpeechSynthesisUtterance&) override;
     void didFinishSpeaking(PlatformSpeechSynthesisUtterance&) override;
-    void speakingErrorOccurred(PlatformSpeechSynthesisUtterance&) override;
+    void speakingErrorOccurred(PlatformSpeechSynthesisUtterance&, std::optional<SpeechSynthesisErrorCode>) override;
     void boundaryEventOccurred(PlatformSpeechSynthesisUtterance&, SpeechBoundary, unsigned charIndex, unsigned charLength) override;
 
     // SpeechSynthesisClient override methods
@@ -92,12 +92,12 @@ private:
     void didFinishSpeaking() override;
     void didPauseSpeaking() override;
     void didResumeSpeaking() override;
-    void speakingErrorOccurred() override;
+    void speakingErrorOccurred(std::optional<SpeechSynthesisErrorCode>) override;
     void boundaryEventOccurred(bool wordBoundary, unsigned charIndex, unsigned charLength) override;
     void voicesChanged() override;
     
     void startSpeakingImmediately(SpeechSynthesisUtterance&);
-    void handleSpeakingCompleted(SpeechSynthesisUtterance&, bool errorOccurred);
+    void handleSpeakingCompleted(SpeechSynthesisUtterance&, std::optional<SpeechSynthesisErrorCode>);
 
     ScriptExecutionContext* scriptExecutionContext() const final { return ContextDestructionObserver::scriptExecutionContext(); }
     EventTargetInterface eventTargetInterface() const final { return SpeechSynthesisEventTargetInterfaceType; }

--- a/Source/WebCore/Modules/speech/SpeechSynthesisErrorCode.h
+++ b/Source/WebCore/Modules/speech/SpeechSynthesisErrorCode.h
@@ -28,7 +28,7 @@
 
 namespace WebCore {
 
-enum class SpeechSynthesisErrorCode {
+enum class SpeechSynthesisErrorCode : uint8_t {
     Canceled,
     Interrupted,
     AudioBusy,

--- a/Source/WebCore/page/SpeechSynthesisClient.h
+++ b/Source/WebCore/page/SpeechSynthesisClient.h
@@ -34,6 +34,7 @@ namespace WebCore {
 class PlatformSpeechSynthesisUtterance;
 class SpeechSynthesisClientObserver;
 class PlatformSpeechSynthesisVoice;
+enum class SpeechSynthesisErrorCode : uint8_t;
     
 class SpeechSynthesisClient : public CanMakeWeakPtr<SpeechSynthesisClient> {
 public:
@@ -59,7 +60,7 @@ public:
     virtual void didFinishSpeaking() = 0;
     virtual void didPauseSpeaking() = 0;
     virtual void didResumeSpeaking() = 0;
-    virtual void speakingErrorOccurred() = 0;
+    virtual void speakingErrorOccurred(std::optional<SpeechSynthesisErrorCode>) = 0;
     virtual void boundaryEventOccurred(bool wordBoundary, unsigned charIndex, unsigned charLength) = 0;
     virtual void voicesChanged() = 0;
 };

--- a/Source/WebCore/platform/PlatformSpeechSynthesizer.h
+++ b/Source/WebCore/platform/PlatformSpeechSynthesizer.h
@@ -29,7 +29,8 @@
 #if ENABLE(SPEECH_SYNTHESIS)
 
 #include "PlatformSpeechSynthesisVoice.h"
-#include <wtf/RefPtr.h>
+#include "SpeechSynthesisErrorCode.h"
+#include <optional>
 #include <wtf/Vector.h>
 
 #if PLATFORM(COCOA)
@@ -55,7 +56,7 @@ public:
     virtual void didFinishSpeaking(PlatformSpeechSynthesisUtterance&) = 0;
     virtual void didPauseSpeaking(PlatformSpeechSynthesisUtterance&) = 0;
     virtual void didResumeSpeaking(PlatformSpeechSynthesisUtterance&) = 0;
-    virtual void speakingErrorOccurred(PlatformSpeechSynthesisUtterance&) = 0;
+    virtual void speakingErrorOccurred(PlatformSpeechSynthesisUtterance&, std::optional<SpeechSynthesisErrorCode>) = 0;
     virtual void boundaryEventOccurred(PlatformSpeechSynthesisUtterance&, SpeechBoundary, unsigned charIndex, unsigned charLength) = 0;
     virtual void voicesDidChange() = 0;
 protected:

--- a/Source/WebCore/platform/mock/PlatformSpeechSynthesizerMock.cpp
+++ b/Source/WebCore/platform/mock/PlatformSpeechSynthesizerMock.cpp
@@ -81,7 +81,7 @@ void PlatformSpeechSynthesizerMock::cancel()
 
     m_speakingFinishedTimer.stop();
     auto utterance = std::exchange(m_utterance, nullptr);
-    client().speakingErrorOccurred(*utterance);
+    client().speakingErrorOccurred(*utterance, SpeechSynthesisErrorCode::Canceled);
 }
 
 void PlatformSpeechSynthesizerMock::pause()

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -361,7 +361,7 @@ struct WebPageProxy::Internals final : WebPopupMenuProxy::Client
     void didFinishSpeaking(WebCore::PlatformSpeechSynthesisUtterance&) final;
     void didPauseSpeaking(WebCore::PlatformSpeechSynthesisUtterance&) final;
     void didResumeSpeaking(WebCore::PlatformSpeechSynthesisUtterance&) final;
-    void speakingErrorOccurred(WebCore::PlatformSpeechSynthesisUtterance&) final;
+    void speakingErrorOccurred(WebCore::PlatformSpeechSynthesisUtterance&, std::optional<WebCore::SpeechSynthesisErrorCode>) final;
     void boundaryEventOccurred(WebCore::PlatformSpeechSynthesisUtterance&, WebCore::SpeechBoundary, unsigned characterIndex, unsigned characterLength) final;
 
     // PlatformSpeechSynthesizerClient

--- a/Source/WebKit/UIProcess/gstreamer/WebPageProxyGStreamer.cpp
+++ b/Source/WebKit/UIProcess/gstreamer/WebPageProxyGStreamer.cpp
@@ -58,9 +58,12 @@ void WebPageProxy::Internals::didResumeSpeaking(WebCore::PlatformSpeechSynthesis
         handler();
 }
 
-void WebPageProxy::Internals::speakingErrorOccurred(WebCore::PlatformSpeechSynthesisUtterance&)
+void WebPageProxy::Internals::speakingErrorOccurred(WebCore::PlatformSpeechSynthesisUtterance&, std::optional<WebCore::SpeechSynthesisErrorCode> error)
 {
-    page.send(Messages::WebPage::SpeakingErrorOccurred());
+    if (!error)
+        page.send(Messages::WebPage::SpeakingErrorOccurred(std::nullopt));
+    else
+        page.send(Messages::WebPage::SpeakingErrorOccurred(static_cast<uint8_t>(*error)));
 }
 
 void WebPageProxy::Internals::boundaryEventOccurred(WebCore::PlatformSpeechSynthesisUtterance&, WebCore::SpeechBoundary speechBoundary, unsigned charIndex, unsigned charLength)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -245,6 +245,7 @@
 #include <WebCore/PlatformKeyboardEvent.h>
 #include <WebCore/PlatformMediaSessionManager.h>
 #include <WebCore/PlatformMouseEvent.h>
+#include <WebCore/PlatformSpeechSynthesizer.h>
 #include <WebCore/PlatformStrategies.h>
 #include <WebCore/PluginDocument.h>
 #include <WebCore/PointerCaptureController.h>
@@ -8027,10 +8028,12 @@ void WebPage::systemPreviewActionTriggered(WebCore::SystemPreviewInfo previewInf
 #endif
 
 #if ENABLE(SPEECH_SYNTHESIS)
-void WebPage::speakingErrorOccurred()
+void WebPage::speakingErrorOccurred(std::optional<uint8_t> error)
 {
     if (auto observer = corePage()->speechSynthesisClient()->observer())
-        observer->speakingErrorOccurred();
+        observer->speakingErrorOccurred(!error
+                                        ? std::nullopt
+                                        : std::make_optional(static_cast<WebCore::SpeechSynthesisErrorCode>(*error)));
 }
 
 void WebPage::boundaryEventOccurred(bool wordBoundary, unsigned charIndex, unsigned charLength)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2079,7 +2079,7 @@ private:
 #endif
 
 #if ENABLE(SPEECH_SYNTHESIS)
-    void speakingErrorOccurred();
+    void speakingErrorOccurred(std::optional<uint8_t> error);
     void boundaryEventOccurred(bool wordBoundary, unsigned charIndex, unsigned charLength);
     void voicesDidChange();
 #endif

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -644,7 +644,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
     SimulateDeviceOrientationChange(double alpha, double beta, double gamma)
 
 #if ENABLE(SPEECH_SYNTHESIS)
-    SpeakingErrorOccurred()
+    SpeakingErrorOccurred(std::optional<uint8_t> error)
     BoundaryEventOccurred(bool wordBoundary, unsigned charIndex, unsigned charLength)
     VoicesDidChange()
 #endif


### PR DESCRIPTION
- Add missing functions
- Add proper error handling (similar to #823 with optional as in #875) for both UIProcess and WebProcess
