### PR TITLE
[GStreamer] Fix negative timestamps handling (edit lists)

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -81,6 +81,10 @@ uint64_t toGstUnsigned64Time(const MediaTime&);
 
 inline GstClockTime toGstClockTime(const MediaTime& mediaTime)
 {
+    if (mediaTime.isInvalid())
+        return GST_CLOCK_TIME_NONE;
+    if (mediaTime < MediaTime::zeroTime())
+        return 0;
     return static_cast<GstClockTime>(toGstUnsigned64Time(mediaTime));
 }
 


### PR DESCRIPTION
Bring back negative timestamps clamp on conversion to gst time that was removed by WebRTC related backports from upstream: 95cae32e59cfdfad7cdd7139909bb47a7aed494e
The part of code comes from Edit list support patch that is entirely reverted upstream.

This fixes YT MSE Codec Tests 84.BufUnbufSeekH264