### PR TITLE
Fix Voice Guidance reads iframe when added to DOM

### DIFF
--- a/Source/WebCore/accessibility/atk/WebKitAccessible.cpp
+++ b/Source/WebCore/accessibility/atk/WebKitAccessible.cpp
@@ -745,7 +745,13 @@ static AtkRole atkRole(AccessibilityObject* coreObject)
     case AccessibilityRole::UserInterfaceTooltip:
         return ATK_ROLE_TOOL_TIP;
     case AccessibilityRole::WebArea:
-        return ATK_ROLE_DOCUMENT_WEB;
+    {
+        WebCore::Frame *frame = coreObject->frame();
+        if (frame)
+           return frame->WebCore::Frame::isMainFrame() ? ATK_ROLE_DOCUMENT_WEB : ATK_ROLE_DOCUMENT_FRAME;
+        else
+           return ATK_ROLE_DOCUMENT_WEB;
+    }
     case AccessibilityRole::WebApplication:
         return ATK_ROLE_EMBEDDED;
     case AccessibilityRole::ApplicationLog:


### PR DESCRIPTION
Backported from:
https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/820

Example test page:
```
<html>
   <head />
   <body bgcolor="white">
   <script>

      setTimeout(()=> {
         var tgt = document.getElementById("tgt");
         var iframe = document.createElement("iframe");
         iframe.src = "https://a11yphl.com";
         iframe.height = "0";
         iframe.width = "0";
         iframe.title = "My iframe";

         console.log("XXXXXXXXXXXXXXXXXXXXXXX Appending iframe...");
         tgt.appendChild(iframe);
         console.log("XXXXXXXXXXXXXXXXXXXXXXX Appending iframe...DONE");
      },4000)

   </script>
      <p>Hello world</p>
      <div id="tgt"></div>
   </body>
</html>
```