### PR TITLE
[MSE SourceBuffer] Reset extra memory cost inside removedFromMediaSou…

### DIFF
--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -445,6 +445,7 @@ void SourceBuffer::removedFromMediaSource()
     m_private->removedFromMediaSource();
     m_private->setIsAttached(false);
     m_source = nullptr;
+    m_extraMemoryCost = 0;
 }
 
 void SourceBuffer::seekToTime(const MediaTime& time)


### PR DESCRIPTION
…rce()

This allows SourceBuffer that was removed from media source to report memory that is actually in use. Otherwise it reports last value even if memory was relased already.

I think m_reportedExtraMemoryCost doesn't need to be reset as memory can not grow after removing SourceBuffer from media source. There is no way to reattach and data are not accepted also.

The same we did in 2.28 https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/34e8375728f5d25cd042e9aefb7d42f782c3adf8