### PR TITLE
[GStreamer] Critical warning when updating video sink stats of a player in error state

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -4221,6 +4221,9 @@ bool MediaPlayerPrivateGStreamer::updateVideoSinkStatistics()
     uint64_t totalVideoFrames = 0;
     uint64_t droppedVideoFrames = 0;
     if (webkitGstCheckVersion(1, 18, 0)) {
+        if (!m_videoSink)
+            return false;
+
         GUniqueOutPtr<GstStructure> stats;
         g_object_get(m_videoSink.get(), "stats", &stats.outPtr(), nullptr);
 


### PR DESCRIPTION
This is a backport from https://commits.webkit.org/264718@main upstream, authored by Philippe Normand.

Reviewed by Xabier Rodriguez-Calvar.

Don't attempt to gather video rendering metrics if the player hasn't created a video sink.

* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp: (WebCore::MediaPlayerPrivateGStreamer::updateVideoSinkStatistics):

Canonical link: https://commits.webkit.org/264718@main