### PR TITLE
[wpe-2.38] Cancel all async tasks scheduled on destruction

### DIFF
--- a/Source/WebCore/platform/AbortableTaskQueue.h
+++ b/Source/WebCore/platform/AbortableTaskQueue.h
@@ -75,6 +75,7 @@ public:
         ASSERT(isMainThread());
         ASSERT(!m_lock.isHeld());
         ASSERT(m_channel.isEmpty());
+        startAborting();
     }
 
     // ===========================

--- a/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp
@@ -142,8 +142,10 @@ TrackPrivateBaseGStreamer::~TrackPrivateBaseGStreamer()
 
 void TrackPrivateBaseGStreamer::disconnect()
 {
-    if (m_stream)
+    if (m_stream) {
         g_signal_handlers_disconnect_matched(m_stream.get(), G_SIGNAL_MATCH_DATA, 0, 0, nullptr, nullptr, this);
+        ASSERT(0 == g_signal_handler_find(m_stream.get(), G_SIGNAL_MATCH_UNBLOCKED, 0, 0, nullptr, nullptr, nullptr));
+    }
 
     m_tags.clear();
 
@@ -155,8 +157,11 @@ void TrackPrivateBaseGStreamer::disconnect()
         m_bestUpstreamPad.clear();
     }
 
-    if (m_pad)
+    if (m_pad) {
+        g_signal_handlers_disconnect_matched(m_pad.get(), G_SIGNAL_MATCH_DATA, 0, 0, nullptr, nullptr, this);
+        ASSERT(0 == g_signal_handler_find(m_pad.get(), G_SIGNAL_MATCH_UNBLOCKED, 0, 0, nullptr, nullptr, nullptr));
         m_pad.clear();
+    }
 }
 
 void TrackPrivateBaseGStreamer::tagsChanged()


### PR DESCRIPTION
Problem: On launching HBOMax app on Comcast STBs (user is already logged into the app) app plays a ~4 second video and on completion destructs the pipeline. Soon after that there is a crash with below signature

Version : wpe-2.38 (39d3d180b2)

```
#0  std::__exchange<WebCore::AbortableTaskQueue::Task*, decltype(nullptr)&>(WebCore::AbortableTaskQueue::Task*&, decltype(nullptr)&) () at ../recipe-sysroot/usr/include/c++/9.3.0/bits/move.h:151
#1  std::exchange<WebCore::AbortableTaskQueue::Task*, decltype(nullptr)&>(WebCore::AbortableTaskQueue::Task*&, decltype(nullptr)&) () at ../recipe-sysroot/usr/include/c++/9.3.0/utility:287
#2  WTF::RawPtrTraits<WebCore::AbortableTaskQueue::Task>::exchange<decltype(nullptr)>(WebCore::AbortableTaskQueue::Task*&, decltype(nullptr)&&) () at WTF/Headers/wtf/RawPtrTraits.h:41
#3  WTF::Ref<WebCore::AbortableTaskQueue::Task, WTF::RawPtrTraits<WebCore::AbortableTaskQueue::Task> >::~Ref () at WTF/Headers/wtf/Ref.h:60
#4  WTF::VectorDestructor<true, WTF::Ref<WebCore::AbortableTaskQueue::Task, WTF::RawPtrTraits<WebCore::AbortableTaskQueue::Task> > >::destruct () at WTF/Headers/wtf/Vector.h:69
#5  WTF::VectorTypeOperations<WTF::Ref<WebCore::AbortableTaskQueue::Task, WTF::RawPtrTraits<WebCore::AbortableTaskQueue::Task> > >::destruct () at WTF/Headers/wtf/Vector.h:252
#6  WTF::Deque<WTF::Ref<WebCore::AbortableTaskQueue::Task, WTF::RawPtrTraits<WebCore::AbortableTaskQueue::Task> >, 0u>::removeFirst () at WTF/Headers/wtf/Deque.h:503
#7  WebCore::AbortableTaskQueue::Task::dispatch () at ../git/Source/WebCore/platform/AbortableTaskQueue.h:204
#8  WebCore::AbortableTaskQueue::postTask(WTF::Function<void ()>&&)::{lambda()#1}::operator()() const () at ../git/Source/WebCore/platform/AbortableTaskQueue.h:223
#9  WTF::Detail::CallableWrapper<WebCore::AbortableTaskQueue::postTask(WTF::Function<void ()>&&)::{lambda()#1}, void>::call() () at WTF/Headers/wtf/Function.h:53
#10 0xb25a0732 in WTF::Function<void ()>::operator()() const () at ../git/Source/WTF/wtf/Function.h:82
#11 WTF::RunLoop::performWork () at ../git/Source/WTF/wtf/RunLoop.cpp:134
#12 0xb25d7522 in operator() () at ../git/Source/WTF/wtf/glib/RunLoopGLib.cpp:80
#13 _FUN () at ../git/Source/WTF/wtf/glib/RunLoopGLib.cpp:82
#14 0xb25d7d70 in operator() () at ../git/Source/WTF/wtf/glib/RunLoopGLib.cpp:53
#15 _FUN () at ../git/Source/WTF/wtf/glib/RunLoopGLib.cpp:56
#16 0xb05cdbe8 in g_main_dispatch (context=0x7eb56638) at ../glib-2.62.4/glib/gmain.c:3216
#17 g_main_context_dispatch (context=context@entry=0x7eb56638) at ../glib-2.62.4/glib/gmain.c:3885
#18 0xb05cdd52 in g_main_context_iterate (context=0x7eb56638, block=block@entry=1, dispatch=dispatch@entry=1, self=<optimized out>) at ../glib-2.62.4/glib/gmain.c:3958
#19 0xb05ce08c in g_main_loop_run (loop=0x7eb57150) at ../glib-2.62.4/glib/gmain.c:4152
#20 0xb25d8010 in WTF::RunLoop::run () at ../git/Source/WTF/wtf/glib/RunLoopGLib.cpp:108
#21 0xb1d6c802 in WebKit::AuxiliaryProcessMainBase<WebKit::WebProcess, true>::run () at ../git/Source/WebKit/Shared/AuxiliaryProcessMain.h:71
#22 WebKit::AuxiliaryProcessMainBase<WebKit::WebProcess, true>::run () at ../git/Source/WebKit/Shared/AuxiliaryProcessMain.h:58
#23 WebKit::AuxiliaryProcessMain<WebKit::WebProcessMainWPE> () at ../git/Source/WebKit/Shared/AuxiliaryProcessMain.h:97
#24 0xb16b698e in __libc_start_main (main=0x7d60d545 <main()>, argc=3, argv=0xbbca0714, init=<optimized out>, fini=0x7d60d699 <__libc_csu_fini>, rtld_fini=0xb3f53099 <_dl_fini>, stack_end=0xbbca0714) at libc-start.c:308
#25 0x7d60d57c in _start () at start.S:112
```

```
2023 Oct 25 16:00:59.618058 LightningApp-0[4906]:  HTML5 video: Player constructed [0x9dd2a600]
2023 Oct 25 16:00:59.618193 LightningApp-0[4906]:  HTML5 video: Loading [https://<hbomaxurl>/outro.6de0c5915653eff4b2dc7648d3927ca0.sha.mp4]
2023 Oct 25 16:00:59.628863 LightningApp-0[4906]:  HTML5 video: Pause [https://<hbomaxurl>/outro.6de0c5915653eff4b2dc7648d3927ca0.sha.mp4]
...
2023 Oct 25 16:01:03.351752 LightningApp-0[4906]:  HTML5 video: Player Destroyed [0x9dd2a600]
...
2023 Oct 25 16:01:06.120051 LightningApp-0[4906]:  pid 8 has terminated (return code 1)
2023 Oct 25 16:01:06.125605 WPEFramework[6615]:  231025-16:01:06.121 [Warning] [tid=9092] OnPluginStateChange:Service.cpp:229 Service::OnPluginStateChange [LightningApp-0 - Deactivation, Failure]
```

It looks like the async task posted by MediaPlayerPrivateGStreamer->TrackPrivateBaseGStreamer on AbortableTaskQueue is dispatched after the Player is destructed. AbortableTaskQueue is composited inside TrackPrivateBaseGStreamer and gets destructed along with Player & TrackPrivateBase.