### PR TITLE
[MSE SourceBuffer] Disable audio flush on samples replacement for Spo…

### DIFF
--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -101,6 +101,10 @@ SourceBuffer::SourceBuffer(Ref<SourceBufferPrivate>&& sourceBufferPrivate, Media
 
     m_private->setClient(this);
     m_private->setIsAttached(true);
+
+    if (document().quirks().shouldBypassAudioFlushOnSampleReplacement()) {
+        m_private->setShouldBypassAudioFlushOnSampleReplacement(true);
+    }
 }
 
 SourceBuffer::~SourceBuffer()

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1490,4 +1490,22 @@ bool Quirks::shouldDisableLazyImageLoadingQuirk() const
     return m_shouldDisableLazyImageLoadingQuirk.value();
 }
 
+#if ENABLE(MEDIA_SOURCE)
+bool Quirks::shouldBypassAudioFlushOnSampleReplacement() const
+{
+    if (!needsQuirks())
+        return false;
+
+    if (m_shouldBypassAudioFlushOnSampleReplacementQuirk)
+        return m_shouldBypassAudioFlushOnSampleReplacementQuirk.value();
+
+    auto domain = m_document->securityOrigin().domain().convertToASCIILowercase();
+
+    m_shouldBypassAudioFlushOnSampleReplacementQuirk =
+        (domain.endsWith(".spotify.com"_s) || domain == "tv.scdn.co"_s);
+
+    return m_shouldBypassAudioFlushOnSampleReplacementQuirk.value();
+}
+#endif
+
 }

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -162,6 +162,10 @@ public:
 
     bool shouldDisableLazyImageLoadingQuirk() const;
     
+#if ENABLE(MEDIA_SOURCE)
+    bool shouldBypassAudioFlushOnSampleReplacement() const;
+#endif
+
 private:
     bool needsQuirks() const;
 
@@ -217,6 +221,10 @@ private:
     mutable std::optional<bool> m_needsVideoShouldMaintainAspectRatioQuirk;
     mutable std::optional<bool> m_shouldExposeShowModalDialog;
     mutable std::optional<bool> m_shouldDisableLazyImageLoadingQuirk;
+#if ENABLE(MEDIA_SOURCE)
+    mutable std::optional<bool> m_shouldBypassAudioFlushOnSampleReplacementQuirk;
+#endif
+
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
@@ -1022,7 +1022,7 @@ void SourceBufferPrivate::didReceiveSample(Ref<MediaSample>&& originalSample)
             // Only force the TrackBuffer to re-enqueue if the removed ranges overlap with enqueued and possibly
             // not yet displayed samples.
             MediaTime currentTime = currentMediaTime();
-            if (trackBuffer.highestEnqueuedPresentationTime().isValid() && currentTime < trackBuffer.highestEnqueuedPresentationTime()) {
+            if (trackBuffer.highestEnqueuedPresentationTime().isValid() && currentTime < trackBuffer.highestEnqueuedPresentationTime() && (!hasAudio() || !m_shouldBypassAudioFlushOnSampleReplacement)) {
                 PlatformTimeRanges possiblyEnqueuedRanges(currentTime, trackBuffer.highestEnqueuedPresentationTime());
                 possiblyEnqueuedRanges.intersectWith(erasedRanges);
                 if (possiblyEnqueuedRanges.length())

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.h
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.h
@@ -130,6 +130,7 @@ public:
     virtual const void* sourceBufferLogIdentifier() = 0;
 #endif
 
+    void setShouldBypassAudioFlushOnSampleReplacement(bool flag) { m_shouldBypassAudioFlushOnSampleReplacement = flag; }
 protected:
     // The following method should never be called directly and be overridden instead.
     WEBCORE_EXPORT virtual void append(Vector<unsigned char>&&);
@@ -193,6 +194,7 @@ private:
 
     bool m_isMediaSourceEnded { false };
     RefPtr<TimeRanges> m_buffered;
+    bool m_shouldBypassAudioFlushOnSampleReplacement { false };
 };
 
 } // namespace WebCore


### PR DESCRIPTION
…tify

With edit lists enabled recently, Spotify started to append the same segment multiple times that to samples replacement and audio flush. As a result audio is breaking on every append.

Disable audio flush on samples replacement for Spotify until this is fixed by Spotify