### PR TITLE
Rialto webaudio with WebKit audio sink (mixer)

### DIFF
--- a/Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp
@@ -156,10 +156,24 @@ AudioDestinationGStreamer::AudioDestinationGStreamer(AudioIOCallback& callback, 
     GstElement* audioResample = makeGStreamerElement("audioresample", nullptr);
     gst_bin_add_many(GST_BIN_CAST(m_pipeline.get()), m_src.get(), audioConvert, audioResample, audioSink.get(), nullptr);
 
-    // Link src pads from webkitAudioSrc to audioConvert ! audioResample ! autoaudiosink.
+    // Link src pads from webkitAudioSrc to audioConvert ! audioResample ! [capsfilter !] webaudiosink.
     gst_element_link_pads_full(m_src.get(), "src", audioConvert, "sink", GST_PAD_LINK_CHECK_NOTHING);
     gst_element_link_pads_full(audioConvert, "src", audioResample, "sink", GST_PAD_LINK_CHECK_NOTHING);
-    gst_element_link_pads_full(audioResample, "src", audioSink.get(), "sink", GST_PAD_LINK_CHECK_NOTHING);
+
+    if (!webkitGstCheckVersion(1, 20, 4)) {
+        // Force audio conversion to 'interleaved' format (by audioconvert element).
+        // 1) Some platform sinks don't support non-interleaved audio without special caps (rialtowebaudiosink).
+        // 2) Interaudio sink/src doesn't fully support non-interleaved audio (webkit audio sink)
+        // 3) audiomixer doesn't support non-interleaved audio in output pipeline (webkit audio sink)
+        GstElement* capsFilter = makeGStreamerElement("capsfilter", nullptr);
+        GRefPtr<GstCaps> caps = adoptGRef(gst_caps_new_simple("audio/x-raw", "layout", G_TYPE_STRING, "interleaved", nullptr));
+        g_object_set(capsFilter, "caps", caps.get(), nullptr);
+        gst_bin_add(GST_BIN_CAST(m_pipeline.get()), capsFilter);
+        gst_element_link_pads_full(audioResample, "src", capsFilter, "sink", GST_PAD_LINK_CHECK_NOTHING);
+        gst_element_link_pads_full(capsFilter, "src", audioSink.get(), "sink", GST_PAD_LINK_CHECK_NOTHING);
+    } else {
+        gst_element_link_pads_full(audioResample, "src", audioSink.get(), "sink", GST_PAD_LINK_CHECK_NOTHING);
+    }
 }
 
 AudioDestinationGStreamer::~AudioDestinationGStreamer()

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.cpp
@@ -29,6 +29,7 @@
 #if USE(GSTREAMER)
 
 #include "GStreamerCommon.h"
+#include "WebKitAudioSinkGStreamer.h"
 #include <wtf/OptionSet.h>
 
 namespace WebCore {
@@ -87,6 +88,10 @@ GstElement* GStreamerQuirkRialto::createAudioSink()
 
 GstElement* GStreamerQuirkRialto::createWebAudioSink()
 {
+    if (GstElement* sink = webkitAudioSinkNew()) {
+        return sink;
+    }
+
     auto sink = makeGStreamerElement("rialtowebaudiosink", nullptr);
     RELEASE_ASSERT_WITH_MESSAGE(sink, "rialtowebaudiosink should be available in the system but it is not");
     return sink;


### PR DESCRIPTION
1) Use Webkit audio sink with Rialto
2) Force 'interleaved' audio for webaudio sinks