### PR TITLE
Gamepad input delay of 5ms cases more delay in overall latency 

### DIFF
--- a/Source/WebCore/platform/gamepad/wpe/WPEGamepadProvider.cpp
+++ b/Source/WebCore/platform/gamepad/wpe/WPEGamepadProvider.cpp
@@ -38,7 +38,7 @@
 namespace WebCore {
 
 static const Seconds connectionDelayInterval { 500_ms };
-static const Seconds inputNotificationDelay { 5_ms };
+static const Seconds inputNotificationDelay { 0_ms };
 
 WPEGamepadProvider& WPEGamepadProvider::singleton()
 {


### PR DESCRIPTION
Gamepad input delay of 5ms cases more delay in overall latency playing Cloud game using webrtc. We do not need to wait 5ms to fire the scheduler. 