### PR TITLE
AX: Incomplete object information with focus event on dynamic created…

### DIFF
--- a/LayoutTests/accessibility/focus-new-element.html
+++ b/LayoutTests/accessibility/focus-new-element.html
@@ -1,0 +1,53 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="container"></div>
+
+<script>
+var output = "This test ensures that the accessiblity tree properly handles focus for an element who has not yet attached a renderer.\n\n";
+
+var axText, axButton;
+function verifyButton() {
+    output += expect("axButton && axButton.isValid", "true");
+    axText = platformTextAlternatives(axButton);
+    output += `${axText}\n`;
+    output += expect("axText.includes('BUTTON')", "true");
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    // Ensure the AXObjectCache is created before issuing focus.
+    touchAccessibilityTree(accessibilityController.rootElement);
+
+    let button = document.createElement("div");
+    button.setAttribute("id", "button"),
+    button.setAttribute("role", "button"),
+    button.setAttribute("tabindex", "0");
+    button.setAttribute("aria-label", "BUTTON");
+    button.innerHTML = "TEST";
+    document.getElementById("container").appendChild(button);
+    button.focus();
+
+    setTimeout(async function() {
+        await waitFor(() => {
+            axButton = accessibilityController.focusedElement;
+            return axButton && axButton.role.toLowerCase().includes("button");
+        });
+        verifyButton();
+
+        axButton = accessibilityController.accessibleElementById("button");
+        verifyButton();
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/accessibility/focus-new-element-expected.txt
+++ b/LayoutTests/platform/glib/accessibility/focus-new-element-expected.txt
@@ -1,0 +1,15 @@
+This test ensures that the accessiblity tree properly handles focus for an element who has not yet attached a renderer.
+
+PASS: axButton && axButton.isValid === true
+	AXTitle: BUTTON
+	AXDescription:
+PASS: axText.includes('BUTTON') === true
+PASS: axButton && axButton.isValid === true
+	AXTitle: BUTTON
+	AXDescription:
+PASS: axText.includes('BUTTON') === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+TEST

--- a/LayoutTests/platform/ios-simulator-wk2/accessibility/focus-new-element-expected.txt
+++ b/LayoutTests/platform/ios-simulator-wk2/accessibility/focus-new-element-expected.txt
@@ -1,0 +1,13 @@
+This test ensures that the accessiblity tree properly handles focus for an element who has not yet attached a renderer.
+
+PASS: axButton && axButton.isValid === true
+	AXLabel: BUTTON
+PASS: axText.includes('BUTTON') === true
+PASS: axButton && axButton.isValid === true
+	AXLabel: BUTTON
+PASS: axText.includes('BUTTON') === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+TEST

--- a/LayoutTests/platform/mac/accessibility/focus-new-element-expected.txt
+++ b/LayoutTests/platform/mac/accessibility/focus-new-element-expected.txt
@@ -1,0 +1,17 @@
+This test ensures that the accessiblity tree properly handles focus for an element who has not yet attached a renderer.
+
+PASS: axButton && axButton.isValid === true
+	AXTitle: BUTTON
+	AXDescription: BUTTON
+	AXHelp:
+PASS: axText.includes('BUTTON') === true
+PASS: axButton && axButton.isValid === true
+	AXTitle: BUTTON
+	AXDescription: BUTTON
+	AXHelp:
+PASS: axText.includes('BUTTON') === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+TEST

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -1557,12 +1557,30 @@ void AXObjectCache::onPageActivityStateChange(OptionSet<ActivityState> newState)
 #endif
 }
 
-void AXObjectCache::onFocusChange(Node* oldNode, Node* newNode)
+static bool shouldDeferFocusChange(Element* element)
 {
-    if (nodeAndRendererAreValid(newNode) && rendererNeedsDeferredUpdate(*newNode->renderer())) {
+    if (!element)
+        return false;
+
+    auto* renderer = element->renderer();
+    if (renderer && rendererNeedsDeferredUpdate(*renderer))
+        return true;
+
+    // We also want to defer handling focus changes for nodes that haven't yet attached their renderer.
+    if (const auto* style = element->existingComputedStyle())
+        return !renderer && element->rendererIsNeeded(*style);
+    // No existing style, so we can't easily determine whether this element will need a renderer.
+    // Resolving style is expensive and we don't want to do it now, so make this decision assuming
+    // a renderer just hasn't been attached yet, indicated by it being nullptr.
+    return !renderer;
+}
+
+void AXObjectCache::onFocusChange(Element* oldElement, Element* newElement)
+{
+    if (shouldDeferFocusChange(newElement)) {
         if (m_deferredFocusedNodeChange) {
             // If we got a focus change notification but haven't committed a previously deferred focus change:
-            if (m_deferredFocusedNodeChange->first == newNode) {
+            if (m_deferredFocusedNodeChange->first == newElement) {
                 // Cancel the focus change entirely if the new focused node will be the same as the old one (i.e. there is no effective focus change).
                 m_deferredFocusedNodeChange = std::nullopt;
                 return;
@@ -1572,14 +1590,16 @@ void AXObjectCache::onFocusChange(Node* oldNode, Node* newNode)
             // meaning it could be unignored solely because it was DOM focused.
             recomputeIsIgnored(m_deferredFocusedNodeChange->second.get());
             // And now we can update the new deferred focus node to be |newNode|.
-            m_deferredFocusedNodeChange->second = newNode;
+            m_deferredFocusedNodeChange->second = newElement;
         } else
-            m_deferredFocusedNodeChange = { oldNode, newNode };
+            m_deferredFocusedNodeChange = { oldElement, newElement };
 
-        if (!newNode->renderer()->needsLayout() && !m_performCacheUpdateTimer.isActive())
+        // Don't start the timer if a layout is pending, as the layout will trigger a cache update.
+        bool needsLayout = newElement->renderer() && newElement->renderer()->needsLayout();
+        if (!needsLayout && !m_performCacheUpdateTimer.isActive())
             m_performCacheUpdateTimer.startOneShot(0_s);
     } else
-        handleFocusedUIElementChanged(oldNode, newNode);
+        handleFocusedUIElementChanged(oldElement, newElement);
 }
 
 void AXObjectCache::onPopoverTargetToggle(const HTMLFormControlElement& popoverInvokerElement)

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -198,7 +198,7 @@ public:
     void childrenChanged(Node*, Node* newChild = nullptr);
     void childrenChanged(RenderObject*, RenderObject* newChild = nullptr);
     void childrenChanged(AccessibilityObject*);
-    void onFocusChange(Node* oldFocusedNode, Node* newFocusedNode);
+    void onFocusChange(Element* oldElement, Element* newElement);
     void onPopoverTargetToggle(const HTMLFormControlElement&);
     void onScrollbarFrameRectChange(const Scrollbar&);
     void onSelectedChanged(Node*);
@@ -755,7 +755,7 @@ inline void AXObjectCache::onTitleChange(Document&) { }
 inline void AXObjectCache::onValidityChange(Element&) { }
 inline void AXObjectCache::onTextCompositionChange(Node&, CompositionState, bool) { }
 inline void AXObjectCache::valueChanged(Element*) { }
-inline void AXObjectCache::onFocusChange(Node*, Node*) { }
+inline void AXObjectCache::onFocusChange(Element*, Element*) { }
 inline void AXObjectCache::onPageActivityStateChange(OptionSet<ActivityState>) { }
 inline void AXObjectCache::onPopoverTargetToggle(const HTMLFormControlElement&) { }
 inline void AXObjectCache::onScrollbarFrameRectChange(const Scrollbar&) { }

--- a/Tools/TestWebKitAPI/Tests/WebKitGtk/TestWebKitAccessibility.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGtk/TestWebKitAccessibility.cpp
@@ -633,6 +633,40 @@ static void testAccessibleState(AccessibilityTest* test, gconstpointer)
     g_assert_true(atspi_state_set_contains(stateSet.get(), ATSPI_STATE_SHOWING));
 }
 
+static void testAccessibleStateChangedFocus(AccessibilityTest* test, gconstpointer)
+{
+    test->showInWindow(800, 600);
+    test->loadHtml(
+        "<html>"
+        "  <body>"
+        "    <div id='container'></div>"
+        "  </body>"
+        "</html>",
+        nullptr);
+    test->waitUntilLoadFinished();
+
+    auto testApp = test->findTestApplication();
+    g_assert_true(ATSPI_IS_ACCESSIBLE(testApp.get()));
+
+    auto documentWeb = test->findDocumentWeb(testApp.get());
+    g_assert_true(ATSPI_IS_ACCESSIBLE(documentWeb.get()));
+
+    test->startEventMonitor(nullptr, { "object:state-changed" });
+    test->runJavaScriptAndWaitUntilFinished(
+        "container=document.getElementById('container');"
+        "var i = document.createElement('div');"
+        "i.setAttribute('tabindex', '-1');"
+        "container.appendChild(i);"
+        "i.innerHTML = 'TEST';"
+        "i.focus();",
+        nullptr);
+    auto events = test->stopEventMonitor(1);
+    g_assert_cmpuint(events.size(), ==, 1);
+    g_assert_cmpstr(events[0]->type, ==, "object:state-changed:focused");
+    auto* div = events[0]->source;
+    g_assert_true(ATSPI_IS_ACCESSIBLE(div));
+}
+
 static void testAccessibleStateChanged(AccessibilityTest* test, gconstpointer)
 {
     test->showInWindow(800, 600);
@@ -3413,6 +3447,7 @@ void beforeAll()
     AccessibilityTest::add("WebKitAccessibility", "selection/menulist", testSelectionMenuList);
     AccessibilityTest::add("WebKitAccessibility", "table/basic", testTableBasic);
     AccessibilityTest::add("WebKitAccessibility", "collection/get-matches", testCollectionGetMatches);
+    AccessibilityTest::add("WebKitAccessibility", "accessible/state-changed/focus", testAccessibleStateChangedFocus);
 }
 
 void afterAll()


### PR DESCRIPTION
… div

https://bugs.webkit.org/show_bug.cgi?id=270433

Reviewed by Tyler Wilcock.

When the element is dynamically created and focused, the focus change event should be deferred in case renderer is not available yet but document needs style recalculation.

* Source/WebCore/accessibility/AXObjectCache.cpp: (WebCore::shouldDeferFocusChange):
(WebCore::AXObjectCache::onFocusChange):
* Tools/TestWebKitAPI/Tests/WebKitGtk/TestWebKitAccessibility.cpp: (testAccessibleStateChangedFocus):
(beforeAll):
* LayoutTests/accessibility/focus-new-element.html: Added.
* LayoutTests/platform/glib/accessibility/focus-new-element-expected.txt: Added.
* LayoutTests/platform/ios-simulator-wk2/accessibility/focus-new-element-expected.txt: Added.
* LayoutTests/platform/mac/accessibility/focus-new-element-expected.txt: Added.

Canonical link: https://commits.webkit.org/275980@main<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/9fb41502895ee7084c65024a7c0333588be82051

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| [✅ 🛠 wpe-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/4/builds/14 "Built successfully") | [✅ 🧪 wpe-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/3/builds/19 "Passed tests") 
| [✅ 🛠 wpe-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/1/builds/14 "Built successfully") | [✅ 🧪 wpe-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/2/builds/4 "Passed tests") 
<!--EWS-Status-Bubble-End-->