### PR TITLE
[WPE][GTK] visible rect in case animations is not correctly calculated

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h
@@ -134,6 +134,7 @@ public:
     void computePixelAlignment(FloatPoint& position, FloatSize&, FloatPoint3D& anchorPoint, FloatSize& alignmentOffset);
 
     IntRect transformedVisibleRect();
+    IntRect transformedVisibleRectIncludingFuture();
 
     void invalidateCoordinator();
     void setCoordinatorIncludingSubLayersIfNeeded(CoordinatedGraphicsLayerClient*);
@@ -211,7 +212,9 @@ private:
 
     Nicosia::PlatformLayer::LayerID m_id;
     GraphicsLayerTransform m_layerTransform;
+    GraphicsLayerTransform m_layerFutureTransform;
     TransformationMatrix m_cachedInverseTransform;
+    TransformationMatrix m_cachedFutureInverseTransform;
     FloatSize m_pixelAlignmentOffset;
     FloatSize m_adjustedSize;
     FloatPoint m_adjustedPosition;


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=280612

Reviewed by Miguel Gomez.

For animations starting partially outside the viewport were not fully rendered when the first frame entered the visible area. This caused incomplete or cut-off frames during the initial stages of the animation. The issue was more noticeable on low-end devices(RPi) or during slow-motion or frame-by-frame analysis of the recordings on x86.

With this change the visible rect is extended with the elements which are currently not fully visible but they will be in a future bacause of animations.

* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp: (WebCore::CoordinatedGraphicsLayer::transformedVisibleRectIncludingFuture): (WebCore::CoordinatedGraphicsLayer::updateContentBuffers): (WebCore::CoordinatedGraphicsLayer::computeTransformedVisibleRect):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h: