### PR TITLE
[wpe-2.38] Improve RWI's frontend shutdown handling

### DIFF
--- a/Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorServer.cpp
+++ b/Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorServer.cpp
@@ -327,6 +327,8 @@ void RemoteInspectorServer::sendMessageToFrontend(SocketConnection& remoteInspec
     uint64_t connectionID = m_remoteInspectorConnectionToIDMap.get(&remoteInspectorConnection);
     auto connectionTargetPair = std::make_pair(connectionID, targetID);
     ASSERT(m_automationTargets.contains(connectionTargetPair) || m_inspectionTargets.contains(connectionTargetPair));
+    if (!m_automationTargets.contains(connectionTargetPair) && !m_inspectionTargets.contains(connectionTargetPair))
+        return;
     SocketConnection* clientConnection = m_inspectionTargets.contains(connectionTargetPair) ? m_clientConnection : m_automationConnection;
     ASSERT(clientConnection);
     clientConnection->sendMessage("SendMessageToFrontend", g_variant_new("(tt&s)", connectionID, targetID, message));


### PR DESCRIPTION
This PR improves RWI's frontend shutdown handling so that the crash described in https://github.com/WebPlatformForEmbedded/WPEWebKit/issues/1220 is not visible anymore in release builds.

Please note that the underlying issue is not fixed with that. In the debug builds there are few assertions like
```
ASSERT(m_automationTargets.contains(connectionTargetPair) || m_inspectionTargets.contains(connectionTargetPair));
```
which are still causing crashes thus signaling that the shutdown of RWI frontend connection is not graceful.