### PR TITLE
Blob should report memory cost

### DIFF
--- a/Source/WebCore/fileapi/Blob.cpp
+++ b/Source/WebCore/fileapi/Blob.cpp
@@ -155,6 +155,7 @@ Blob::Blob(ScriptExecutionContext* context, Vector<uint8_t>&& data, const String
     , m_type(contentType)
     , m_size(data.size())
     , m_internalURL(BlobURL::createInternalURL())
+    , m_memoryCost(data.size())
 {
     ThreadableBlobRegistry::registerBlobURL(m_internalURL, { BlobPart(WTFMove(data)) }, contentType);
 }
@@ -381,6 +382,11 @@ BlobURLHandle Blob::handle() const
 WebCoreOpaqueRoot root(Blob* blob)
 {
     return WebCoreOpaqueRoot { blob };
+}
+
+size_t Blob::memoryCost() const
+{
+    return m_memoryCost;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/fileapi/Blob.h
+++ b/Source/WebCore/fileapi/Blob.h
@@ -121,6 +121,8 @@ public:
     // Keeping the handle alive will keep the Blob data alive (but not the Blob object).
     BlobURLHandle handle() const;
 
+    size_t memoryCost() const;
+
 protected:
     WEBCORE_EXPORT explicit Blob(ScriptExecutionContext*);
     Blob(ScriptExecutionContext&, Vector<BlobPartVariant>&&, const BlobPropertyBag&);
@@ -153,6 +155,8 @@ private:
     URL m_internalURL;
 
     HashSet<std::unique_ptr<BlobLoader>> m_blobLoaders;
+
+    std::atomic<size_t> m_memoryCost { 0 };
 };
 
 WebCoreOpaqueRoot root(Blob*);

--- a/Source/WebCore/fileapi/Blob.idl
+++ b/Source/WebCore/fileapi/Blob.idl
@@ -36,6 +36,7 @@ typedef (BufferSource or Blob or USVString) BlobPart;
     Exposed=(Window,Worker),
     GenerateIsReachable=Impl,
     CustomToJSObject,
+    ReportExtraMemoryCost,
 ] interface Blob {
     [CallWith=CurrentScriptExecutionContext] constructor(optional sequence<BlobPart> blobParts, optional BlobPropertyBag options);
 


### PR DESCRIPTION
At least for blobs allocated via XHRs. 

This resolves the high memory usage seen in network process after application allocated a lot of blobs.  

Here is a simple test page: https://github.com/emutavchi/tests/blob/master/lng/image-worker-test/test.html 
