### PR TITLE
[MSE][GStreamer] take playbin's states lock when sending seek event

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -268,8 +268,10 @@ bool MediaPlayerPrivateGStreamerMSE::doSeek(const MediaTime& position, float rat
 
     // Important: In order to ensure correct propagation whether pre-roll has happened or not, we send the seek directly
     // to the source element, rather than letting playbin do the routing.
+    GST_STATE_LOCK (pipeline());
     gst_element_seek(m_source.get(), rate, GST_FORMAT_TIME, seekFlags,
         GST_SEEK_TYPE_SET, toGstClockTime(m_seekTime), GST_SEEK_TYPE_NONE, 0);
+    GST_STATE_UNLOCK (pipeline());
     invalidateCachedPosition();
 
     // Notify MediaSource and have new frames enqueued (when they're available).


### PR DESCRIPTION
This fixes possible race between application (triggering another seek from 'seeked' event) and 'state change' continuation (triggered by playbin).

Top level bin element does change the state as result of 'async-done' handling from previous seek request(see gst_bin_continue_func in gstbin.c). Which may race with handling of 'async-start' posted by sinks on flushing seek. And may leave the pipeline in inconsistent state and 'hanging' seek that never finishes.

By taking the states lock of top level bin element player will wait for possible state change continuation to complete before sending next seek event.
