### PR TITLE
[ARRISEOS-44876] : PIP video displays a black screen while transition…

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -2732,7 +2732,7 @@ void MediaPlayerPrivateGStreamer::didEnd()
 
     if (!m_player->isLooping() && !isMediaSource()) {
         m_isPaused = true;
-        changePipelineState(GST_STATE_READY);
+        changePipelineState(GST_STATE_PAUSED);
         m_didDownloadFinish = false;
         configureMediaStreamAudioTracks();
 


### PR DESCRIPTION
PIP video displays a black screen while transitioning to the next episodes in 'itvx news'  rail

ITVx uses MP4 progressive download for showing ITVx news videos. When a video ends (or it's about to end) the app will change the size of the <video> tag to make it a Picture-in-Picture video and it will keep playing until the end of it. ITVx will not teardown the video player until a change of page/video happens.

On Horizon as soon as the video ends, it will show a black box (see attached picture) instead of showing last frame played as browser or TiVo devices do.

2. Reproducibility rate
100%

Scenario to reproduce
1. Launch the ITVx App
2. Play assets from itvx news rail
3. Observe the behaviour while transitioning to next episode

Expected result
PIP Video keeps playing until it finishes
Actual results
PIP video displays a black screen while transitioning to the next episodes in 'itvx news'  rail


![Screenshot from 2023-10-04 15-42-55](https://github.com/WebPlatformForEmbedded/WPEWebKit/assets/136487900/3830440f-f33f-4a11-b049-6e6ad7fdb47a)


================================================================================================
Issue is seen only with Progressive based content. If we try same use case contents which are MSE based playback then no issue is seen on PIP, In PIP we can see last 10 seconds video is played.

But, in case of progressive , we are getting EOS message from G streamer and based upon this message, we are setting the pipeline state to READY which show the black screen in PIP.
So, in this case, we have changed the pipeline state to PAUSED so that we can see Last frame in PIP instead of Black screen.
================================================================================================

