### PR TITLE
[JHBuild] Add header for missing function 'mkpath' 

### DIFF
--- a/Tools/Scripts/update-webkit-libs-jhbuild
+++ b/Tools/Scripts/update-webkit-libs-jhbuild
@@ -22,6 +22,7 @@ use warnings;
 use Cwd qw(realpath);
 use Digest::MD5 qw(md5_hex);
 use File::Basename;
+use File::Path qw(mkpath);
 use FindBin;
 use lib $FindBin::Bin;
 use webkitdirs;

--- a/Tools/gstreamer/jhbuild.modules
+++ b/Tools/gstreamer/jhbuild.modules
@@ -67,6 +67,16 @@
     </branch>
   </autotools>
 
+  <meson id="graphene">
+    <pkg-config>graphene-1.0.pc</pkg-config>
+    <branch repo="github.com"
+            module="ebassi/graphene.git"
+            tag="1.10.6"/>
+    <dependencies>
+      <dep package="glib"/>
+    </dependencies>
+  </meson>
+
   <!-- GStreamer plugins have been moved with the base code to a monorepo.
   Is not longer needed to fetch different tarballs when using the main repository.
   See: https://gstreamer.freedesktop.org/documentation/frequently-asked-questions/mono-repository.html -->

--- a/Tools/gtk/jhbuild.modules
+++ b/Tools/gtk/jhbuild.modules
@@ -181,15 +181,6 @@
             hash="sha256:455eb90c09ed1b71f95f3ebfe1c904c206727e0eeb34fc94e5aaf944663a820c"/>
   </autotools>
 
-  <meson id="graphene">
-    <branch repo="github.com"
-            module="ebassi/graphene.git"
-            tag="1.6.0"/>
-    <dependencies>
-      <dep package="glib"/>
-    </dependencies>
-  </meson>
-
   <autotools id="librsvg" autogen-sh="configure"
              autogenargs="--disable-introspection --enable-pixbuf-loader --disable-gtk-theme">
     <if condition-set="macos">

--- a/Tools/jhbuild/jhbuild-wrapper
+++ b/Tools/jhbuild/jhbuild-wrapper
@@ -24,7 +24,7 @@ import shlex
 import subprocess
 import sys
 
-jhbuild_revision = '93d37507d0fbf550aa3e96b5d632f3772c0189f0'
+jhbuild_revision = 'acb52b03594989cfb45173841b318fccf557fefb'
 
 def determine_platform():
     if '--gtk' in sys.argv:


### PR DESCRIPTION
Bot [WPE-238-ARM-32-bit-Release-Build](https://build-wpe-rdk.igalia.com/#/builders/5) is failing on the `jhbuild` step with the following error message:

```
Can't locate object method "mkpath" via package "/home/buildbot/worker/WPE-238-ARM-32-bit-Release-Build/build/WebKitBuild/DependenciesWPE/wpe" (perhaps you forgot to load "/home/buildbot/worker/WPE-238-ARM-32-bit-Release-Build/build/WebKitBuild/DependenciesWPE/wpe"?) at Tools/Scripts/update-webkit-libs-jhbuild line 133.
Died at Tools/Scripts/update-webkitwpe-libs line 26.
```
Add header for `mkpath`. Also in this PR, update JHBuild commit and add dependency 'graphene' to gstreamer modules, which is a warning (`W: gstreamer has a dependency on unknown "graphene" module`).