### PR TITLE
[wpe-2.38] Fix playback position during simulated preroll

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -1353,8 +1353,7 @@ MediaTime MediaPlayerPrivateGStreamer::playbackPosition() const
     else if (m_canFallBackToLastFinishedSeekPosition)
         playbackPosition = m_seekTime;
 
-    setCachedPosition(playbackPosition);
-    invalidateCachedPositionOnNextIteration();
+    setCachedPositionForOneIteration(playbackPosition);
     return playbackPosition;
 }
 
@@ -3613,6 +3612,12 @@ void MediaPlayerPrivateGStreamer::setCachedPosition(const MediaTime& cachedPosit
 {
     m_cachedPosition = cachedPosition;
     m_isCachedPositionValid = true;
+}
+
+void MediaPlayerPrivateGStreamer::setCachedPositionForOneIteration(const MediaTime& position) const
+{
+    setCachedPosition(position);
+    invalidateCachedPositionOnNextIteration();
 }
 
 void MediaPlayerPrivateGStreamer::invalidateCachedPosition() const

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -372,6 +372,7 @@ protected:
 #endif
 
     void setCachedPosition(const MediaTime&) const;
+    void setCachedPositionForOneIteration(const MediaTime&) const;
 
     Ref<MainThreadNotifier<MainThreadNotification>> m_notifier;
     MediaPlayer* m_player;

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -276,6 +276,7 @@ bool MediaPlayerPrivateGStreamerMSE::doSeek(const MediaTime& position, float rat
             m_player->queueTaskOnEventLoop([weakThis = WeakPtr { *this }, this] {
                 if (!weakThis)
                     return;
+                setCachedPositionForOneIteration(m_seekTime);
                 didPreroll();
             });
         }


### PR DESCRIPTION
When simulating preroll in MSE, the player sets `m_isSeeking = false` immediately despite the actual preroll may not be done yet and hence playback position may not yield correct results at that time.

CC @calvaris 