### PR TITLE
[wpe-2.38] Fix flushing

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
@@ -151,7 +151,7 @@ void SourceBufferPrivateGStreamer::flush(const AtomString& trackId)
     }
 
     GST_DEBUG_OBJECT(m_playerPrivate.pipeline(), "Source element has emitted tracks, let it handle the flush, which may cause a pipeline flush as well. trackId = '%s'", trackId.string().utf8().data());
-    webKitMediaSrcFlush(m_playerPrivate.webKitMediaSrc(), trackId);
+    webKitMediaSrcFlush(m_playerPrivate.webKitMediaSrc(), trackId, toGstClockTime(m_playerPrivate.currentMediaTime()));
 }
 
 void SourceBufferPrivateGStreamer::enqueueSample(Ref<MediaSample>&& sample, const AtomString& trackId)

--- a/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
@@ -96,7 +96,7 @@ static gboolean webKitMediaSrcActivateMode(GstPad*, GstObject*, GstPadMode, gboo
 static void webKitMediaSrcLoop(void*);
 static void webKitMediaSrcTearDownStream(WebKitMediaSrc* source, const AtomString& name);
 static void webKitMediaSrcGetProperty(GObject*, unsigned propId, GValue*, GParamSpec*);
-static void webKitMediaSrcStreamFlush(Stream*, bool isSeekingFlush);
+static void webKitMediaSrcStreamFlush(Stream*, bool isSeekingFlush, GstClockTime time);
 static gboolean webKitMediaSrcSendEvent(GstElement*, GstEvent*);
 
 #define webkit_media_src_parent_class parent_class
@@ -343,7 +343,7 @@ static void webKitMediaSrcTearDownStream(WebKitMediaSrc* source, const AtomStrin
     GST_DEBUG_OBJECT(source, "Tearing down stream '%s'", name.string().utf8().data());
 
     // Flush the source element **and** downstream. We want to stop the streaming thread and for that we need all elements downstream to be idle.
-    webKitMediaSrcStreamFlush(stream, false);
+    webKitMediaSrcStreamFlush(stream, false, GST_CLOCK_TIME_NONE);
     // Stop the thread now.
     gst_pad_set_active(stream->pad.get(), false);
 
@@ -573,7 +573,7 @@ static void webKitMediaSrcLoop(void* userData)
         ASSERT_NOT_REACHED();
 }
 
-static void webKitMediaSrcStreamFlush(Stream* stream, bool isSeekingFlush)
+static void webKitMediaSrcStreamFlush(Stream* stream, bool isSeekingFlush, GstClockTime time)
 {
     ASSERT(isMainThread());
     bool skipFlush = false;
@@ -630,12 +630,7 @@ static void webKitMediaSrcStreamFlush(Stream* stream, bool isSeekingFlush)
         // In the case of non-seeking flushes we don't reset the timeline, so instead we need to increase the `base` field
         // by however running time we're starting after the flush.
 
-        GstClockTime pipelineStreamTime;
-        gst_element_query_position(findPipeline(GRefPtr<GstElement>(GST_ELEMENT(stream->source))).get(), GST_FORMAT_TIME,
-            reinterpret_cast<gint64*>(&pipelineStreamTime));
-        GST_DEBUG_OBJECT(stream->source, "pipelineStreamTime from position query: %" GST_TIME_FORMAT, GST_TIME_ARGS(pipelineStreamTime));
-        // GST_CLOCK_TIME_NONE is returned when the pipeline is not yet pre-rolled (e.g. just after a seek). In this case
-        // we don't need to adjust the segment though, as running time has not advanced.
+        GstClockTime pipelineStreamTime = time;
         if (GST_CLOCK_TIME_IS_VALID(pipelineStreamTime)) {
             DataMutexLocker streamingMembers { stream->streamingMembersDataMutex };
             // We need to increase the base by the running time accumulated during the previous segment.
@@ -680,13 +675,13 @@ static void webKitMediaSrcStreamFlush(Stream* stream, bool isSeekingFlush)
         stream->track->trackId().string().utf8().data(), boolForPrinting(isSeekingFlush));
 }
 
-void webKitMediaSrcFlush(WebKitMediaSrc* source, const AtomString& streamName)
+void webKitMediaSrcFlush(WebKitMediaSrc* source, const AtomString& streamName, GstClockTime time)
 {
     ASSERT(isMainThread());
     GST_DEBUG_OBJECT(source, "Received non-seek flush request for stream '%s'.", streamName.string().utf8().data());
     Stream* stream = source->priv->streamByName(streamName);
 
-    webKitMediaSrcStreamFlush(stream, false);
+    webKitMediaSrcStreamFlush(stream, false, time);
 }
 
 static void webKitMediaSrcSeek(WebKitMediaSrc* source, uint64_t startTime, double rate)
@@ -697,7 +692,7 @@ static void webKitMediaSrcSeek(WebKitMediaSrc* source, uint64_t startTime, doubl
     GST_DEBUG_OBJECT(source, "Seek requested to time %" GST_TIME_FORMAT " with rate %f.", GST_TIME_ARGS(startTime), rate);
 
     for (const RefPtr<Stream>& stream : source->priv->streams.values())
-        webKitMediaSrcStreamFlush(stream.get(), true);
+        webKitMediaSrcStreamFlush(stream.get(), true, startTime);
 }
 
 static int countStreamsOfType(WebKitMediaSrc* source, WebCore::TrackPrivateBaseGStreamer::TrackType type)

--- a/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
@@ -667,6 +667,11 @@ static void webKitMediaSrcStreamFlush(Stream* stream, bool isSeekingFlush)
         gst_pad_push_event(stream->pad.get(), gst_event_new_flush_stop(isSeekingFlush));
         GST_DEBUG_OBJECT(stream->pad.get(), "FLUSH_STOP sent.");
 
+        {
+            DataMutexLocker streamingMembers { stream->streamingMembersDataMutex };
+            streamingMembers->hasPoppedFirstObject = false;
+        }
+
         GST_DEBUG_OBJECT(stream->pad.get(), "Starting webKitMediaSrcLoop task and releasing the STREAM_LOCK.");
         gst_pad_start_task(stream->pad.get(), webKitMediaSrcLoop, stream->pad.get(), nullptr);
     }

--- a/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
@@ -172,7 +172,7 @@ struct Stream : public ThreadSafeRefCounted<Stream> {
             : pendingInitialCaps(WTFMove(initialCaps))
         {
             gst_segment_init(&segment, GST_FORMAT_TIME);
-            segment.start = segment.time = startTime;
+            segment.position = segment.start = segment.time = startTime;
             segment.rate = rate;
             ASSERT(pendingInitialCaps);
         }
@@ -625,7 +625,7 @@ static void webKitMediaSrcStreamFlush(Stream* stream, bool isSeekingFlush)
         DataMutexLocker streamingMembers { stream->streamingMembersDataMutex };
         streamingMembers->segment.base = 0;
         streamingMembers->segment.rate = priv->rate;
-        streamingMembers->segment.start = streamingMembers->segment.time = priv->startTime;
+        streamingMembers->segment.position = streamingMembers->segment.start = streamingMembers->segment.time = priv->startTime;
     } else {
         // In the case of non-seeking flushes we don't reset the timeline, so instead we need to increase the `base` field
         // by however running time we're starting after the flush.
@@ -646,7 +646,7 @@ static void webKitMediaSrcStreamFlush(Stream* stream, bool isSeekingFlush)
                 GST_TIME_ARGS(pipelineRunningTime), GST_TIME_ARGS(pipelineStreamTime));
             streamingMembers->segment.base = pipelineRunningTime;
 
-            streamingMembers->segment.start = streamingMembers->segment.time = static_cast<GstClockTime>(pipelineStreamTime);
+            streamingMembers->segment.position = streamingMembers->segment.start = streamingMembers->segment.time = static_cast<GstClockTime>(pipelineStreamTime);
         }
     }
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.h
@@ -63,7 +63,7 @@ GType webkit_media_src_get_type(void);
 
 void webKitMediaSrcEmitStreams(WebKitMediaSrc* source, const Vector<RefPtr<WebCore::MediaSourceTrackGStreamer>>& tracks);
 
-void webKitMediaSrcFlush(WebKitMediaSrc*, const AtomString& streamName);
+void webKitMediaSrcFlush(WebKitMediaSrc*, const AtomString& streamName, GstClockTime time);
 
 G_END_DECLS
 


### PR DESCRIPTION
This PR has two commits to deal with below scenarios:
1) Seeking to unbuffered range doesn't succeed (playback resumes from different position than the requested one)
     - gst seek is performed and MSE waits for buffer for the seek position
     - when data arrives, seek completion path reenqueues data in turn triggers flush
     - **flush resets segment.time & segment.base with the current playback time** 
     - buffer is pushed downstream
     - Segment event is sent with the current playback time (which is not desired)
     - the log excerpts can be found @ https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1157#issuecomment-1722979577

2) Audio language switch during playback causes playback to start from beginning (in Prime video app)
     - Some sinks, like westerossink on amlogic platform, rely on segment.position for playback position calculation
     - when language switch is made by user, application clears audio buffer, flushing audio track
     - audio sink reports 0 position (after flush)
     - this results in westerossink's position to be returned as the playback position (as it is the greatest of the two sinks)
     - but westerossink's position is not correct either (as the segments we have sent before didn't have position field set)
     - when application queries the current position, this incorrect value is returned
     - app then makes a seek slightly before the correct position (100 micro second)
     - this ends up in a completely different playback position from where we switched the audio language