### PR TITLE
[wpe-2.38][webrtc] Build gstwebrtc with gst 1.18

### DIFF
--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
@@ -402,10 +402,12 @@ void GStreamerMediaEndpoint::doSetLocalDescription(const RTCSessionDescription* 
         if (protectedThis->isStopped())
             return;
         if (error) {
+#if GST_CHECK_VERSION(1, 20, 0)
             if (error->code == GST_WEBRTC_ERROR_INVALID_STATE) {
                 m_peerConnectionBackend.setLocalDescriptionFailed(Exception { InvalidStateError, "Failed to set local answer sdp: no pending remote description."_s });
                 return;
             }
+#endif
             m_peerConnectionBackend.setLocalDescriptionFailed(Exception { OperationError, String::fromUTF8(error->message) });
         } else
             m_peerConnectionBackend.setLocalDescriptionFailed(Exception { OperationError, "Unable to apply session local description"_s });
@@ -484,8 +486,11 @@ void GStreamerMediaEndpoint::doSetRemoteDescription(const RTCSessionDescription&
     }, [protectedThis = Ref(*this), this](const GError* error) {
         if (protectedThis->isStopped())
             return;
+
+#if GST_CHECK_VERSION(1, 20, 0)
         if (error && error->code == GST_WEBRTC_ERROR_INVALID_STATE)
             m_peerConnectionBackend.setRemoteDescriptionFailed(Exception { InvalidStateError, "Failed to set remote answer sdp"_s });
+#endif
         else
             m_peerConnectionBackend.setRemoteDescriptionFailed(Exception { OperationError, "Unable to apply session remote description"_s });
     });

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp
@@ -36,16 +36,20 @@ namespace WebCore {
 GStreamerRtpTransceiverBackend::GStreamerRtpTransceiverBackend(GRefPtr<GstWebRTCRTPTransceiver>&& rtcTransceiver)
     : m_rtcTransceiver(WTFMove(rtcTransceiver))
 {
+#if GST_CHECK_VERSION(1, 20, 0)
     GstWebRTCKind kind;
     g_object_get(m_rtcTransceiver.get(), "kind", &kind, nullptr);
+#endif
 
     gst_util_set_object_arg(G_OBJECT(m_rtcTransceiver.get()), "fec-type", "ulp-red");
 
     // Enable nack only for video transceivers, so that RTX payloads are not signaled in SDP
     // offer/answer. Those are confusing some media servers... Internally webrtcbin will always
     // setup RTX, RED and FEC anyway.
+#if GST_CHECK_VERSION(1, 20, 0)
     if (kind != GST_WEBRTC_KIND_VIDEO)
         return;
+#endif
 
     g_object_set(m_rtcTransceiver.get(), "do-nack", TRUE, nullptr);
 }

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
@@ -83,10 +83,14 @@ static inline std::optional<RTCIceCandidateType> toRTCIceCandidateType(const Str
 
 RefPtr<RTCError> toRTCError(GError* rtcError)
 {
+#if GST_CHECK_VERSION(1, 20, 0)
     auto detail = toRTCErrorDetailType(static_cast<GstWebRTCError>(rtcError->code));
     if (!detail)
         return nullptr;
     return RTCError::create(*detail, String::fromUTF8(rtcError->message));
+#else
+    return nullptr;
+#endif
 }
 
 static inline double toWebRTCBitRatePriority(RTCPriorityType priority)

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.h
@@ -238,6 +238,7 @@ static inline GstWebRTCICETransportPolicy iceTransportPolicyFromConfiguration(co
     return GST_WEBRTC_ICE_TRANSPORT_POLICY_ALL;
 }
 
+#if GST_CHECK_VERSION(1, 20, 0)
 static inline std::optional<RTCErrorDetailType> toRTCErrorDetailType(GstWebRTCError code)
 {
     switch (code) {
@@ -258,6 +259,7 @@ static inline std::optional<RTCErrorDetailType> toRTCErrorDetailType(GstWebRTCEr
         return { };
     };
 }
+#endif
 
 RefPtr<RTCError> toRTCError(GError*);
 

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
@@ -884,10 +884,12 @@ RTCRtpCapabilities GStreamerRegistryScanner::videoRtpCapabilities(Configuration 
 static inline Vector<RTCRtpCapabilities::HeaderExtensionCapability> probeRtpExtensions(const Vector<const char*>& candidates)
 {
     Vector<RTCRtpCapabilities::HeaderExtensionCapability> extensions;
+#if GST_CHECK_VERSION(1, 20, 0)
     for (const auto& uri : candidates) {
         if (auto extension = adoptGRef(gst_rtp_header_extension_create_from_uri(uri)))
             extensions.append({ String::fromLatin1(uri) });
     }
+#endif
     return extensions;
 }
 

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.cpp
@@ -120,6 +120,7 @@ int RealtimeIncomingSourceGStreamer::registerClient(GRefPtr<GstElement>&& appsrc
             self->dispatchSample(WTFMove(sample));
             return GST_FLOW_OK;
         },
+#if GST_CHECK_VERSION(1, 20, 0)
         [](GstAppSink* sink, gpointer userData) -> gboolean {
             auto* self = reinterpret_cast<RealtimeIncomingSourceGStreamer*>(userData);
             auto event = adoptGRef(GST_EVENT_CAST(gst_app_sink_pull_object(sink)));
@@ -153,9 +154,6 @@ int RealtimeIncomingSourceGStreamer::registerClient(GRefPtr<GstElement>&& appsrc
 
             return false;
         },
-#if GST_CHECK_VERSION(1, 23, 0)
-        // propose_allocation
-        nullptr,
 #endif
         { nullptr }
     };


### PR DESCRIPTION
Based on GStreamerChecks.cmake gstwebrtc is supported from gstreame version 1.18. Added checks for types defined in version 1.20.

Alternative approach would be to support gstwebrtc from gstreamer version 1.20. 