### PR TITLE
Decrease schedule input notification to 5.

### DIFF
--- a/Source/WebCore/platform/gamepad/wpe/WPEGamepadProvider.cpp
+++ b/Source/WebCore/platform/gamepad/wpe/WPEGamepadProvider.cpp
@@ -38,7 +38,7 @@
 namespace WebCore {
 
 static const Seconds connectionDelayInterval { 500_ms };
-static const Seconds inputNotificationDelay { 50_ms };
+static const Seconds inputNotificationDelay { 5_ms };
 
 WPEGamepadProvider& WPEGamepadProvider::singleton()
 {


### PR DESCRIPTION
With 50 millisec, js is getting events in every 50 millisec. Where as user as already pressed the button/axes
Decrease the delay to 5 milli sec. 