### PR TITLE
[wpe-2.38] Fix crash upon trying to add fence sync

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerBuffer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerBuffer.cpp
@@ -187,7 +187,10 @@ bool TextureMapperPlatformLayerBuffer::isHolePunchBuffer()
 
 void TextureMapperPlatformLayerBuffer::addFenceSyncIfAvailable()
 {
-    unsigned version = GLContext::current()->version();
+    GLContext* const currentGLContext = GLContext::current();
+    if (!currentGLContext)
+        return;
+    unsigned version = currentGLContext->version();
     if (version >= 300 && glFenceSync) {
         // GLES 3, so fences are available and we can use them.
         m_sync = static_cast<void*>(glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0));


### PR DESCRIPTION
This PR attempts fixing #1239 just by adding simple `nullptr` check. I'm not sure if this is enough i.e. if it's valid that `GLContext::current()` may be null at this point, although judging by same check being done in the same class in `TextureMapperPlatformLayerBuffer::clone()` it likely may be.

Should be reviewed by @magomez 