### PR TITLE
Add setting to enable/disable WebRTC ICE candidate filtering

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
@@ -180,6 +180,7 @@ enum {
     PROP_ALLOW_MOVE_TO_SUSPEND_ON_WINDOW_CLOSE,
     PROP_ENABLE_DIRECTORY_UPLOAD,
     PROP_ENABLE_SERVICE_WORKER,
+    PROP_ENABLE_ICE_CANDIDATE_FILTERING,
     N_PROPERTIES,
 };
 
@@ -434,6 +435,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     case PROP_ENABLE_SERVICE_WORKER:
         webkit_settings_set_enable_service_worker(settings, g_value_get_boolean(value));
         break;
+    case PROP_ENABLE_ICE_CANDIDATE_FILTERING:
+        webkit_settings_set_enable_ice_candidate_filtering(settings, g_value_get_boolean(value));
+        break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propId, paramSpec);
         break;
@@ -658,6 +662,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         break;
     case PROP_ENABLE_SERVICE_WORKER:
         g_value_set_boolean(value, webkit_settings_get_enable_service_worker(settings));
+        break;
+    case PROP_ENABLE_ICE_CANDIDATE_FILTERING:
+        g_value_set_boolean(value, webkit_settings_get_enable_ice_candidate_filtering(settings));
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propId, paramSpec);
@@ -1751,6 +1758,19 @@ static void webkit_settings_class_init(WebKitSettingsClass* klass)
         "enable-service-worker",
         _("Enable service worker"),
         _("Whether service worker support should be enabled."),
+        TRUE,
+        readWriteConstructParamFlags);
+
+    /**
+     * WebKitSettings:enable-ice-candidate-filtering:
+     *
+     * Enable or disable ICE candidate filtering.
+     *
+     */
+    sObjProperties[PROP_ENABLE_ICE_CANDIDATE_FILTERING] = g_param_spec_boolean(
+        "enable-ice-candidate-filtering",
+        _("Enable ICE candidate filtering"),
+        _("Whether ICE candidate filtering should be enabled."),
         TRUE,
         readWriteConstructParamFlags);
 
@@ -4410,4 +4430,39 @@ void webkit_settings_set_enable_service_worker(WebKitSettings* settings, gboolea
 
     priv->preferences->setServiceWorkersEnabled(enabled);
     g_object_notify_by_pspec(G_OBJECT(settings), sObjProperties[PROP_ENABLE_SERVICE_WORKER]);
+}
+
+/**
+ * webkit_settings_get_enable_ice_candidate_filtering:
+ * @settings: a #WebKitSettings
+ *
+ * Get the #WebKitSettings:enable-ice-candidate-filtering property.
+ *
+ * Returns: %TRUE If ICE candidate filtering is enabled or %FALSE otherwise.
+ */
+gboolean webkit_settings_get_enable_ice_candidate_filtering(WebKitSettings* settings)
+{
+    g_return_val_if_fail(WEBKIT_IS_SETTINGS(settings), FALSE);
+
+    return settings->priv->preferences->iceCandidateFilteringEnabled();
+}
+
+/**
+ * webkit_settings_set_enable_ice_candidate_filtering:
+ * @settings: a #WebKitSettings
+ * @enabled: Value to be set
+ *
+ * Set the #WebKitSettings:enable-ice-candidate-filtering property.
+ */
+void webkit_settings_set_enable_ice_candidate_filtering(WebKitSettings* settings, gboolean enabled)
+{
+    g_return_if_fail(WEBKIT_IS_SETTINGS(settings));
+
+    WebKitSettingsPrivate* priv = settings->priv;
+    bool currentValue = priv->preferences->iceCandidateFilteringEnabled();
+    if (currentValue == enabled)
+        return;
+
+    priv->preferences->setICECandidateFilteringEnabled(enabled);
+    g_object_notify(G_OBJECT(settings), "enable-ice-candidate-filtering");
 }

--- a/Source/WebKit/UIProcess/API/wpe/WebKitSettings.h
+++ b/Source/WebKit/UIProcess/API/wpe/WebKitSettings.h
@@ -533,6 +533,13 @@ WEBKIT_API void
 webkit_settings_set_enable_service_worker                       (WebKitSettings* settings,
                                                                  gboolean enabled);
 
+WEBKIT_API gboolean
+webkit_settings_get_enable_ice_candidate_filtering             (WebKitSettings *settings);
+
+WEBKIT_API void
+webkit_settings_set_enable_ice_candidate_filtering             (WebKitSettings *settings,
+                                                                gboolean        enabled);
+
 G_END_DECLS
 
 #endif /* WebKitSettings_h */


### PR DESCRIPTION
Add setting to be able to control filtering of webRTC ICE candidates (server reflex, relay and host).