### PR TITLE
[wpe-2.38] Restore local storage after corruption

### DIFF
--- a/Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.h
+++ b/Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.h
@@ -48,6 +48,7 @@ private:
     void clear() final;
     HashMap<String, String> allItems() final;
     Expected<void, StorageError> setItem(IPC::Connection::UniqueID, StorageAreaImplIdentifier, String&& key, String&& value, const String& urlString) final;
+    Expected<void, StorageError> setItem(const String& key, const String& value, bool handleDatabaseCorruption);
     Expected<void, StorageError> removeItem(IPC::Connection::UniqueID, StorageAreaImplIdentifier, const String& key, const String& urlString) final;
     Expected<void, StorageError> clear(IPC::Connection::UniqueID, StorageAreaImplIdentifier, const String& urlString) final;
 


### PR DESCRIPTION
In `wpe-2.28` there was a mechanism which was restoring local storage from the cached values after database re-creation due to corruption.
This PR adds the same for `wpe-2.38`.