### PR TITLE
Fix HEVC codec string parsing

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
@@ -762,8 +762,7 @@ MediaPlayerEnums::SupportsType GStreamerRegistryScanner::isContentTypeSupported(
     if (codecs.isEmpty())
         return SupportsType::MayBeSupported;
 
-    for (const auto& item : codecs) {
-        auto codec = item.convertToASCIILowercase();
+    for (const auto& codec : codecs) {
         bool requiresHardwareSupport = contentTypesRequiringHardwareSupport
             .findIf([containerType, codec](auto& hardwareContentType) -> bool {
             auto hardwareContainer = hardwareContentType.containerType();


### PR DESCRIPTION
Codec string is first moved into lowercase and then compared in uppercase. This is backport of 5ee3f9a7c6a9 from upstream:

Two new failures media/media-can-play-case-sensitive-flac.html, media/media-can-play-type-case-sensitive.html https://bugs.webkit.org/show_bug.cgi?id=260625

Reviewed by Xabier Rodriguez-Calvar.

Codec string matching is now case-sensitive in the registry scanner.

* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp: (WebCore::GStreamerRegistryScanner::initializeDecoders): (WebCore::GStreamerRegistryScanner::isContentTypeSupported const):

Canonical link: https://commits.webkit.org/267343@main