### PR TITLE
[wpe-2.38][webrtc] Compilation fix when libwebrtc is enabled

### DIFF
--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp
@@ -141,6 +141,8 @@ static inline webrtc::SdpType sessionDescriptionType(RTCSdpType sdpType)
     case RTCSdpType::Rollback:
         return webrtc::SdpType::kRollback;
     }
+
+    RELEASE_ASSERT_NOT_REACHED();
 }
 
 void LibWebRTCMediaEndpoint::doSetLocalDescription(const RTCSessionDescription* description)


### PR DESCRIPTION
g++ version: 9.3. Error output:
LibWebRTCMediaEndpoint.cpp:146:1: error: control reaches end of non-void function [-Werror=return-type]
