### PR TITLE
[wpe-2.38] Prevent journal files from wasting disk space

### DIFF
--- a/Source/WebCore/platform/sql/SQLiteDatabase.cpp
+++ b/Source/WebCore/platform/sql/SQLiteDatabase.cpp
@@ -152,6 +152,12 @@ bool SQLiteDatabase::open(const String& filename, OpenMode openMode)
             LOG_ERROR("SQLite database could not set temp_store to memory");
     }
 
+    {
+        SQLiteTransactionInProgressAutoCounter transactionCounter;
+        // prevent wasting disk space, see https://www.sqlite.org/pragma.html#pragma_journal_size_limit
+        executeCommand("PRAGMA journal_size_limit = 0;"_s);
+    }
+
     if (filename != inMemoryPath()) {
         if (openMode != OpenMode::ReadOnly && !useWALJournalMode())
             return false;


### PR DESCRIPTION
I'd like to gather some feedback on potential setting of `PRAGMA journal_size_limit = 0;` in local storage's SQLite database.
What it does, is slightly improving the effectiveness of disk space usage at the slight expense of performance.
I was wondering if it's maybe worth adding it behind some flag being controlled from settings perhaps?