### PR TITLE
Issue: Audio not heard after seek of AppleTV video

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -2928,6 +2928,14 @@ void MediaPlayerPrivateGStreamer::createGSTPlayBin(const URL& url)
 
     ASSERT(!m_pipeline);
 
+    GRefPtr<GstPluginFeature> ac3parse = gst_registry_lookup_feature(registry, "ac3parse");
+    //Making ac3parser lowest rank so as to not get it included in pipeline, else will cause packet drop
+    //for ac3 encrypted content, especially after a seek
+    if (ac3parse) {
+        GST_DEBUG_OBJECT(pipeline(),"Making ac3pasre lowest rank to not get it included in gst pipeline");
+        gst_plugin_feature_set_rank(ac3parse.get(), 0);
+    }
+
     auto elementId = m_player->elementId();
     if (elementId.isEmpty())
         elementId = "media-player"_s;


### PR DESCRIPTION
Description: When AppleTV+ video content is played and if seek/jump is performed, it is seen that audio is not heard. AppleTV uses AC3 encrypted audio. AC3 parser which is automatically added in the gst pipeline drops encrypted audio.

Solution: Make AC3 parser lowest rank so as to not get included in the gst pipeline.

# Pull Request Template

## File a Bug

All changes should be associated with a bug. The WebKit project is currently using [Bugzilla](https://bugs.webkit.org) as our bug tracker. Note that multiple changes may be associated with a single bug.

## Provided Tooling

The WebKit Project strongly recommends contributors use [`Tools/Scripts/git-webkit`](https://github.com/WebKit/WebKit/tree/main/Tools/Scripts/git-webkit) to generate pull requests. See [Setup](https://github.com/WebKit/WebKit/wiki/Contributing#setup) and [Contributing Code](https://github.com/WebKit/WebKit/wiki/Contributing#contributing-code) for how to do this.

## Template

If a contributor wishes to file a pull request manually, the template is below. Manually-filed pull requests should contain their commit message as the pull request description, and their commit message should be formatted like the template below.

Additionally, the pull request should be mentioned on [Bugzilla](https://bugs.webkit.org), labels applied to the pull request matching the component and version of the [Bugzilla](https://bugs.webkit.org) associated with the pull request and the pull request assigned to its author.

<pre>
< bug title >
<a href="https://bugs.webkit.org/enter_bug.cgi">https://bugs.webkit.org/show_bug.cgi?id=#####</a>

Reviewed by NOBODY (OOPS!).

* path/changed.ext:
(function):
(class.function):

</pre>
