### PR TITLE
[libwebrtc] fix build without pulse audio

### DIFF
--- a/Source/ThirdParty/libwebrtc/CMakeLists.txt
+++ b/Source/ThirdParty/libwebrtc/CMakeLists.txt
@@ -2154,14 +2154,23 @@ else ()
 
         Source/webrtc/modules/audio_device/linux/alsasymboltable_linux.cc
         Source/webrtc/modules/audio_device/linux/audio_device_alsa_linux.cc
-        Source/webrtc/modules/audio_device/linux/audio_device_pulse_linux.cc
         Source/webrtc/modules/audio_device/linux/audio_mixer_manager_alsa_linux.cc
-        Source/webrtc/modules/audio_device/linux/audio_mixer_manager_pulse_linux.cc
         Source/webrtc/modules/audio_device/linux/latebindingsymboltable_linux.cc
-        Source/webrtc/modules/audio_device/linux/pulseaudiosymboltable_linux.cc
 
         Source/webrtc/modules/video_coding/codecs/h264/h264.cc
     )
+
+    find_package(LibPulse)
+    if (NOT LIBPULSE_FOUND)
+        message(STATUS "libpulse is not found, not building support.")
+    else()
+        list(APPEND webrtc_SOURCES
+            Source/webrtc/modules/audio_device/linux/audio_device_pulse_linux.cc
+            Source/webrtc/modules/audio_device/linux/audio_mixer_manager_pulse_linux.cc
+            Source/webrtc/modules/audio_device/linux/pulseaudiosymboltable_linux.cc
+        )
+    endif ()
+
 endif ()
 
 add_library(webrtc STATIC ${webrtc_SOURCES})

--- a/Source/ThirdParty/libwebrtc/cmake/FindLibPulse.cmake
+++ b/Source/ThirdParty/libwebrtc/cmake/FindLibPulse.cmake
@@ -1,0 +1,28 @@
+# Copyright 2023 RDK Management
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+
+find_package(PkgConfig)
+pkg_check_modules(PC_LIBPULSE libpulse)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(LibPulse DEFAULT_MSG PC_LIBPULSE_VERSION)


### PR DESCRIPTION
Pulse audio is not available on RDK. This change makes libpulse dependency optional.