### PR TITLE
[2.38][SoupNetworkProcess] Destroy all Network sessions at exit

### DIFF
--- a/Source/WebKit/NetworkProcess/soup/NetworkProcessMainSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/NetworkProcessMainSoup.cpp
@@ -52,6 +52,13 @@ public:
         // FIXME: Is this still needed? We should probably destroy all existing sessions at this point instead.
         // Needed to destroy the SoupSession and SoupCookieJar, e.g. to avoid
         // leaking SQLite temporary journaling files.
+        Vector<PAL::SessionID> sessionIDs;
+        process().forEachNetworkSession([&sessionIDs](auto& session) {
+            sessionIDs.append(session.sessionID());
+        });
+        for (auto& sessionID : sessionIDs) {
+            process().destroySession(sessionID);
+        }
         process().destroySession(PAL::SessionID::defaultSessionID());
     }
 };


### PR DESCRIPTION
Destroy all NetworkSession(s) in platformFinalize() to make sure all resources are cleared.

It happens that DestroySession message from UI process is not handled in NetworkProcess becasue of UI process connection loss that triggers exit procedure on Network process side. Once that happens, active NetworkSessions are never destroyed.

This fixes a crash when main thread is exiting, executing exit handlers and unloading libraries, while ssl thread is performing asynchronous handshake:

```
Open SSL GIO thread:

10|0|libpthread-2.31.so|__pthread_rwlock_rdlock|/usr/src/debug/glibc/2.31+gitAUTOINC+1094741224-r0/git/nptl/pthread_rwlock_common.c|299|0x8
10|1|libcrypto.so.1.1|CRYPTO_THREAD_read_lock|/usr/src/debug/openssl/1.1.1l-r0/build/../openssl-1.1.1l/crypto/threads_pthread.c|65|0x3
10|2|libcrypto.so.1.1|int_err_get_item|/usr/src/debug/openssl/1.1.1l-r0/build/../openssl-1.1.1l/crypto/err/err.c|179|0x3
10|3|libcrypto.so.1.1|ERR_lib_error_string|/usr/src/debug/openssl/1.1.1l-r0/build/../openssl-1.1.1l/crypto/err/err.c|647|0x3
10|4|libcrypto.so.1.1|ERR_error_string_n|/usr/src/debug/openssl/1.1.1l-r0/build/../openssl-1.1.1l/crypto/err/err.c|595|0x3
10|5|libgioopenssl.so|perform_openssl_io|/usr/src/debug/glib-networking/2.72.2-r0/build/../glib-networking-2.72.2/tls/openssl/gtlsconnection-openssl.c|325|0x9
10|6|libgioopenssl.so|g_tls_connection_openssl_handshake_thread_handshake|/usr/src/debug/glib-networking/2.72.2-r0/build/../glib-networking-2.72.2/tls/openssl/gtlsconnection-openssl.c|838|0x23
10|7|libgioopenssl.so|handshake_thread|/usr/src/debug/glib-networking/2.72.2-r0/build/../glib-networking-2.72.2/tls/base/gtlsconnection-base.c|1564|0x11
10|8|libgioopenssl.so|async_handshake_thread|/usr/src/debug/glib-networking/2.72.2-r0/build/../glib-networking-2.72.2/tls/base/gtlsconnection-base.c|1848|0x9
10|9|libgio-2.0.so.0.7200.3|g_task_thread_pool_thread|/usr/src/debug/glib-2.0/1_2.72.3-r0/build/../glib-2.72.3/gio/gtask.c|1452|0xb
10|10|libglib-2.0.so.0.7200.3|g_thread_pool_thread_proxy|/usr/src/debug/glib-2.0/1_2.72.3-r0/build/../glib-2.72.3/glib/gthreadpool.c|354|0x7
10|11|libglib-2.0.so.0.7200.3|g_thread_proxy|/usr/src/debug/glib-2.0/1_2.72.3-r0/build/../glib-2.72.3/glib/gthread.c|827|0x5
10|12|libpthread-2.31.so|start_thread|/usr/src/debug/glibc/2.31+gitAUTOINC+1094741224-r0/git/nptl/pthread_create.c|477|0x1
10|13|libc-2.31.so|clone|||0x3a

MAIN THREAD is executing exit handlers and is destroying static objects:

0|0|libc-2.31.so|__libc_free|/usr/src/debug/glibc/2.31+gitAUTOINC+1094741224-r0/git/malloc/malloc.c|3122|0xe
0|1|libWPEFrameworkCOM.so.4.4.1|WPEFramework::Core::FrameType<512u, true, unsigned int>::AllocatorType<512u, unsigned int>::~AllocatorType()|/usr/src/debug/wpeframework/4.4-r0/git/Source/core/../core/Frame.h|142|0x3
0|2|libWPEFrameworkCOM.so.4.4.1|WPEFramework::Core::IPCMessageType<1u, WPEFramework::RPC::Data::Init, WPEFramework::RPC::Data::Setup>::RawSerializedType<WPEFramework::RPC::Data::Init, 2u>::~RawSerializedType()|/usr/src/debug/wpeframework/4.4-r0/git/Source/core/../core/Frame.h|447|0x3
0|3|libWPEFrameworkCOM.so.4.4.1|WPEFramework::Core::IPCMessageType<1u, WPEFramework::RPC::Data::Init, WPEFramework::RPC::Data::Setup>::~IPCMessageType()|/usr/src/debug/wpeframework/4.4-r0/git/Source/core/../core/IPCConnector.h|432|0x19
0|4|libWPEFrameworkCOM.so.4.4.1|WPEFramework::Core::ProxyObject<WPEFramework::Core::ProxyContainerType<WPEFramework::Core::ProxyPoolType<WPEFramework::Core::IPCMessageType<1u, WPEFramework::RPC::Data::Init, WPEFramework::RPC::Data::Setup> >, WPEFramework::Core::IPCMessageType<1u, WPEFramework::RPC::Data::Init, WPEFramework::RPC::Data::Setup>, WPEFramework::Core::IPCMessageType<1u, WPEFramework::RPC::Data::Init, WPEFramework::RPC::Data::Setup> > >::~ProxyObject()|/usr/src/debug/wpeframework/4.4-r0/git/Source/core/../core/Proxy.h|1221|0xf
0|5|libWPEFrameworkCOM.so.4.4.1|WPEFramework::Core::ProxyObject<WPEFramework::Core::ProxyContainerType<WPEFramework::Core::ProxyPoolType<WPEFramework::Core::IPCMessageType<1u, WPEFramework::RPC::Data::Init, WPEFramework::RPC::Data::Setup> >, WPEFramework::Core::IPCMessageType<1u, WPEFramework::RPC::Data::Init, WPEFramework::RPC::Data::Setup>, WPEFramework::Core::IPCMessageType<1u, WPEFramework::RPC::Data::Init, WPEFramework::RPC::Data::Setup> > >::~ProxyObject()|/usr/src/debug/wpeframework/4.4-r0/git/Source/core/../core/Proxy.h|119|0x3
0|6|libWPEFrameworkCOM.so.4.4.1|WPEFramework::Core::ProxyObject<WPEFramework::Core::ProxyContainerType<WPEFramework::Core::ProxyPoolType<WPEFramework::Core::IPCMessageType<1u, WPEFramework::RPC::Data::Init, WPEFramework::RPC::Data::Setup> >, WPEFramework::Core::IPCMessageType<1u, WPEFramework::RPC::Data::Init, WPEFramework::RPC::Data::Setup>, WPEFramework::Core::IPCMessageType<1u, WPEFramework::RPC::Data::Init, WPEFramework::RPC::Data::Setup> > >::Release() const|/usr/src/debug/wpeframework/4.4-r0/git/Source/core/../core/Proxy.h|136|0x3
0|7|libWPEFrameworkCOM.so.4.4.1|WPEFramework::Core::ProxyType<WPEFramework::Core::ProxyContainerType<WPEFramework::Core::ProxyPoolType<WPEFramework::Core::IPCMessageType<1u, WPEFramework::RPC::Data::Init, WPEFramework::RPC::Data::Setup> >, WPEFramework::Core::IPCMessageType<1u, WPEFramework::RPC::Data::Init, WPEFramework::RPC::Data::Setup>, WPEFramework::Core::IPCMessageType<1u, WPEFramework::RPC::Data::Init, WPEFramework::RPC::Data::Setup> > >::~ProxyType()|/usr/src/debug/wpeframework/4.4-r0/git/Source/core/../core/Proxy.h|435|0x5
0|8|libWPEFrameworkCOM.so.4.4.1|WPEFramework::Core::ProxyPoolType<WPEFramework::Core::IPCMessageType<1u, WPEFramework::RPC::Data::Init, WPEFramework::RPC::Data::Setup> >::~ProxyPoolType()|/usr/src/debug/wpeframework/4.4-r0/git/Source/core/../core/Proxy.h|1451|0x5
0|9|libc-2.31.so|__cxa_finalize|/usr/src/debug/glibc/2.31+gitAUTOINC+1094741224-r0/git/stdlib/cxa_finalize.c|83|0x5
0|10|libWPEFrameworkCOM.so.4.4.1|__do_global_dtors_aux|||0x1c
0|11|ld-2.31.so|_dl_fini|/usr/src/debug/glibc/2.31+gitAUTOINC+1094741224-r0/git/elf/dl-fini.c|138|0x3
```