### PR TITLE
[EME] Keep MediaKeySystemAccess alive in createMediaKeys() async task

### DIFF
--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySystemAccess.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySystemAccess.cpp
@@ -67,7 +67,7 @@ void MediaKeySystemAccess::createMediaKeys(Document& document, Ref<DeferredPromi
     // When this method is invoked, the user agent must run the following steps:
     // 1. Let promise be a new promise.
     // 2. Run the following steps in parallel:
-    document.eventLoop().queueTask(TaskSource::MediaElement, [this, weakThis = WeakPtr { *this }, weakDocument = WeakPtr { document }, promise = WTFMove(promise)] () mutable {
+    queueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [this, weakThis = WeakPtr { *this }, weakDocument = WeakPtr { document }, promise = WTFMove(promise)] () mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;


### PR DESCRIPTION
Bring back piece of code from upstream that is missing in 2.38

Original PR:
https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/922/

No need to upstream, the change is there already in the upstream and 2.42 as well