### PR TITLE
Fix crash on shutdown in non-composited GL mode

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1619,9 +1619,10 @@ void WebPage::close()
 
     m_printContext = nullptr;
     m_mainFrame->coreFrame()->loader().detachFromParent();
-    m_drawingArea = nullptr;
 
     DeferredPageDestructor::createDeferredPageDestructor(WTFMove(m_page), this);
+
+    m_drawingArea = nullptr;
 
     bool isRunningModal = m_isRunningModal;
     m_isRunningModal = false;


### PR DESCRIPTION
Use case: page using non-composited GL mode and redirection with
original frame remaining in cache

In non-composited GL mode, a page that has a canvas element will lead to
the creation of an HTMLCanvasElement instance followed by the creation
of a WebGLRenderingContext instance (and down to the EGL context).

If we trigger a redirection to another page with a canvas element from
within the javascript section and outside of any callback/promise
handler, the previous rendering context will get released and a new one
created as part of the new html page that was loaded.

However, when the redirection takes place from within a promise handler,
the original page frame is cached (CachedFrame instance) and the new one
loaded without the context getting released. If we close the browser
instance after the redirection has completed, 2 WebGL contexts will
exist and attempted to be released, one associated with the cached frame
before the redirection took place, and another one with the new one
after the redirection.

In this case we run into a race condition involving the cached frame and
current page destruction, and the Threaded Compositor (and therefore the
window surface / GL Context) destruction.

In the working case (no crash), the sequence of destroying the cached
frame (CachedFrame::destroy) consequence of the "ClearCachedPage"
message, followed by frame loader "detachFromParent" call, ensure that
both contexts get destroyed before the Threaded Compositor.

In the crash scenario, the sequence consists of a call to the frame
loader "detachFromParent" due WebProcess::stopRunLoop() invocation
(UIProcess comms channel disconnection detected), followed by the call
to the cached frame destruction, now consequence of the call to the
DeferredPageDestructor (not "ClearCachePage" message). In this case the
Threaded Compositor was already destroyed and with it the underlying
contexts.

The attached [test.zip](https://github.com/user-attachments/files/16549960/test.zip) package contains a simplified test page to reproduce the issue (see included readme.txt for instructions)

 