### PR TITLE
Decrease schedule input notification to 5.

### DIFF
--- a/Source/WebCore/platform/gamepad/libwpe/GamepadProviderLibWPE.cpp
+++ b/Source/WebCore/platform/gamepad/libwpe/GamepadProviderLibWPE.cpp
@@ -39,7 +39,7 @@
 namespace WebCore {
 
 static const Seconds connectionDelayInterval { 500_ms };
-static const Seconds inputNotificationDelay { 50_ms };
+static const Seconds inputNotificationDelay { 5_ms };
 
 GamepadProviderLibWPE& GamepadProviderLibWPE::singleton()
 {


### PR DESCRIPTION
With 50 millisec, js is getting events in every 50 millisec. Where as user as already pressed the button/axes
