### PR TITLE
[wpe-2.38][KeyEvent] Throttle keys repetition

### DIFF
--- a/Source/WebKit/Shared/WebKeyboardEvent.cpp
+++ b/Source/WebKit/Shared/WebKeyboardEvent.cpp
@@ -223,4 +223,18 @@ bool WebKeyboardEvent::isKeyboardEventType(Type type)
     return type == RawKeyDown || type == KeyDown || type == KeyUp || type == Char;
 }
 
+bool operator==(const WebKeyboardEvent& a, const WebKeyboardEvent& b)
+{
+    return a.type() == b.type()
+        && a.modifiers() == b.modifiers()
+        && a.text() == b.text()
+        && a.unmodifiedText() == b.unmodifiedText()
+        && a.key() == b.key()
+        && a.code() == b.code()
+        && a.keyIdentifier() == b.keyIdentifier()
+        && a.windowsVirtualKeyCode() == b.windowsVirtualKeyCode()
+        && a.nativeVirtualKeyCode() == b.nativeVirtualKeyCode()
+        && a.macCharCode() == b.macCharCode();
+}
+
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebKeyboardEvent.h
+++ b/Source/WebKit/Shared/WebKeyboardEvent.h
@@ -82,6 +82,7 @@ public:
 
     static bool isKeyboardEventType(Type);
 
+    friend bool operator==(const WebKeyboardEvent&, const WebKeyboardEvent&);
 private:
     String m_text;
     String m_unmodifiedText;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -3111,6 +3111,11 @@ bool WebPageProxy::handleKeyboardEvent(const NativeWebKeyboardEvent& event)
     
     LOG(KeyHandling, "WebPageProxy::handleKeyboardEvent: %s", webKeyboardEventTypeString(event.type()));
 
+    if (event.type() == WebEvent::KeyDown && !m_keyEventQueue.isEmpty() && m_keyEventQueue.last() == event) {
+        // Throtthe key repetition if we still have previous keypress pending
+        return true;
+    }
+
     m_keyEventQueue.append(event);
 
     m_process->startResponsivenessTimer(event.type() == WebEvent::KeyDown ? WebProcessProxy::UseLazyStop::Yes : WebProcessProxy::UseLazyStop::No);


### PR DESCRIPTION
In some apps it takes long time to handle key input (e.g. >500ms), longer than key repetition interval is.
WebKit collects all key repetitions (KeyDown events) in m_keyEventQueue and sends them one by one to the WebProcess. This may take significant time, even after releasing all the buttons (keyboard/RCU) blocking web app UI and making the app unresponsive untill all repetitions are handled.

Proposed solution is to simply detect key repetition (next KeyDown event without KeyUp) and skip it if the previous one wasn't handled yet.