### PR TITLE
[2.38] Destroy acc surface and egl target in nonCompositedWebGL mode

### DIFF
--- a/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.cpp
+++ b/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.cpp
@@ -110,15 +110,17 @@ void ThreadedCompositor::invalidate()
     m_compositingRunLoop->stopUpdates();
     m_displayRefreshMonitor->invalidate();
     m_compositingRunLoop->performTaskSync([this, protectedThis = Ref { *this }] {
-        if (!m_context || !m_context->makeContextCurrent())
-            return;
+        if (m_context) {
+            if (!m_context->makeContextCurrent())
+                return;
 
-        // Update the scene at this point ensures the layers state are correctly propagated
-        // in the ThreadedCompositor and in the CompositingCoordinator.
-        updateSceneWithoutRendering();
+            // Update the scene at this point ensures the layers state are correctly propagated
+            // in the ThreadedCompositor and in the CompositingCoordinator.
+            updateSceneWithoutRendering();
 
-        m_scene->purgeGLResources();
-        m_context = nullptr;
+            m_scene->purgeGLResources();
+            m_context = nullptr;
+        }
         m_client.didDestroyGLContext();
         m_scene = nullptr;
     });


### PR DESCRIPTION
In case of nonCompositedWebGL enabled (Lightning) egl target from renderer backend was never destroyed that was causing crash on egl backend destruction as the backend outlived the target.

This change ensures that egl target is destroyed
on LayerTreeHost and ThreadedCompositor destruction freeing native window.

Also need to ensure that static window context from NicosiaGCGLLayer is destroyed before egl target destruction (otherwise it will crash). Add ref counting and destroy global window context when no longer needed.
(Can be recreated if neccesary)