### PR TITLE
RDKDEV-1093: improve gfx memory handling

### DIFF
--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -1305,6 +1305,8 @@ void WebGLRenderingContextBase::destroyGraphicsContextGL()
     removeActivityStateChangeObserver();
 
     if (m_context) {
+        // first release the big textures allocated for the FBOs
+        m_context->reshape(0,0);
         m_context->setClient(nullptr);
         m_context = nullptr;
         removeActiveContext(*this);


### PR DESCRIPTION
(1) calling 'reshape(0,0)' when destroying webgl context

This releases the textures attached to context fbo faster, without waiting for GC. These textures make up for a big chunk of gfx memory used, and when opening different apps quickly we were running out of gfx memory before GC was able to kick in.

(2) changing order of operations in ~WebGLRenderingContextBase

Removing from the context group before the context itself is removed. Otherwise, WebGLContextGroup will not be able to release some of the 'group shared' resources (these that still have attachements when being removed via WebGLSharedObject destructor) - it happens eg. for WebGLVertexArrayObjectBase objects that have buffers set on destruction time.
