### PR TITLE
[GTK][WPE] PlatformDisplay::terminateEglDisplays() is never called

### DIFF
--- a/Source/WebKit/ChangeLog
+++ b/Source/WebKit/ChangeLog
@@ -1,3 +1,21 @@
+2022-02-23  Pablo Saavedra  <psaavedra@igalia.com>
+
+        [GTK][WPE] PlatformDisplay::terminateEglDisplays() is never called
+        https://bugs.webkit.org/show_bug.cgi?id=217655
+
+        Stop the run loop for GTK and WPE to ensure a normal exit, since we need
+        atexit handlers to be called to cleanup resources like EGL displays.
+
+        Reviewed by Carlos Garcia Campos.
+
+        * Shared/AuxiliaryProcess.cpp:
+        (WebKit::AuxiliaryProcess::didClose):
+        * WebProcess/WebProcess.cpp:
+        (WebKit::WebProcess::initializeConnection):
+        * WebProcess/WebProcess.h:
+        * WebProcess/glib/WebProcessGLib.cpp:
+        (WebKit::WebProcess::stopRunLoop):
+
 2021-11-02  Zixing Liu  <liushuyu011@gmail.com>
 
         [GTK][WPE] Support setting status code and getting HTTP method in custom URI scheme handlers

--- a/Source/WebKit/Shared/AuxiliaryProcess.cpp
+++ b/Source/WebKit/Shared/AuxiliaryProcess.cpp
@@ -55,7 +55,13 @@ AuxiliaryProcess::~AuxiliaryProcess()
 
 void AuxiliaryProcess::didClose(IPC::Connection&)
 {
+// Stop the run loop for GTK and WPE to ensure a normal exit, since we need
+// atexit handlers to be called to cleanup resources like EGL displays.
+#if PLATFORM(GTK) || PLATFORM(WPE)
+    stopRunLoop();
+#else
     _exit(EXIT_SUCCESS);
+#endif
 }
 
 void AuxiliaryProcess::initialize(const AuxiliaryProcessInitializationParameters& parameters)

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -439,7 +439,7 @@ private:
     bool shouldTerminate() override;
     void terminate() override;
 
-#if USE(APPKIT)
+#if USE(APPKIT) || PLATFORM(GTK) || PLATFORM(WPE)
     void stopRunLoop() override;
 #endif
 

--- a/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
+++ b/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
@@ -29,6 +29,7 @@
 
 #include "WebKitExtensionManager.h"
 #include "WebKitWebExtensionPrivate.h"
+#include "WebPage.h"
 #include "WebProcessCreationParameters.h"
 #include <JavaScriptCore/RemoteInspector.h>
 
@@ -50,6 +51,20 @@
 namespace WebKit {
 
 using namespace WebCore;
+
+void WebProcess::stopRunLoop()
+{
+    // Pages are normally closed after Close message is received from the UI
+    // process, but it can happen that the connection is closed before the
+    // Close message is processed because the UI process close the socket
+    // right after sending the Close message. Close here any pending page to
+    // ensure the threaded compositor is invalidated and GL resources
+    // released (see https://bugs.webkit.org/show_bug.cgi?id=217655).
+    for (auto& webPage : copyToVector(m_pageMap.values()))
+        webPage->close();
+
+    AuxiliaryProcess::stopRunLoop();
+}
 
 void WebProcess::platformSetCacheModel(CacheModel cacheModel)
 {


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=217655

Stop the run loop for GTK and WPE to ensure a normal exit, since we need atexit handlers to be called to cleanup resources like EGL displays.

Reviewed by Carlos Garcia Campos.

* Shared/AuxiliaryProcess.cpp: (WebKit::AuxiliaryProcess::didClose):
* WebProcess/WebProcess.cpp: (WebKit::WebProcess::initializeConnection):
* WebProcess/WebProcess.h:
* WebProcess/glib/WebProcessGLib.cpp: (WebKit::WebProcess::stopRunLoop):

Canonical link: https://commits.webkit.org/247678@main
git-svn-id: https://svn.webkit.org/repository/webkit/trunk@290360 268f45cc-cd09-0410-ab3c-d52691b4dbfc