### PR TITLE
[2.38][MemoryPressureHandler] Subtract GPU memory from RSS when deciding me…

### DIFF
--- a/Source/WTF/wtf/MemoryPressureHandler.h
+++ b/Source/WTF/wtf/MemoryPressureHandler.h
@@ -59,6 +59,7 @@ enum class MemoryUsagePolicy : uint8_t {
     Unrestricted, // Allocate as much as you want
     Conservative, // Maybe you don't cache every single thing
     Strict, // Time to start pinching pennies for real
+    StrictSynchronous, // Time to start pinching pennies for real, and do it now
 };
 
 enum class MemoryType : uint8_t {

--- a/Source/WTF/wtf/MemoryPressureHandler.h
+++ b/Source/WTF/wtf/MemoryPressureHandler.h
@@ -244,6 +244,7 @@ private:
     std::optional<size_t> thresholdForMemoryKill(MemoryType);
     size_t thresholdForPolicy(MemoryUsagePolicy, MemoryType);
     MemoryUsagePolicy policyForFootprints(size_t, size_t);
+    size_t calculateFootprintForPolicyDecision(size_t footprint, size_t footprintVideo);
 
     void memoryPressureStatusChanged();
 


### PR DESCRIPTION
…mory policy

On Mali GPU drivers GPU memory is also included in process RSS mem (RSSFile) that cause pressure handler to kick in too early comparing to other devices. GPU memory doesn't increase container's total mem usage in cgroups so this change doesn't affect total memory allowance but delays pressure handler only.

Hidden under env variable, disabled by default because whole GPU memory (footprintVideo) is custom donwstream solution and is controlled with envs currently. 