### PR TITLE
[GTK/WPE] Web Inspector: crash in remote web inspector when connectio…

### DIFF
--- a/Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorServer.cpp
+++ b/Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorServer.cpp
@@ -326,7 +326,9 @@ void RemoteInspectorServer::sendMessageToFrontend(SocketConnection& remoteInspec
 
     uint64_t connectionID = m_remoteInspectorConnectionToIDMap.get(&remoteInspectorConnection);
     auto connectionTargetPair = std::make_pair(connectionID, targetID);
-    ASSERT(m_automationTargets.contains(connectionTargetPair) || m_inspectionTargets.contains(connectionTargetPair));
+    if (!m_automationTargets.contains(connectionTargetPair) && !m_inspectionTargets.contains(connectionTargetPair))
+        return;
+
     SocketConnection* clientConnection = m_inspectionTargets.contains(connectionTargetPair) ? m_clientConnection : m_automationConnection;
     ASSERT(clientConnection);
     clientConnection->sendMessage("SendMessageToFrontend", g_variant_new("(tt&s)", connectionID, targetID, message));


### PR DESCRIPTION
…n closed during data transfer

https://bugs.webkit.org/show_bug.cgi?id=265304

Reviewed by Carlos Garcia Campos.

It seems that after closing remote web inspector connection it is possible that some of messages can be still sent from WebProcess to UIProcess and in RemoteInspectorServer::sendMessageToFrontend there can be a crash because of missing socketConnection which was removed by previous closing remote web inspector connection(RemoteInspectorServer::close).

* Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorServer.cpp: (Inspector::RemoteInspectorServer::sendMessageToFrontend):

Canonical link: https://commits.webkit.org/271097@main
