### PR TITLE
[MemoryPressure] Increase MemoryPressure logging in RELESE builds

### DIFF
--- a/Source/WTF/wtf/unix/MemoryPressureHandlerUnix.cpp
+++ b/Source/WTF/wtf/unix/MemoryPressureHandlerUnix.cpp
@@ -69,7 +69,7 @@ void MemoryPressureHandler::triggerMemoryPressureEvent(bool isCritical)
         return;
 
     if (ReliefLogger::loggingEnabled())
-        LOG(MemoryPressure, "Got memory pressure notification (%s)", isCritical ? "critical" : "non-critical");
+        RELEASE_LOG(MemoryPressure, "Got memory pressure notification (%s)", isCritical ? "critical" : "non-critical");
 
     setMemoryPressureStatus(MemoryPressureStatus::SystemCritical);
 
@@ -80,7 +80,7 @@ void MemoryPressureHandler::triggerMemoryPressureEvent(bool isCritical)
     });
 
     if (ReliefLogger::loggingEnabled() && isUnderMemoryPressure())
-        LOG(MemoryPressure, "System is no longer under memory pressure.");
+        RELEASE_LOG(MemoryPressure, "System is no longer under memory pressure.");
 
     setMemoryPressureStatus(MemoryPressureStatus::Normal);
 }

--- a/Source/WTF/wtf/unix/MemoryPressureHandlerUnix.cpp
+++ b/Source/WTF/wtf/unix/MemoryPressureHandlerUnix.cpp
@@ -79,7 +79,7 @@ void MemoryPressureHandler::triggerMemoryPressureEvent(bool isCritical)
         respondToMemoryPressure(isCritical ? Critical::Yes : Critical::No, isCritical ? Synchronous::Yes : Synchronous::No);
     });
 
-    if (ReliefLogger::loggingEnabled() && isUnderMemoryPressure())
+    if (ReliefLogger::loggingEnabled() && !isUnderMemoryPressure())
         RELEASE_LOG(MemoryPressure, "System is no longer under memory pressure.");
 
     setMemoryPressureStatus(MemoryPressureStatus::Normal);

--- a/Source/WebKit/UIProcess/linux/MemoryPressureMonitor.cpp
+++ b/Source/WebKit/UIProcess/linux/MemoryPressureMonitor.cpp
@@ -287,13 +287,13 @@ static int systemMemoryUsedAsPercentage(FILE* memInfoFile, FILE* zoneInfoFile, C
         return -1;
 
     int memoryUsagePercentage = ((memoryTotal - memoryAvailable) * 100) / memoryTotal;
-    LOG_VERBOSE(MemoryPressure, "MemoryPressureMonitor::memory: real (memory total=%zu MB) (memory available=%zu MB) (memory usage percentage=%d MB)", memoryTotal, memoryAvailable, memoryUsagePercentage);
+    RELEASE_LOG_INFO(MemoryPressure, "MemoryPressureMonitor::memory: real (memory total=%zu MB) (memory available=%zu MB) (memory usage percentage=%d)", memoryTotal, memoryAvailable, memoryUsagePercentage);
     if (memoryController->isActive()) {
         memoryTotal = memoryController->getMemoryTotalWithCgroup();
         size_t memoryUsage = memoryController->getMemoryUsageWithCgroup();
         if (memoryTotal != notSet && memoryUsage != notSet) {
             int memoryUsagePercentageWithCgroup = 100 * ((float) memoryUsage / (float) memoryTotal);
-            LOG_VERBOSE(MemoryPressure, "MemoryPressureMonitor::memory: cgroup (memory total=%zu bytes) (memory usage=%zu bytes) (memory usage percentage=%d bytes)", memoryTotal, memoryUsage, memoryUsagePercentageWithCgroup);
+            RELEASE_LOG_INFO(MemoryPressure, "MemoryPressureMonitor::memory: cgroup (memory total=%zu bytes) (memory usage=%zu bytes) (memory usage percentage=%d)", memoryTotal, memoryUsage, memoryUsagePercentageWithCgroup);
             if (memoryUsagePercentageWithCgroup > memoryUsagePercentage)
                 memoryUsagePercentage = memoryUsagePercentageWithCgroup;
         }


### PR DESCRIPTION
1) Print crucial logs as RELEASE_LOG to be also visible when RELEASE_LOG is enabled (but regural logs disabled).
2) Fix memory relief condition

Nothing more should be visible by default.
With WEBKIT_DEBUG=MemoryPressure addtional logging will be shown (global system/cgroup memory stats and notifications about pressure events).