### PR TITLE
Fix Security Origin handling in network process

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -75,6 +75,7 @@
 #include "WebsiteDataStoreParameters.h"
 #include <WebCore/DocumentStorageAccess.h>
 #include <WebCore/HTTPCookieAcceptPolicy.h>
+#include <WebCore/LegacySchemeRegistry.h>
 #include <WebCore/NetworkStorageSession.h>
 #include <WebCore/ResourceError.h>
 #include <WebCore/ResourceLoadObserver.h>
@@ -1440,6 +1441,11 @@ void NetworkConnectionToWebProcess::installMockContentFilter(WebCore::MockConten
     MockContentFilterSettings::singleton() = WTFMove(settings);
 }
 #endif
+
+void NetworkConnectionToWebProcess::registerURLSchemeAsHandledBySchemeHandler(const String& scheme)
+{
+    WebCore::LegacySchemeRegistry::registerURLSchemeAsHandledBySchemeHandler(scheme);
+}
 
 } // namespace WebKit
 

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -239,6 +239,8 @@ private:
 
     void registerURLSchemesAsCORSEnabled(Vector<String>&& schemes);
 
+    void registerURLSchemeAsHandledBySchemeHandler(const String& scheme);
+
     void cookiesForDOM(const URL& firstParty, const WebCore::SameSiteInfo&, const URL&, WebCore::FrameIdentifier, WebCore::PageIdentifier, WebCore::IncludeSecureCookies, WebCore::ShouldAskITP, WebCore::ShouldRelaxThirdPartyCookieBlocking, CompletionHandler<void(String cookieString, bool secureCookiesAccessed)>&&);
     void setCookiesFromDOM(const URL& firstParty, const WebCore::SameSiteInfo&, const URL&, WebCore::FrameIdentifier, WebCore::PageIdentifier, WebCore::ShouldAskITP, const String&, WebCore::ShouldRelaxThirdPartyCookieBlocking);
     void cookieRequestHeaderFieldValue(const URL& firstParty, const WebCore::SameSiteInfo&, const URL&, std::optional<WebCore::FrameIdentifier>, std::optional<WebCore::PageIdentifier>, WebCore::IncludeSecureCookies, WebCore::ShouldAskITP, WebCore::ShouldRelaxThirdPartyCookieBlocking, CompletionHandler<void(String cookieString, bool secureCookiesAccessed)>&&);

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
@@ -117,4 +117,5 @@ messages -> NetworkConnectionToWebProcess LegacyReceiver {
 #if ENABLE(CONTENT_FILTERING_IN_NETWORKING_PROCESS)
     InstallMockContentFilter(WebCore::MockContentFilterSettings settings)
 #endif
+    RegisterURLSchemeAsHandledBySchemeHandler(String scheme)
 }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -7285,6 +7285,8 @@ void WebPage::registerURLSchemeHandler(WebURLSchemeHandlerIdentifier handlerIden
     WebCore::LegacySchemeRegistry::registerURLSchemeAsCORSEnabled(scheme);
     auto schemeResult = m_schemeToURLSchemeHandlerProxyMap.add(scheme, WebURLSchemeHandlerProxy::create(*this, handlerIdentifier));
     m_identifierToURLSchemeHandlerProxyMap.add(handlerIdentifier, schemeResult.iterator->value.get());
+
+    WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::RegisterURLSchemeAsHandledBySchemeHandler { scheme }, 0);
 }
 
 void WebPage::urlSchemeTaskWillPerformRedirection(WebURLSchemeHandlerIdentifier handlerIdentifier, WebCore::ResourceLoaderIdentifier taskIdentifier, ResourceResponse&& response, ResourceRequest&& request, CompletionHandler<void(WebCore::ResourceRequest&&)>&& completionHandler)


### PR DESCRIPTION
Currently, when a custom uri scheme handler is registered, its existence is not passed to the network process. Consequently, when creating a SecurityOrigin object for an URI that uses a custom scheme handler, the instance may be created as unique due shouldTreatAsUniqueOrigin() not detecting the associated scheme as registered (in LegacySchemeRegistry).

This will cause calls to SecurityPolicy::isAccessAllowed() to not return the correct authorization in case a custom URI is whitelisted using webkit_web_extension_add_origin_access_whitelist_entry() API, which leads to the inclusion of the "Origin" header with the custom URI in network requests when it should not be included in such case.