### PR TITLE
[wpe-2.38] [HTMLMediaElement] Reschedule `timeupdate` event if fired too early

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -4246,8 +4246,11 @@ void HTMLMediaElement::scheduleTimeupdateEvent(bool periodicEvent)
     Seconds timedelta = now - m_clockTimeAtLastUpdateEvent;
 
     // throttle the periodic events
-    if (periodicEvent && timedelta < maxTimeupdateEventFrequency)
+    if (periodicEvent && timedelta < maxTimeupdateEventFrequency) {
+        // Reschedule the timer to fire at the correct time, ensuring that no full cycles are skipped
+        m_playbackProgressTimer.start(maxTimeupdateEventFrequency - timedelta, maxTimeupdateEventFrequency);
         return;
+    }
 
     // Some media engines make multiple "time changed" callbacks at the same time, but we only want one
     // event at a given time so filter here


### PR DESCRIPTION
HTMLMediaElement fires `timeupdate` every 250ms in repeating timer. If timer is fired before 250ms from the last occurance it is silently skipped and needs to wait for another 250ms. As a result the gap between two following timeupdate events may vary 250-500ms. This may happen in two cases:
1) Non-periodic timeupdate event is scheduled for any reason
2) When the difference between two timer calls is lower than 250ms.
The second may happen when there are multiple timers to handle at the same time in ThreadTimers (maxDurationOfFiringTimers)

Reproduced with https://ytlr-cert.appspot.com/latest/main.html?&test_type=progressive-test#1724678529990 maxGranularity tests