### PR TITLE
[2.38] Ignore sinks position while seeking

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -1391,7 +1391,8 @@ MediaTime MediaPlayerPrivateGStreamer::playbackPosition() const
         return m_cachedPosition;
     }
 
-    GstClockTime gstreamerPosition = gstreamerPositionFromSinks();
+    // We can't trust sinks position when pipeline is flushed (e.g. after MSE samples removal).
+    GstClockTime gstreamerPosition = isPipelineSeeking() ? GST_CLOCK_TIME_NONE : gstreamerPositionFromSinks();
     GST_TRACE_OBJECT(pipeline(), "Position %" GST_TIME_FORMAT ", canFallBackToLastFinishedSeekPosition: %s", GST_TIME_ARGS(gstreamerPosition), boolForPrinting(m_canFallBackToLastFinishedSeekPosition));
 
     // Cached position is marked as non valid here but we might fail to get a new one so initializing to this as "educated guess".


### PR DESCRIPTION
[2.38] Don't trust sinks position when pipeline is not prerolled as behavor is different across devices.
Use last cached position instead.

After removing MSE data, sinks get flushed and are not able to return valid playback time. Some implementation returns invalid time, 0.00 or even some random value.
This value may be then reported up to HTMLMediaElement that may be confusing to web applications.

This fixes Disney+ video "Restart" button as application may skip currentTime change to 0.00 because video element already reports that position is 0.00:
1) Video play at position x.xx
2) pause
3) Remove video and audio MSE data
4) video.currentTime is 0.00 so no need to change it (position reported by sink with no preroll)
5) Append new data and start playback
6) Position returns back to x.xx