### PR TITLE
RDKDEV-1086: allow to pass "stuns" locators

### DIFF
--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
@@ -461,7 +461,7 @@ ExceptionOr<Vector<MediaEndpointConfiguration::IceServerInfo>> RTCPeerConnection
                         if (server.credential.utf8().length() > MaxTurnUsernameLength || server.username.utf8().length() > MaxTurnUsernameLength)
                             return Exception { TypeError, "TURN/TURNS username and/or credential are too long"_s };
                     }
-                } else if (!serverURL.protocolIs("stun"_s))
+                } else if (!serverURL.protocolIs("stun"_s) && !serverURL.protocolIs("stuns"_s))
                     return Exception { NotSupportedError, "ICE server protocol not supported"_s };
             }
             if (serverURLs.size())


### PR DESCRIPTION
Based on the information found in the following tickets, comparisons and tests on PC Chrome and WPE2.38 and code review there are not available at all stuns implementation:

https://issues.webrtc.org/issues/42225835
https://issues.webrtc.org/issues/42230379
https://issues.webrtc.org/issues/42227696

After check "stuns" locators are processed by libwebrtc library in the same way like "stun" ones (udp only protocol is used), we could now allow to pass such locators without exception.

We could accept stuns locator, but the inernal implementation in libwebrtc would do stun via UDP requests for that.