### PR TITLE
[WebRTC] Use WebCore::LibWebRTCProvider by default

### DIFF
--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.h
@@ -78,9 +78,12 @@ private:
 #endif
 };
 
-inline UniqueRef<LibWebRTCProvider> createLibWebRTCProvider(WebPage& page)
+inline UniqueRef<LibWebRTCProviderBase> createLibWebRTCProvider(WebPage& page)
 {
-    return makeUniqueRef<LibWebRTCProvider>(page);
+    // In downstream WPEWebKit WebProcess sandbox is disabled,
+    // so moving LibWebRTC networking out of it doesn't make much sense.
+    // For better performance keep it in WPEWebProcess
+    return makeUniqueRef<LibWebRTCProviderBase>();
 }
 
 #elif USE(GSTREAMER_WEBRTC)


### PR DESCRIPTION
We observe very high CPU usage while using webRTC in AmazonLuna gaming app. Usually it's around 150% (rough measuring with 'top' cmd).
This traffic is mainly generated by WPEWebProcess ~110% and WPENetworkProcess ~20%
In WPEWebProcess there are 3 threads responsible for most of the usage WebKitWebRTCNet, main thread and WebKitWebRTCSig.

With this patch CPU usage drops around 20%. WPEWebProcess usually stays below 100% while WPENetworkProcess CPU usage is not significant any more.

This patch changes default LibWebRTCProvider. Not sure if this is beneficial for others. We can flip it to keep default provider from Network and use WebCore provider only if env is set.
