### PR TITLE
[2.38] Add missing feComposite filter's arithmetic operation implementation

### DIFF
--- a/Source/WebCore/platform/graphics/cpu/arm/filters/FECompositeArithmeticNEON.h
+++ b/Source/WebCore/platform/graphics/cpu/arm/filters/FECompositeArithmeticNEON.h
@@ -36,7 +36,7 @@
 namespace WebCore {
 
 template <int b1, int b4>
-inline void FEComposite::computeArithmeticPixelsNeon(const uint8_t* source, uint8_t* destination, unsigned pixelArrayLength, float k1, float k2, float k3, float k4)
+inline void FECompositeSoftwareApplier::computeArithmeticPixelsNeon(const uint8_t* source, uint8_t* destination, unsigned pixelArrayLength, float k1, float k2, float k3, float k4)
 {
     float32x4_t k1x4 = vdupq_n_f32(k1 / 255);
     float32x4_t k2x4 = vdupq_n_f32(k2);
@@ -67,7 +67,7 @@ inline void FEComposite::computeArithmeticPixelsNeon(const uint8_t* source, uint
     }
 }
 
-inline void FEComposite::platformArithmeticNeon(const uint8_t* source, uint8_t* destination, unsigned pixelArrayLength, float k1, float k2, float k3, float k4)
+inline void FECompositeSoftwareApplier::platformArithmeticNeon(const uint8_t* source, uint8_t* destination, unsigned pixelArrayLength, float k1, float k2, float k3, float k4)
 {
     if (!k4) {
         if (!k1) {

--- a/Source/WebCore/platform/graphics/filters/FEComposite.h
+++ b/Source/WebCore/platform/graphics/filters/FEComposite.h
@@ -73,13 +73,6 @@ private:
 
     WTF::TextStream& externalRepresentation(WTF::TextStream&, FilterRepresentation) const override;
 
-#if HAVE(ARM_NEON_INTRINSICS)
-    template <int b1, int b4>
-    static inline void computeArithmeticPixelsNeon(const uint8_t* source, uint8_t* destination, unsigned pixelArrayLength, float k1, float k2, float k3, float k4);
-
-    static inline void platformArithmeticNeon(const uint8_t* source, uint8_t* destination, unsigned pixelArrayLength, float k1, float k2, float k3, float k4);
-#endif
-
     CompositeOperationType m_type;
     float m_k1;
     float m_k2;

--- a/Source/WebCore/platform/graphics/filters/software/FECompositeSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FECompositeSoftwareApplier.cpp
@@ -25,6 +25,7 @@
 #include "config.h"
 #include "FECompositeSoftwareApplier.h"
 
+#include "FECompositeArithmeticNEON.h"
 #include "FEComposite.h"
 #include "GraphicsContext.h"
 #include "ImageBuffer.h"
@@ -147,6 +148,8 @@ bool FECompositeSoftwareApplier::applyArithmetic(FilterImage& input, FilterImage
     ASSERT(length == destinationPixelBuffer->sizeInBytes());
 #if !HAVE(ARM_NEON_INTRINSICS)
     applyPlatformArithmetic(sourcePixelBytes, destinationPixelBytes, length, m_effect.k1(), m_effect.k2(), m_effect.k3(), m_effect.k4());
+#else
+    platformArithmeticNeon(sourcePixelBytes, destinationPixelBytes, length, m_effect.k1(), m_effect.k2(), m_effect.k3(), m_effect.k4());
 #endif
     return true;
 }

--- a/Source/WebCore/platform/graphics/filters/software/FECompositeSoftwareApplier.h
+++ b/Source/WebCore/platform/graphics/filters/software/FECompositeSoftwareApplier.h
@@ -50,6 +50,13 @@ private:
 
     bool applyArithmetic(FilterImage& input, FilterImage& input2, FilterImage& result) const;
     bool applyNonArithmetic(FilterImage& input, FilterImage& input2, FilterImage& result) const;
+
+#if HAVE(ARM_NEON_INTRINSICS)
+    template <int b1, int b4>
+    static inline void computeArithmeticPixelsNeon(const uint8_t* source, uint8_t* destination, unsigned pixelArrayLength, float k1, float k2, float k3, float k4);
+
+    static inline void platformArithmeticNeon(const uint8_t* source, uint8_t* destination, unsigned pixelArrayLength, float k1, float k2, float k3, float k4);
+#endif
 };
 
 } // namespace WebCore


### PR DESCRIPTION
fixes #1145

On ARM platforms having neon intrinsics ABI available the implementation of platfrom-specific arithmetic operation of feComposite filter was not hooked despite the fact that implementation was in place - it was probably missed during cherry-picking.