### PR TITLE
make gamepad visible/connected when gamepad axis is moved

### DIFF
--- a/Source/WebCore/platform/gamepad/wpe/WPEGamepad.cpp
+++ b/Source/WebCore/platform/gamepad/wpe/WPEGamepad.cpp
@@ -81,7 +81,7 @@ void WPEGamepad::absoluteAxisChanged(unsigned axis, double value)
     m_lastUpdateTime = MonotonicTime::now();
     m_axisValues[axis].setValue(value);
 
-    WPEGamepadProvider::singleton().scheduleInputNotification(*this, WPEGamepadProvider::ShouldMakeGamepadsVisible::No);
+    WPEGamepadProvider::singleton().scheduleInputNotification(*this, WPEGamepadProvider::ShouldMakeGamepadsVisible::Yes);
 }
 
 } // namespace WebCore


### PR DESCRIPTION
< Make gamepad visible on axis movement >

Reviewed by NOBODY (OOPS!).

https://www.w3.org/TR/gamepad/#dfn-gamepadconnected

W3C Gamepad says 
A user agent MUST dispatch this event type to indicate the user has connected a gamepad. If a gamepad was already connected when the page was loaded, the gamepadconnected event SHOULD be dispatched when the user presses a button or **moves an axis**.

Currently with axis movement, gamepad does not show connected. 
