### PR TITLE
[GTK][WPE] Network sessions are not destroyed in platformFinalize

### DIFF
--- a/Source/WebKit/NetworkProcess/soup/NetworkProcessMainSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/NetworkProcessMainSoup.cpp
@@ -49,10 +49,14 @@ public:
 
     void platformFinalize() override
     {
-        // FIXME: Is this still needed? We should probably destroy all existing sessions at this point instead.
         // Needed to destroy the SoupSession and SoupCookieJar, e.g. to avoid
         // leaking SQLite temporary journaling files.
-        process().destroySession(PAL::SessionID::defaultSessionID());
+        Vector<PAL::SessionID> sessionIDs;
+        process().forEachNetworkSession([&sessionIDs](auto& session) {
+            sessionIDs.append(session.sessionID());
+        });
+        for (auto& sessionID : sessionIDs)
+            process().destroySession(sessionID);
     }
 };
 


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=281143

Reviewed by Michael Catanzaro and Carlos Garcia Campos.

When we close UIProcess it sends to NetworkProcess message(s) to destroy all sessions (DestroySession) but right after that the IPC connection is close which causes that NetworkProcess can be closed without destroying all sessions.

This change destroys all sessions when the NetworkProcess is closing.

Original author: Andrzej Surdej <Andrzej_Surdej@comcast.com>

See: https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1406

* Source/WebKit/NetworkProcess/soup/NetworkProcessMainSoup.cpp:

Canonical link: https://commits.webkit.org/285119@main