### PR TITLE
Disable blending of hole punching buffers with rounded rect clip

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/TextureMapperGL.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperGL.cpp
@@ -712,7 +712,7 @@ void TextureMapperGL::drawSolidColor(const FloatRect& rect, const Transformation
         flags |= ShouldAntialias | (isBlendingAllowed ? ShouldBlend : 0);
     }
 
-    if (clipStack().isRoundedRectClipEnabled()) {
+    if (clipStack().isRoundedRectClipEnabled() && isBlendingAllowed) {
         options.add(TextureMapperShaderProgram::RoundedRectClip);
         flags |= ShouldBlend;
     }
@@ -720,7 +720,7 @@ void TextureMapperGL::drawSolidColor(const FloatRect& rect, const Transformation
     Ref<TextureMapperShaderProgram> program = data().getShaderProgram(options);
     glUseProgram(program->programID());
 
-    if (clipStack().isRoundedRectClipEnabled())
+    if (options.contains(TextureMapperShaderProgram::RoundedRectClip))
         prepareRoundedRectClip(program.get(), clipStack().roundedRectComponents(), clipStack().roundedRectInverseTransformComponents(), clipStack().roundedRectCount());
 
     auto [r, g, b, a] = premultiplied(color.toColorTypeLossy<SRGBA<float>>()).resolved();


### PR DESCRIPTION
Fixes hole punching when page layout applies rounding rect clip to hole punching layer. Reproducible with desktop version of YouTube: https://www.youtube.com/watch?v=TRgqtaYb4sU