### PR TITLE
[Parser] Fix self closing object handling

### DIFF
--- a/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
+++ b/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
@@ -718,6 +718,12 @@ void HTMLTreeBuilder::processStartTagForInBody(AtomHTMLToken&& token)
         if (!pluginContentIsAllowed(m_tree.parserContentPolicy()))
             return;
     }
+    if (token.selfClosing() && token.name() == objectTag) {
+        m_tree.reconstructTheActiveFormattingElements();
+        m_tree.insertSelfClosingHTMLElement(WTFMove(token));
+        m_framesetOk = false;
+        return;
+    }
     if (token.name() == appletTag || token.name() == marqueeTag || token.name() == objectTag) {
         m_tree.reconstructTheActiveFormattingElements();
         m_tree.insertHTMLElement(WTFMove(token));


### PR DESCRIPTION
When specifying the object element as `<object />`, the closing tag is not recognized, causing next elements to be added as childs of the object element. When using `<object></object>`, this issue does not occur.

This can be reproduced with the following html:
```
<html>
    <head>
    </head>
    <body >
        <div>
            <object id="myobject"/>
        </div>
        <div>
            This shall not be a child of the object element
        </div>
    </body>
</html>

```
Without the fix, this is the element tree that results from the parsing:
![object-self-close-failed](https://github.com/user-attachments/assets/9ba4e1e4-03e0-44f6-939b-09a0d5092a68)

