### PR TITLE
Force sync layer states on making browser visible

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
@@ -266,8 +266,8 @@ void LayerTreeHost::pauseRendering()
 void LayerTreeHost::resumeRendering()
 {
     m_isSuspended = false;
+    renderNextFrame(true);
     m_compositor->resume();
-    scheduleLayerFlush();
 }
 
 GraphicsLayerFactory* LayerTreeHost::graphicsLayerFactory()


### PR DESCRIPTION
Problem:
With wpe-2.38 (f7120b43b806bfcc19aec3802c68b7d075b8d26f), flashing of stale frame (UI of previously loaded web app) was observed when browser instance is reused. Below is the sequence of operations to reproduce the issue

1) Load http://www.google.com
2) Put the browser instance in hidden state (we were using webkitbrowser-plugin, setting visibility property to 'hidden' through curl command achieves hiding the browser instance)
3) Load http://www.example.com
4) Make the browser instance visible (use curl command to set visibility property to 'visible')
5) Observe the first frame displayed is google then immediately, example.com's UI is displayed.

Analysis:
I see that this behavior is caused by couple reasons:
1) In wpe-2.38, on resuming painting immediately an update is scheduled (refer https://github.com/WebPlatformForEmbedded/WPEWebKit/blob/wpe-2.38/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.cpp#L173). In wpe-2.28 it is not done. This update uses the existing states and renders the UI from google.com
2) In wpe-2.28, the states are synced always with compositor thread because of this https://github.com/WebPlatformForEmbedded/WPEWebKit/blob/wpe-2.28/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp#L796. But in wpe-2.38, it is not the case.

I am proposing to force the state sync, on resuming visibility.