### PR TITLE
Web Inspector: Uncaught Exception: Right side of assignment cannot be…

### DIFF
--- a/Source/WebInspectorUI/ChangeLog
+++ b/Source/WebInspectorUI/ChangeLog
@@ -1,3 +1,13 @@
+2020-03-22  Devin Rousso  <drousso@apple.com>
+
+        Web Inspector: Uncaught Exception: Right side of assignment cannot be destructured (at QuickConsole.js:358:30)
+        https://bugs.webkit.org/show_bug.cgi?id=209388
+
+        Reviewed by Joseph Pecoraro.
+
+        * UserInterface/Views/QuickConsole.js:
+        (WI.QuickConsole.prototype._handleFramePageExecutionContextChanged):
+
 2022-03-08  Adrian Perez de Castro  <aperez@igalia.com> and Carlos Garcia Campos  <cgarcia@igalia.com>
 
         [GTK][WPE] Web Inspector: make it possible to use the remote inspector from other browsers

--- a/Source/WebInspectorUI/UserInterface/Views/QuickConsole.js
+++ b/Source/WebInspectorUI/UserInterface/Views/QuickConsole.js
@@ -337,15 +337,15 @@ WI.QuickConsole = class QuickConsole extends WI.View
 
     _handleFramePageExecutionContextChanged(event)
     {
-        if (this._restoreSelectedExecutionContextForFrame !== event.target)
+        let frame = event.target;
+
+        if (this._restoreSelectedExecutionContextForFrame !== frame)
             return;
 
         this._restoreSelectedExecutionContextForFrame = null;
 
-        let {context} = event.data;
-
         this._useExecutionContextOfInspectedNode = false;
-        this._setActiveExecutionContext(context);
+        this._setActiveExecutionContext(frame.pageExecutionContext);
     }
 
     _handleFrameExecutionContextsCleared(event)


### PR DESCRIPTION
… destructured (at QuickConsole.js:358:30)

https://bugs.webkit.org/show_bug.cgi?id=209388

Reviewed by Joseph Pecoraro.

* UserInterface/Views/QuickConsole.js: (WI.QuickConsole.prototype._handleFramePageExecutionContextChanged):

Canonical link: https://commits.webkit.org/222323@main
git-svn-id: https://svn.webkit.org/repository/webkit/trunk@258818 268f45cc-cd09-0410-ab3c-d52691b4dbfc
