### PR TITLE
[GTK][WPE] Use enable-html5-database runtime flag to control IndexedD…

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
@@ -1955,7 +1955,7 @@ gboolean webkit_settings_get_enable_html5_database(WebKitSettings* settings)
 {
     g_return_val_if_fail(WEBKIT_IS_SETTINGS(settings), FALSE);
 
-    return settings->priv->preferences->databasesEnabled();
+    return settings->priv->preferences->indexedDBAPIEnabled();
 }
 
 /**
@@ -1970,11 +1970,11 @@ void webkit_settings_set_enable_html5_database(WebKitSettings* settings, gboolea
     g_return_if_fail(WEBKIT_IS_SETTINGS(settings));
 
     WebKitSettingsPrivate* priv = settings->priv;
-    bool currentValue = priv->preferences->databasesEnabled();
+    bool currentValue = priv->preferences->indexedDBAPIEnabled();
     if (currentValue == enabled)
         return;
 
-    priv->preferences->setDatabasesEnabled(enabled);
+    priv->preferences->setIndexedDBAPIEnabled(enabled);
     g_object_notify_by_pspec(G_OBJECT(settings), sObjProperties[PROP_ENABLE_HTML5_DATABASE]);
 }
 


### PR DESCRIPTION
…B API

https://bugs.webkit.org/show_bug.cgi?id=261669

Reviewed by Michael Catanzaro.

By default IndexedDB API is enabled. To change that we can use runtime flag: "enable-html5-database" or by calling "webkit_settings_set_enable_html5-database".

* Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp: (webkit_settings_get_enable_html5_database):
(webkit_settings_set_enable_html5_database):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebView.cpp: (testWebViewEnableHTML5Database):
(beforeAll):

Canonical link: https://commits.webkit.org/268142@main