### PR TITLE
[MemoryPressure] Set memory pressure timer priority for GLIB based ru…

### DIFF
--- a/Source/WTF/wtf/MemoryPressureHandler.cpp
+++ b/Source/WTF/wtf/MemoryPressureHandler.cpp
@@ -36,6 +36,10 @@
 #include <wtf/RAMSize.h>
 #include <wtf/text/StringToIntegerConversion.h>
 
+#if USE(GLIB_EVENT_LOOP)
+#include <wtf/glib/RunLoopSourcePriority.h>
+#endif
+
 namespace WTF {
 
 WTF_EXPORT_PRIVATE bool MemoryPressureHandler::ReliefLogger::s_loggingEnabled = false;
@@ -154,6 +158,10 @@ void MemoryPressureHandler::setShouldUsePeriodicMemoryMonitor(bool use)
     if (use) {
         m_measurementTimer = makeUnique<RunLoop::Timer<MemoryPressureHandler>>(RunLoop::main(), this, &MemoryPressureHandler::measurementTimerFired);
         m_measurementTimer->startRepeating(m_configuration.pollInterval);
+#if USE(GLIB_EVENT_LOOP)
+        m_measurementTimer->setPriority(MemoryPressureHandlerTimer);
+#endif
+
     } else
         m_measurementTimer = nullptr;
 }


### PR DESCRIPTION
…nloop

This change increases m_measurementTimer priority over default one to make sure memory check is not blocked by any other tasks.

Current values:
  RunLoopDispatcher = 0,
  RunLoopTimer = 0,
  MemoryPressureHandlerTimer = -10,
