### PR TITLE
[wpe-2.38] Fix audio sink detection

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -1864,13 +1864,13 @@ void MediaPlayerPrivateGStreamer::handleMessage(GstMessage* message)
 
 #if PLATFORM(BROADCOM) || USE(WESTEROS_SINK) || PLATFORM(AMLOGIC) || PLATFORM(REALTEK)
         if (currentState <= GST_STATE_READY && newState >= GST_STATE_READY) {
-            // If we didn't create an audio sink, store a reference to the created one.
-            if (!m_audioSink) {
-                // Detect an audio sink element.
-                GstElement* element = GST_ELEMENT(GST_MESSAGE_SRC(message));
-                if (GST_OBJECT_FLAG_IS_SET(element, GST_ELEMENT_FLAG_SINK)) {
-                    const gchar* klassStr = gst_element_get_metadata(element, "klass");
-                    if (strstr(klassStr, "Sink") && strstr(klassStr, "Audio"))
+            // Detect an audio sink element and store reference to it if it supersedes what we currently have.
+            GstElement* element = GST_ELEMENT(GST_MESSAGE_SRC(message));
+            if (GST_OBJECT_FLAG_IS_SET(element, GST_ELEMENT_FLAG_SINK)) {
+                const gchar* klassStr = gst_element_get_metadata(element, "klass");
+                if (strstr(klassStr, "Sink") && strstr(klassStr, "Audio")) {
+                    GstState currentAudioSinkState, currentAudioSinkPendingState;
+                    if (!m_audioSink || (m_audioSink.get() != element && GST_STATE(m_audioSink.get()) == GST_STATE_NULL))
                         m_audioSink = element;
                 }
             }


### PR DESCRIPTION
This PR addresses the following flow:

1. audio playback is about to start 
2. playbin2 detects ABC audio sink, and tries to use it
3. ABC sink transitions from `NULL` to `READY` and notifies webkit
4. webkit updates `m_audioSink`
5. playbin2 decides to reject ABC audio sink and tries XYZ audio sink instead
6. ABC sink transitions from `READY` to `NULL` without notifing webkit
7. XYZ sink transitions from `NULL` to `READY` and notifies webkit
8. webkit **does not** update `m_audioSink`
9. playback starts
10. position queries are performed against ABC sink and therefore make no sense

So, the proposed fix is basically to do an extra check to detect such situation and update `m_audioSink` to the correct sink.
 