### PR TITLE
Implement list of available images matching logic

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-loading-lazy-available-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-loading-lazy-available-expected.txt
@@ -1,5 +1,5 @@
 
 
 
-FAIL The list of available images gets checked before deciding to make a load lazy assert_equals: The list of available images should be checked before delaying the image load expected 256 but got 0
+PASS The list of available images gets checked before deciding to make a load lazy
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-loading-lazy-use-list-of-available-images-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-loading-lazy-use-list-of-available-images-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL Lazyload images can load immediately from the list of available images promise_test: Unhandled rejection with value: object "Error: The `loading=lazy` image should load immediately from the list of available images, beating this timeout promise."
+PASS Lazyload images can load immediately from the list of available images
 


### PR DESCRIPTION
 https://bugs.webkit.org/show_bug.cgi?id=243790

Reviewed by Sihui Liu and Chris Dumez.

Implement list of available images matching logic: https://html.spec.whatwg.org/multipage/images.html#updating-the-image-data:list-of-available-images

This is restricted to lazy loading for now.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-loading-lazy-available-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-loading-lazy-use-list-of-available-images-expected.txt:
* Source/WebCore/loader/ImageLoader.cpp: (WebCore::canReuseFromListOfAvailableImages):
(WebCore::ImageLoader::updateFromElement):