### PR TITLE
Enable MemoryPressureHandler for MALLOC_HEAP_BREAKDOWN

### DIFF
--- a/Source/WTF/wtf/MemoryPressureHandler.cpp
+++ b/Source/WTF/wtf/MemoryPressureHandler.cpp
@@ -152,11 +152,13 @@ MemoryPressureHandler::MemoryPressureHandler()
 
 void MemoryPressureHandler::setShouldUsePeriodicMemoryMonitor(bool use)
 {
+#if !ENABLE(MALLOC_HEAP_BREAKDOWN)
     if (!isFastMallocEnabled()) {
         // If we're running with FastMalloc disabled, some kind of testing or debugging is probably happening.
         // Let's be nice and not enable the memory kill mechanism.
         return;
     }
+#endif
 
     if (use) {
         m_measurementTimer = makeUnique<RunLoop::Timer>(RunLoop::main(), this, &MemoryPressureHandler::measurementTimerFired);


### PR DESCRIPTION
Enabling MALLOC_HEAP_BREAKDOWN currently disables MemoryPressureHandler. We would like to keep both enabled to be able to track memory related issues.