### PR TITLE
[GStreamer][MSE] Audio only live stream doesn't work

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -343,10 +343,14 @@ void MediaPlayerPrivateGStreamerMSE::didPreroll()
     // that order.
 
     if (m_isSeeking) {
+        m_cachedPosition = currentMediaTime();
         m_isSeeking = false;
         GST_DEBUG("Seek complete because of preroll. currentMediaTime = %s", currentMediaTime().toString().utf8().data());
         // By calling timeChanged(), m_isSeeking will be checked an a "seeked" event will be emitted.
         m_player->timeChanged();
+        propagateReadyStateToPlayer();
+        invalidateCachedPosition();
+        return;
     }
 
     propagateReadyStateToPlayer();


### PR DESCRIPTION
Issue reproduced on BBC Sounds application on Broadcom platform

Reproduction flow:
- seek to position 100
- seek range is buffered : [99, 103]
- player is in preroll state (MediaPlayerPrivateGStreamerMSE::didPreroll)
- m_isSeeking is set to false
- call to currentMediaTime() triggers invalidateCachedPositionOnNextIteration()
- MediaSource readyState is set to HaveEnoughData
- invalidateCachedPosition is called() asynchronously
- currentMediaTime returns position 0
- MediaSource readyState drops to HaveMetadata state

Solution: during preroll state we still remember seek position as a cached value