### PR TITLE
[Modern Media Controls] remove window event listeners at deinitialization

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/controls/media-controls.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/media-controls.js
@@ -205,6 +205,16 @@ class MediaControls extends LayoutNode
         return this.children.some(child => child.element.contains(tappedElement));
     }
 
+    deinitialize()
+    {
+        window.removeEventListener("dragstart", this, true);
+    }
+
+    reinitialize()
+    {
+        window.addEventListener("dragstart", this, true);
+    }
+
     // Protected
 
     handleEvent(event)

--- a/Source/WebCore/Modules/modern-media-controls/media/media-controller.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/media-controller.js
@@ -222,6 +222,9 @@ class MediaController
     deinitialize()
     {
         this.shadowRoot.removeChild(this.container);
+        window.removeEventListener("keydown", this);
+        if (this.controls)
+            this.controls.deinitialize();
         return true;
     }
 
@@ -232,6 +235,9 @@ class MediaController
         this.mediaWeakRef = new WeakRef(media);
         this.host = host;
         shadowRoot.appendChild(this.container);
+        window.addEventListener("keydown", this);
+        if (this.controls)
+            this.controls.reinitialize();
         return true;
     }
 
@@ -268,6 +274,9 @@ class MediaController
             for (let supportingObject of this._supportingObjects)
                 supportingObject.disable();
         }
+
+        if (previousControls)
+            previousControls.deinitialize();
 
         this.controls = new ControlsClass;
         this.controls.delegate = this;


### PR DESCRIPTION
DOMWindow keeps media controls object alive because of installed event listeners (see JSDOMWindow::visitAdditionalChildren). This results in extra memory usage until DOMWindow cleared (on top level navigation).

