### PR TITLE
[GSTMediaPlayer] For progressive playback wait for underflow before b…

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -389,6 +389,8 @@ protected:
     bool m_canFallBackToLastFinishedSeekPosition { false };
     bool m_isChangingRate { false };
     bool m_didDownloadFinish { false };
+    bool m_hasUnderflow { false };
+    Atomic<bool> m_underflowSignalConnected { false };
     bool m_didErrorOccur { false };
     mutable bool m_isEndReached { false };
     mutable std::optional<bool> m_isLiveStream;
@@ -523,6 +525,7 @@ private:
     void processBufferingStats(GstMessage*);
     void updateBufferingStatus(GstBufferingMode, double percentage);
     void updateMaxTimeLoaded(double percentage);
+    void handleBufferUnderflow();
 
 #if USE(GSTREAMER_MPEGTS)
     void processMpegTsSection(GstMpegtsSection*);
@@ -540,6 +543,7 @@ private:
     static void downloadBufferFileCreatedCallback(MediaPlayerPrivateGStreamer*);
 
     void configureVideoDecoder(GstElement*);
+    void configureVideoSink(GstElement*);
     void configureElement(GstElement*);
 
     void configureElementPlatformQuirks(GstElement*);


### PR DESCRIPTION
…uffering again

Some elements in GST pipeline have significant buffer size and are able to drain queue2 element almost immediately. This results with many "buffering" messages alternating between 0% and 100%, especially at the beginning of progressive playback and for low bitrate content. This triggers updateStates(), ready state changes, etc that unnecessary block the main thread.

As a solution wait for `buffer-undeflow-callback` from video sink before marking buffering again.

The issue is visible with YT cert tests for progressive playback, maxGranularity test cases, where many tasks on main thread delay timeupdate event