### PR TITLE
Support unrestricted ports usage for custom URI schemes

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -2155,7 +2155,7 @@ bool HTMLMediaElement::isSafeToLoadURL(const URL& url, InvalidURLAction actionIf
         return false;
     }
 
-    if (!portAllowed(url)) {
+    if (!document().securityOrigin().isUnrestrictedPortsEnabled(url) && !portAllowed(url)) {
         if (actionIfInvalid == Complain) {
             if (frame)
                 FrameLoader::reportBlockedLoadFailed(*frame, url);

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -676,7 +676,7 @@ void DocumentLoader::willSendRequest(ResourceRequest&& newRequest, const Resourc
             cancelMainResourceLoad(frameLoader()->cancelledError(newRequest));
             return completionHandler(WTFMove(newRequest));
         }
-        if (!portAllowed(newRequest.url())) {
+        if (!redirectingOrigin.get().isUnrestrictedPortsEnabled(newRequest.url()) && !portAllowed(newRequest.url())) {
             DOCUMENTLOADER_RELEASE_LOG("willSendRequest: canceling - redirecting to a URL with a blocked port");
             if (m_frame)
                 FrameLoader::reportBlockedLoadFailed(*m_frame, newRequest.url());

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1259,7 +1259,7 @@ void FrameLoader::loadFrameRequest(FrameLoadRequest&& request, Event* event, Ref
         return;
     }
 
-    if (!portAllowed(url)) {
+    if (!request.requesterSecurityOrigin().isUnrestrictedPortsEnabled(url) && !portAllowed(url)) {
         FRAMELOADER_RELEASE_LOG(ResourceLoading, "loadFrameRequest: canceling - port not allowed");
         reportBlockedLoadFailed(m_frame, url);
         return;

--- a/Source/WebCore/loader/PingLoader.cpp
+++ b/Source/WebCore/loader/PingLoader.cpp
@@ -90,7 +90,7 @@ void PingLoader::loadImage(Frame& frame, const URL& url)
         return;
     }
 
-    if (!portAllowed(url)) {
+    if (!document.securityOrigin().isUnrestrictedPortsEnabled(url) && !portAllowed(url)) {
         FrameLoader::reportBlockedLoadFailed(frame, url);
         return;
     }

--- a/Source/WebCore/loader/ResourceLoader.cpp
+++ b/Source/WebCore/loader/ResourceLoader.cpp
@@ -154,7 +154,7 @@ void ResourceLoader::init(ResourceRequest&& clientRequest, CompletionHandler<voi
         return completionHandler(false);
     }
 
-    if (!portAllowed(clientRequest.url())) {
+    if (!m_frame->document()->securityOrigin().isUnrestrictedPortsEnabled(clientRequest.url()) && !portAllowed(clientRequest.url())) {
         RESOURCELOADER_RELEASE_LOG("init: Cancelling load to a blocked port.");
         FrameLoader::reportBlockedLoadFailed(*m_frame, clientRequest.url());
         releaseResources();

--- a/Source/WebCore/loader/SubframeLoader.cpp
+++ b/Source/WebCore/loader/SubframeLoader.cpp
@@ -136,7 +136,7 @@ bool FrameLoader::SubframeLoader::pluginIsLoadable(const URL& url)
             return false;
         }
 
-        if (!portAllowed(url)) {
+        if (!document->securityOrigin().isUnrestrictedPortsEnabled(url) && !portAllowed(url)) {
             FrameLoader::reportBlockedLoadFailed(m_frame, url);
             return false;
         }
@@ -268,7 +268,7 @@ RefPtr<Frame> FrameLoader::SubframeLoader::loadSubframe(HTMLFrameOwnerElement& o
         return nullptr;
     }
 
-    if (!portAllowed(url)) {
+    if (!document->securityOrigin().isUnrestrictedPortsEnabled(url) && !portAllowed(url)) {
         FrameLoader::reportBlockedLoadFailed(m_frame, url);
         return nullptr;
     }

--- a/Source/WebCore/loader/SubresourceLoader.cpp
+++ b/Source/WebCore/loader/SubresourceLoader.cpp
@@ -297,7 +297,7 @@ void SubresourceLoader::willSendRequestInternal(ResourceRequest&& newRequest, co
             return completionHandler(WTFMove(newRequest));
         }
 
-        if (!portAllowed(newRequest.url())) {
+        if (!(m_origin && m_origin->isUnrestrictedPortsEnabled(newRequest.url())) && !portAllowed(newRequest.url())) {
             SUBRESOURCELOADER_RELEASE_LOG("willSendRequestInternal: resource load (redirect) canceled because it attempted to use a blocked port");
             if (m_frame)
                 FrameLoader::reportBlockedLoadFailed(*m_frame, newRequest.url());

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -905,7 +905,9 @@ ResourceErrorOr<CachedResourceHandle<CachedResource>> CachedResourceLoader::requ
         return makeUnexpected(ResourceError { errorDomainWebKitInternal, 0, url, "Not allowed to request resource"_s, ResourceError::Type::AccessControl });
     }
 
-    if (!portAllowed(url)) {
+    auto requestedOrigin = SecurityOrigin::create(url);
+
+    if (!requestedOrigin->isUnrestrictedPortsEnabled(url) && !portAllowed(url)) {
         if (forPreload == ForPreload::No)
             FrameLoader::reportBlockedLoadFailed(frame, url);
         CACHEDRESOURCELOADER_RELEASE_LOG_WITH_FRAME("CachedResourceLoader::requestResource URL has a blocked port", frame);
@@ -950,7 +952,6 @@ ResourceErrorOr<CachedResourceHandle<CachedResource>> CachedResourceLoader::requ
 
     if (m_documentLoader && !m_documentLoader->customHeaderFields().isEmpty()) {
         bool sameOriginRequest = false;
-        auto requestedOrigin = SecurityOrigin::create(url);
         if (type == CachedResource::Type::MainResource) {
             if (frame.isMainFrame())
                 sameOriginRequest = true;

--- a/Source/WebCore/page/SecurityOrigin.cpp
+++ b/Source/WebCore/page/SecurityOrigin.cpp
@@ -619,4 +619,9 @@ bool SecurityOrigin::isLocalHostOrLoopbackIPAddress(StringView host)
     return false;
 }
 
+bool SecurityOrigin::isUnrestrictedPortsEnabled(const URL& url) const
+{
+    return LegacySchemeRegistry::shouldTreatURLSchemeAsUnrestrictedPortsEnabled(url.protocol());
+}
+
 } // namespace WebCore

--- a/Source/WebCore/page/SecurityOrigin.h
+++ b/Source/WebCore/page/SecurityOrigin.h
@@ -207,6 +207,9 @@ public:
 
     WEBCORE_EXPORT static bool isLocalHostOrLoopbackIPAddress(StringView);
 
+    // Returns true if this SecurityOrigin can have access to all ports
+    WEBCORE_EXPORT bool isUnrestrictedPortsEnabled(const URL&) const;
+
     const SecurityOriginData& data() const { return m_data; }
 
     template<class Encoder> void encode(Encoder&) const;

--- a/Source/WebCore/platform/LegacySchemeRegistry.cpp
+++ b/Source/WebCore/platform/LegacySchemeRegistry.cpp
@@ -538,4 +538,25 @@ bool LegacySchemeRegistry::isBuiltinScheme(const String& scheme)
     return !scheme.isNull() && (allBuiltinSchemes().contains(scheme) || WTF::URLParser::isSpecialScheme(scheme));
 }
 
+static URLSchemesMap& unrestrictedPortsURLSchemes() WTF_REQUIRES_LOCK(schemeRegistryLock)
+{
+    ASSERT(schemeRegistryLock.isHeld());
+    static NeverDestroyed<URLSchemesMap> unrestrictedPortsURLSchemes;
+    return unrestrictedPortsURLSchemes;
+}
+
+void LegacySchemeRegistry::registerURLSchemeAsUnrestrictedPortsEnabled(const String& scheme)
+{
+    ASSERT(!isInNetworkProcess());
+    if (scheme.isNull())
+        return;
+    unrestrictedPortsURLSchemes().add(scheme);
+}
+
+bool LegacySchemeRegistry::shouldTreatURLSchemeAsUnrestrictedPortsEnabled(const StringView& scheme)
+{
+    ASSERT(!isInNetworkProcess());
+    return !scheme.isNull() && unrestrictedPortsURLSchemes().contains<StringViewHashTranslator>(scheme);
+}
+
 } // namespace WebCore

--- a/Source/WebCore/platform/LegacySchemeRegistry.h
+++ b/Source/WebCore/platform/LegacySchemeRegistry.h
@@ -101,6 +101,10 @@ public:
     static bool shouldPartitionCacheForURLScheme(const String& scheme); // Thread safe.
 
     static bool isUserExtensionScheme(StringView scheme);
+
+    // Allow non-network related URL schemes to be registered to allow making requests without ports restrictions.
+    WEBCORE_EXPORT static void registerURLSchemeAsUnrestrictedPortsEnabled(const String& scheme);
+    WEBCORE_EXPORT static bool shouldTreatURLSchemeAsUnrestrictedPortsEnabled(const StringView& scheme);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/network/ResourceHandle.cpp
+++ b/Source/WebCore/platform/network/ResourceHandle.cpp
@@ -85,7 +85,7 @@ ResourceHandle::ResourceHandle(NetworkingContext* context, const ResourceRequest
         return;
     }
 
-    if (!portAllowed(request.url())) {
+    if (!(d->m_sourceOrigin && d->m_sourceOrigin->isUnrestrictedPortsEnabled(request.url())) && !portAllowed(request.url())) {
         scheduleFailure(BlockedFailure);
         return;
     }

--- a/Source/WebKit/Shared/WebProcessCreationParameters.cpp
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.cpp
@@ -69,6 +69,7 @@ void WebProcessCreationParameters::encode(IPC::Encoder& encoder) const
     encoder << urlSchemesRegisteredAsAlwaysRevalidated;
     encoder << urlSchemesRegisteredAsCachePartitioned;
     encoder << urlSchemesRegisteredAsCanDisplayOnlyIfCanRequest;
+    encoder << urlSchemesRegisteredAsUnrestrictedPortsEnabled;
     encoder << cacheModel;
     encoder << shouldAlwaysUseComplexTextCodePath;
     encoder << shouldEnableMemoryPressureReliefLogging;
@@ -279,6 +280,8 @@ bool WebProcessCreationParameters::decode(IPC::Decoder& decoder, WebProcessCreat
     if (!decoder.decode(parameters.urlSchemesRegisteredAsCachePartitioned))
         return false;
     if (!decoder.decode(parameters.urlSchemesRegisteredAsCanDisplayOnlyIfCanRequest))
+        return false;
+    if (!decoder.decode(parameters.urlSchemesRegisteredAsUnrestrictedPortsEnabled))
         return false;
     if (!decoder.decode(parameters.cacheModel))
         return false;

--- a/Source/WebKit/Shared/WebProcessCreationParameters.h
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.h
@@ -103,6 +103,7 @@ struct WebProcessCreationParameters {
     Vector<String> urlSchemesRegisteredAsAlwaysRevalidated;
     Vector<String> urlSchemesRegisteredAsCachePartitioned;
     Vector<String> urlSchemesRegisteredAsCanDisplayOnlyIfCanRequest;
+    Vector<String> urlSchemesRegisteredAsUnrestrictedPortsEnabled;
 
     Vector<String> fontAllowList;
     Vector<String> overrideLanguages;

--- a/Source/WebKit/UIProcess/API/wpe/WebKitSecurityManager.h
+++ b/Source/WebKit/UIProcess/API/wpe/WebKitSecurityManager.h
@@ -58,55 +58,63 @@ struct _WebKitSecurityManagerClass {
 };
 
 WEBKIT_API GType
-webkit_security_manager_get_type                                (void);
+webkit_security_manager_get_type                                            (void);
 
 WEBKIT_API void
-webkit_security_manager_register_uri_scheme_as_local            (WebKitSecurityManager *security_manager,
-                                                                 const gchar           *scheme);
+webkit_security_manager_register_uri_scheme_as_local                        (WebKitSecurityManager *security_manager,
+                                                                             const gchar           *scheme);
 
 WEBKIT_API gboolean
-webkit_security_manager_uri_scheme_is_local                     (WebKitSecurityManager *security_manager,
-                                                                 const gchar           *scheme);
+webkit_security_manager_uri_scheme_is_local                                 (WebKitSecurityManager *security_manager,
+                                                                             const gchar           *scheme);
 
 WEBKIT_API void
-webkit_security_manager_register_uri_scheme_as_no_access        (WebKitSecurityManager *security_manager,
-                                                                 const gchar           *scheme);
+webkit_security_manager_register_uri_scheme_as_no_access                    (WebKitSecurityManager *security_manager,
+                                                                             const gchar           *scheme);
 
 WEBKIT_API gboolean
-webkit_security_manager_uri_scheme_is_no_access                 (WebKitSecurityManager *security_manager,
-                                                                 const gchar           *scheme);
+webkit_security_manager_uri_scheme_is_no_access                             (WebKitSecurityManager *security_manager,
+                                                                             const gchar           *scheme);
 
 WEBKIT_API void
-webkit_security_manager_register_uri_scheme_as_display_isolated (WebKitSecurityManager *security_manager,
-                                                                 const gchar           *scheme);
+webkit_security_manager_register_uri_scheme_as_display_isolated             (WebKitSecurityManager *security_manager,
+                                                                             const gchar           *scheme);
 
 WEBKIT_API gboolean
-webkit_security_manager_uri_scheme_is_display_isolated          (WebKitSecurityManager *security_manager,
-                                                                 const gchar           *scheme);
+webkit_security_manager_uri_scheme_is_display_isolated                      (WebKitSecurityManager *security_manager,
+                                                                             const gchar           *scheme);
 
 WEBKIT_API void
-webkit_security_manager_register_uri_scheme_as_secure           (WebKitSecurityManager *security_manager,
-                                                                 const gchar           *scheme);
+webkit_security_manager_register_uri_scheme_as_secure                       (WebKitSecurityManager *security_manager,
+                                                                             const gchar           *scheme);
 
 WEBKIT_API gboolean
-webkit_security_manager_uri_scheme_is_secure                    (WebKitSecurityManager *security_manager,
-                                                                 const gchar           *scheme);
+webkit_security_manager_uri_scheme_is_secure                                (WebKitSecurityManager *security_manager,
+                                                                             const gchar           *scheme);
 
 WEBKIT_API void
-webkit_security_manager_register_uri_scheme_as_cors_enabled     (WebKitSecurityManager *security_manager,
-                                                                 const gchar           *scheme);
+webkit_security_manager_register_uri_scheme_as_cors_enabled                 (WebKitSecurityManager *security_manager,
+                                                                             const gchar           *scheme);
 
 WEBKIT_API gboolean
-webkit_security_manager_uri_scheme_is_cors_enabled              (WebKitSecurityManager *security_manager,
-                                                                 const gchar           *scheme);
+webkit_security_manager_uri_scheme_is_cors_enabled                          (WebKitSecurityManager *security_manager,
+                                                                             const gchar           *scheme);
 
 WEBKIT_API void
-webkit_security_manager_register_uri_scheme_as_empty_document   (WebKitSecurityManager *security_manager,
-                                                                 const gchar           *scheme);
+webkit_security_manager_register_uri_scheme_as_empty_document               (WebKitSecurityManager *security_manager,
+                                                                             const gchar           *scheme);
 
 WEBKIT_API gboolean
-webkit_security_manager_uri_scheme_is_empty_document            (WebKitSecurityManager *security_manager,
-                                                                 const gchar           *scheme);
+webkit_security_manager_uri_scheme_is_empty_document                        (WebKitSecurityManager *security_manager,
+                                                                             const gchar           *scheme);
+
+WEBKIT_API void
+webkit_security_manager_register_uri_scheme_as_unrestricted_ports_enabled   (WebKitSecurityManager *security_manager,
+                                                                             const gchar           *scheme);
+
+WEBKIT_API gboolean
+webkit_security_manager_uri_scheme_is_unrestricted_ports_enabled            (WebKitSecurityManager *security_manager,
+                                                                             const gchar           *scheme);
 
 G_END_DECLS
 

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -809,6 +809,7 @@ void WebProcessPool::initializeNewWebProcess(WebProcessProxy& process, WebsiteDa
     parameters.urlSchemesRegisteredAsAlwaysRevalidated = copyToVector(m_schemesToRegisterAsAlwaysRevalidated);
     parameters.urlSchemesRegisteredAsCachePartitioned = copyToVector(m_schemesToRegisterAsCachePartitioned);
     parameters.urlSchemesRegisteredAsCanDisplayOnlyIfCanRequest = copyToVector(m_schemesToRegisterAsCanDisplayOnlyIfCanRequest);
+    parameters.urlSchemesRegisteredAsUnrestrictedPortsEnabled = copyToVector(m_schemesToRegisterAsUnrestrictedPortsEnabled);
 
     parameters.shouldAlwaysUseComplexTextCodePath = m_alwaysUsesComplexTextCodePath;
     parameters.shouldUseFontSmoothing = m_shouldUseFontSmoothing;
@@ -1350,6 +1351,12 @@ void WebProcessPool::registerURLSchemeAsCORSEnabled(const String& urlScheme)
 {
     m_schemesToRegisterAsCORSEnabled.add(urlScheme);
     sendToAllProcesses(Messages::WebProcess::RegisterURLSchemeAsCORSEnabled(urlScheme));
+}
+
+void WebProcessPool::registerURLSchemeAsUnrestrictedPortsEnabled(const String& urlScheme)
+{
+    m_schemesToRegisterAsUnrestrictedPortsEnabled.add(urlScheme);
+    sendToAllProcesses(Messages::WebProcess::RegisterURLSchemeAsUnrestrictedPortsEnabled(urlScheme));
 }
 
 void WebProcessPool::registerGlobalURLSchemeAsHavingCustomProtocolHandlers(const String& urlScheme)

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -272,6 +272,7 @@ public:
     void registerURLSchemeAsCORSEnabled(const String&);
     void registerURLSchemeAsCachePartitioned(const String&);
     void registerURLSchemeAsCanDisplayOnlyIfCanRequest(const String&);
+    void registerURLSchemeAsUnrestrictedPortsEnabled(const String&);
 
     VisitedLinkStore& visitedLinkStore() { return m_visitedLinkStore.get(); }
 
@@ -663,6 +664,7 @@ private:
     HashSet<String> m_schemesToRegisterAsAlwaysRevalidated;
     HashSet<String> m_schemesToRegisterAsCachePartitioned;
     HashSet<String> m_schemesToRegisterAsCanDisplayOnlyIfCanRequest;
+    HashSet<String> m_schemesToRegisterAsUnrestrictedPortsEnabled;
 
     bool m_alwaysUsesComplexTextCodePath { false };
     bool m_shouldUseFontSmoothing { true };

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -570,6 +570,9 @@ void WebProcess::initializeWebProcess(WebProcessCreationParameters&& parameters)
     for (auto& scheme : parameters.urlSchemesRegisteredAsCanDisplayOnlyIfCanRequest)
         registerURLSchemeAsCanDisplayOnlyIfCanRequest(scheme);
 
+    for (auto& scheme : parameters.urlSchemesRegisteredAsUnrestrictedPortsEnabled)
+        registerURLSchemeAsUnrestrictedPortsEnabled(scheme);
+
     setDefaultRequestTimeoutInterval(parameters.defaultRequestTimeoutInterval);
 
     setBackForwardCacheCapacity(parameters.backForwardCacheCapacity);
@@ -775,6 +778,11 @@ void WebProcess::registerURLSchemeAsCachePartitioned(const String& urlScheme) co
 void WebProcess::registerURLSchemeAsCanDisplayOnlyIfCanRequest(const String& urlScheme) const
 {
     LegacySchemeRegistry::registerAsCanDisplayOnlyIfCanRequest(urlScheme);
+}
+
+void WebProcess::registerURLSchemeAsUnrestrictedPortsEnabled(const String& urlScheme) const
+{
+    LegacySchemeRegistry::registerURLSchemeAsUnrestrictedPortsEnabled(urlScheme);
 }
 
 void WebProcess::setDefaultRequestTimeoutInterval(double timeoutInterval)

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -429,6 +429,7 @@ private:
     void registerURLSchemeAsAlwaysRevalidated(const String&) const;
     void registerURLSchemeAsCachePartitioned(const String&) const;
     void registerURLSchemeAsCanDisplayOnlyIfCanRequest(const String&) const;
+    void registerURLSchemeAsUnrestrictedPortsEnabled(const String& urlScheme) const;
 
     void setDefaultRequestTimeoutInterval(double);
     void setAlwaysUsesComplexTextCodePath(bool);

--- a/Source/WebKit/WebProcess/WebProcess.messages.in
+++ b/Source/WebKit/WebProcess/WebProcess.messages.in
@@ -41,6 +41,7 @@ messages -> WebProcess LegacyReceiver NotRefCounted {
     RegisterURLSchemeAsCORSEnabled(String scheme)
     RegisterURLSchemeAsCachePartitioned(String scheme)
     RegisterURLSchemeAsCanDisplayOnlyIfCanRequest(String scheme)
+    RegisterURLSchemeAsUnrestrictedPortsEnabled(String scheme)
 
     SetDefaultRequestTimeoutInterval(double timeoutInterval)
     SetAlwaysUsesComplexTextCodePath(bool alwaysUseComplexText)


### PR DESCRIPTION
Some custom URI schemes may assign a different meaning to the port of an URI. Webkit restricts, by default, usage of certain ports. The new API allows configuring which URI schemes are allowed to use all ports. Network based schemes, such as http, continue to have the ports restriction in place and bypass is not possible using the new API.
