### PR TITLE
Fix seek getting called in a loop if the application passes negative…

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -3453,7 +3453,9 @@ MediaTime HTMLMediaElement::currentMediaTime() const
     if (!m_player)
         return MediaTime::zeroTime();
 
-    if (m_defaultPlaybackStartPosition != MediaTime::zeroTime())
+    // Based on the commit : https://github.com/LibertyGlobal/WPEWebKit/commit/a7f9b178bfe7382a495943cd57efac7023df8eae,
+    // m_defaultPlaybackStartPosition needs to be higher than zero
+    if (m_defaultPlaybackStartPosition > MediaTime::zeroTime())
         return m_defaultPlaybackStartPosition;
 
     if (m_seeking) {


### PR DESCRIPTION
… seek position which will eventually impact playback functionality

Return appropriate m_defaultPlaybackStartPosition from WebCore::HTMLMediaElement::currentMediaTime() method when m_defaultPlaybackStartPosition is higher than zero

Based on the commit: https://github.com/LibertyGlobal/WPEWebKit/commit/a7f9b178bfe7382a495943cd57efac7023df8eae, it is mentioned that we need to return m_defaultPlaybackStartPosition when it is higher than zero from WebCore::HTMLMediaElement::currentMediaTime() method. In the https://github.com/LibertyGlobal/WPEWebKit/blob/e4ddfbf5bca252aae8d8f428804b5fe6a11bc3fb/Source/WebCore/html/HTMLMediaElement.cpp#L3422, the condition check is not appropriate due to which if the application passes negative seek position, this will lead into seek getting triggered in a loop and eventually the playback fails.

This patch needs to be upstreamed to main WebKit: https://github.com/WebKit/WebKit if accepted.
