### PR TITLE
Fix race in ref/deref of StringImpl for some cases

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourceTrackGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourceTrackGStreamer.h
@@ -45,7 +45,7 @@ public:
     virtual ~MediaSourceTrackGStreamer();
 
     TrackPrivateBaseGStreamer::TrackType type() const { return m_type; }
-    AtomString trackId() const { return m_trackId; }
+    const AtomString& trackId() const { return m_trackId; }
     GRefPtr<GstCaps>& initialCaps() { return m_initialCaps; }
     DataMutex<TrackQueue>& queueDataMutex() { return m_queueDataMutex; }
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
@@ -185,12 +185,12 @@ void SourceBufferPrivateGStreamer::notifyClientWhenReadyForMoreSamples(const Ato
     ASSERT(isMainThread());
     ASSERT(m_tracks.contains(trackId));
     MediaSourceTrackGStreamer* track = m_tracks.get(trackId);
-    track->notifyWhenReadyForMoreSamples([weakPtr = WeakPtr { *this }, this, trackId]() mutable {
-        RunLoop::main().dispatch([weakPtr = WTFMove(weakPtr), this, trackId]() {
+    track->notifyWhenReadyForMoreSamples([weakPtr = WeakPtr { *this }, this, trackId = trackId.string().isolatedCopy()]() mutable {
+        RunLoop::main().dispatch([weakPtr = WTFMove(weakPtr), this, trackId = WTFMove(trackId)]() {
             if (!weakPtr)
                 return;
             if (!m_hasBeenRemovedFromMediaSource)
-                provideMediaData(trackId);
+                provideMediaData(AtomString{ trackId });
         });
     });
 }

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaAnimation.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaAnimation.cpp
@@ -184,7 +184,7 @@ Animation::Animation(const String& name, const KeyframeValueList& keyframes, con
 }
 
 Animation::Animation(const Animation& other)
-    : m_name(other.m_name.isSafeToSendToAnotherThread() ? other.m_name : other.m_name.isolatedCopy())
+    : m_name(other.m_name.isolatedCopy())
     , m_keyframes(other.m_keyframes)
     , m_boxSize(other.m_boxSize)
     , m_timingFunction(other.m_timingFunction->clone())
@@ -202,7 +202,7 @@ Animation::Animation(const Animation& other)
 
 Animation& Animation::operator=(const Animation& other)
 {
-    m_name = other.m_name.isSafeToSendToAnotherThread() ? other.m_name : other.m_name.isolatedCopy();
+    m_name = other.m_name.isolatedCopy();
     m_keyframes = other.m_keyframes;
     m_boxSize = other.m_boxSize;
     m_timingFunction = other.m_timingFunction->clone();


### PR DESCRIPTION
This fixes some random use-after-free reported by ASAN (when destroying SourceBufferPrivateGStreamer) and by Ref/Deref threading check applied on StringImpl object. 

- first commit addresses the race between main and streaming thread on track id string refcount. WebKitMediaSourceGStreamer references trackId in streaming thread when creating stream id, when notifying of low buffer level and for debugging purposes. The lifetime of trackId is guarantied to outlive streaming thread, so it should be enough to avoid copying the trackId or create an isolated copy when needed.

- second commit addresses potential problem with the copy of Nicosia Animation. The Ref/Deref check report that same string is shared between main and compositor threads.

The Ref/Deref threading check implementation is available here:
https://github.com/emutavchi/WebKitForWayland/commit/724ef45a45fa0ec8527f68248038ea582a754ca5. It is not included in this PR because it brings some overhead and may give false positive results (so reports should be reviewed carefully).