### PR TITLE
[MSE] Ignore SourceBuffer size limit before init segment received

### DIFF
--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
@@ -560,6 +560,9 @@ void SourceBufferPrivate::evictCodedFrames(uint64_t newDataSize, uint64_t maximu
 
 bool SourceBufferPrivate::isBufferFullFor(uint64_t requiredSize, uint64_t maximumBufferSize)
 {
+    if (!m_receivedFirstInitializationSegment)
+        return false;
+
     auto totalRequired = checkedSum<uint64_t>(totalTrackBufferSizeInBytes(), requiredSize);
     if (totalRequired.hasOverflowed())
         return true;


### PR DESCRIPTION
SourceBuffer has separate max size limits for video, audio and text. But it has to parse init segment first to know if there are any video, audio or text tracks.
At the very first appendBuffer() there are not tracks parsed yet so platformMaximumBufferSize() returns 0 (as no tracks are ther) and the limit is taken from MediaElementSession as audio limit 15MB as no video track is present.

Ignore buffer overflow at the very first appendBuffer() before tracks are parsed from init segment.

The issue is visible only with high resolution start - 4K - that is rather unlikely as most of apps starts from lower resolution.
Still, if first appendBuffer() is big enough it can overflow 15MB default limit.

As a test case we can use YT cert test "72. VP9.Profile2.10Bit.PQ.2160p60" from "Format Support Tests" https://ytlr-cert.appspot.com/