### PR TITLE
Fix LTO build

### DIFF
--- a/Source/ThirdParty/libwebrtc/CMakeLists.txt
+++ b/Source/ThirdParty/libwebrtc/CMakeLists.txt
@@ -81,7 +81,6 @@ set(webrtc_SOURCES
     Source/third_party/abseil-cpp/absl/synchronization/notification.cc
     Source/third_party/abseil-cpp/absl/hash/internal/wyhash.cc
     Source/third_party/abseil-cpp/absl/hash/internal/hash.cc
-    Source/third_party/abseil-cpp/absl/hash/internal/print_hash_of.cc
     Source/third_party/abseil-cpp/absl/hash/internal/city.cc
     Source/third_party/abseil-cpp/absl/debugging/symbolize.cc
     Source/third_party/abseil-cpp/absl/debugging/failure_signal_handler.cc
@@ -119,7 +118,6 @@ set(webrtc_SOURCES
     Source/third_party/abseil-cpp/absl/random/gaussian_distribution.cc
     Source/third_party/abseil-cpp/absl/random/discrete_distribution.cc
     Source/third_party/abseil-cpp/absl/random/seed_gen_exception.cc
-    Source/third_party/abseil-cpp/absl/random/internal/gaussian_distribution_gentables.cc
     Source/third_party/abseil-cpp/absl/random/internal/seed_material.cc
     Source/third_party/abseil-cpp/absl/random/internal/randen_slow.cc
     Source/third_party/abseil-cpp/absl/random/internal/chi_square.cc
@@ -240,11 +238,6 @@ set(webrtc_SOURCES
     Source/third_party/boringssl/src/crypto/evp/sign.c
     Source/third_party/boringssl/src/crypto/ex_data.c
     Source/third_party/boringssl/src/crypto/fipsmodule/bcm.c
-    Source/third_party/boringssl/src/crypto/fipsmodule/dh/check.c
-    Source/third_party/boringssl/src/crypto/fipsmodule/dh/dh.c
-    Source/third_party/boringssl/src/crypto/fipsmodule/ecdh/ecdh.c
-    Source/third_party/boringssl/src/crypto/fipsmodule/ec/p256.c
-    Source/third_party/boringssl/src/crypto/fipsmodule/rand/fork_detect.c
     Source/third_party/boringssl/src/crypto/hkdf/hkdf.c
     Source/third_party/boringssl/src/crypto/hpke/hpke.c
     Source/third_party/boringssl/src/crypto/hrss/hrss.c
@@ -1001,7 +994,6 @@ set(webrtc_SOURCES
     Source/webrtc/modules/audio_processing/splitting_filter.cc
     Source/webrtc/modules/audio_processing/test/conversational_speech/config.cc
     Source/webrtc/modules/audio_processing/test/conversational_speech/timing.cc
-    Source/webrtc/modules/audio_processing/test/py_quality_assessment/quality_assessment/vad.cc
     Source/webrtc/modules/audio_processing/three_band_filter_bank.cc
     Source/webrtc/modules/audio_processing/transient/file_utils.cc
     Source/webrtc/modules/audio_processing/transient/moving_moments.cc

--- a/Source/WebCore/Modules/mediastream/RTCDataChannel.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannel.cpp
@@ -104,6 +104,8 @@ RTCDataChannel::RTCDataChannel(ScriptExecutionContext& context, std::unique_ptr<
 {
 }
 
+RTCDataChannel::~RTCDataChannel() = default;
+
 std::optional<unsigned short> RTCDataChannel::id() const
 {
     if (!m_options.id && m_handler)

--- a/Source/WebCore/Modules/mediastream/RTCDataChannel.h
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannel.h
@@ -89,6 +89,7 @@ public:
     using RefCounted<RTCDataChannel>::deref;
 
     WEBCORE_EXPORT static std::unique_ptr<RTCDataChannelHandler> handlerFromIdentifier(RTCDataChannelLocalIdentifier);
+    virtual ~RTCDataChannel();
 
 private:
     RTCDataChannel(ScriptExecutionContext&, std::unique_ptr<RTCDataChannelHandler>&&, String&&, RTCDataChannelInit&&);

--- a/Source/cmake/OptionsWPE.cmake
+++ b/Source/cmake/OptionsWPE.cmake
@@ -197,6 +197,7 @@ set(bmalloc_LIBRARY_TYPE OBJECT)
 set(WTF_LIBRARY_TYPE OBJECT)
 set(JavaScriptCore_LIBRARY_TYPE OBJECT)
 set(WebCore_LIBRARY_TYPE OBJECT)
+set(PAL_LIBRARY_TYPE OBJECT)
 
 # These are shared variables, but we special case their definition so that we can use the
 # CMAKE_INSTALL_* variables that are populated by the GNUInstallDirs macro.


### PR DESCRIPTION
This PR:
- fixes link failure complaining about missing vtable entry for  'RTCDataChannel::~RTCDataChannel'
- removes compilation of test binaries in libwebrtc
- removes duplication of compilation of files already included in Source/ThirdParty/libwebrtc/Source/third_party/boringssl/src/crypto/fipsmodule/bcm.c
- changes the type of PAL library to object for WPE platform