### PR TITLE
RDK-588: GC/bmalloc finetuning on Broadcom platforms

### DIFF
--- a/Source/JavaScriptCore/heap/FullGCActivityCallback.cpp
+++ b/Source/JavaScriptCore/heap/FullGCActivityCallback.cpp
@@ -41,7 +41,7 @@ void FullGCActivityCallback::doCollection(VM& vm)
     Heap& heap = vm.heap;
     m_didGCRecently = false;
 
-#if !PLATFORM(IOS_FAMILY) || PLATFORM(MACCATALYST)
+#if (!PLATFORM(IOS_FAMILY) && !PLATFORM(BROADCOM)) || PLATFORM(MACCATALYST)
     MonotonicTime startTime = MonotonicTime::now();
     if (MemoryPressureHandler::singleton().isUnderMemoryPressure() && heap.isPagedOut()) {
         cancel();

--- a/Source/WTF/wtf/MemoryPressureHandler.cpp
+++ b/Source/WTF/wtf/MemoryPressureHandler.cpp
@@ -40,7 +40,7 @@ namespace WTF {
 
 WTF_EXPORT_PRIVATE bool MemoryPressureHandler::ReliefLogger::s_loggingEnabled = false;
 
-#if PLATFORM(IOS_FAMILY)
+#if PLATFORM(IOS_FAMILY) || PLATFORM(BROADCOM)
 static const double s_conservativeThresholdFraction = 0.5;
 static const double s_strictThresholdFraction = 0.65;
 #else
@@ -55,6 +55,15 @@ static const Seconds s_pollInterval = 30_s;
 static String s_GPUMemoryFile;
 static ssize_t s_envBaseThresholdVideo = 0;
 static bool s_videoMemoryInFootprint = false;
+
+static double from_env_or_default(const char *envname, double defaultValue) {
+    double val = defaultValue;
+    const char *ev = getenv(envname);
+    if (ev) {
+        val = atof(ev);
+    }
+    return val;
+}
 
 static bool isWebProcess()
 {
@@ -484,8 +493,8 @@ void MemoryPressureHandler::setDispatchQueue(OSObjectPtr<dispatch_queue_t>&& que
 MemoryPressureHandler::Configuration::Configuration()
     : baseThreshold(std::min(3 * GB, ramSize()))
     , baseThresholdVideo(1 * GB)
-    , conservativeThresholdFraction(s_conservativeThresholdFraction)
-    , strictThresholdFraction(s_strictThresholdFraction)
+    , conservativeThresholdFraction(from_env_or_default("WPE_MEMORY_PRESSURE_HANDLER_CONSERVATIVE_THRESHOLD_FRACTION",s_conservativeThresholdFraction))
+    , strictThresholdFraction(from_env_or_default("WPE_MEMORY_PRESSURE_HANDLER_STRICT_THRESHOLD_FRACTION", s_strictThresholdFraction))
     , killThresholdFraction(s_killThresholdFraction)
     , pollInterval(s_pollInterval)
 {

--- a/Source/WebCore/page/MemoryRelease.cpp
+++ b/Source/WebCore/page/MemoryRelease.cpp
@@ -126,7 +126,7 @@ static void releaseCriticalMemory(Synchronous synchronous, MaintainBackForwardCa
         GCController::singleton().deleteAllCode(JSC::DeleteAllCodeIfNotCollecting);
         GCController::singleton().garbageCollectNow();
     } else {
-#if PLATFORM(IOS_FAMILY)
+#if PLATFORM(IOS_FAMILY) || PLATFORM(BROADCOM)
         GCController::singleton().garbageCollectNowIfNotDoneRecently();
 #else
         GCController::singleton().garbageCollectSoon();

--- a/Source/WebCore/workers/WorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/WorkerGlobalScope.cpp
@@ -606,7 +606,7 @@ void WorkerGlobalScope::deleteJSCodeAndGC(Synchronous synchronous)
             return;
         }
     }
-#if PLATFORM(IOS_FAMILY)
+#if PLATFORM(IOS_FAMILY) || PLATFORM(BROADCOM)
     if (!vm().heap.currentThreadIsDoingGCWork()) {
         vm().heap.collectNowFullIfNotDoneRecently(JSC::Async);
         return;

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -1042,6 +1042,10 @@ void WebProcess::isJITEnabled(CompletionHandler<void(bool)>&& completionHandler)
 
 void WebProcess::garbageCollectJavaScriptObjects()
 {
+    {
+        JSLockHolder lock(commonVM());
+        commonVM().shrinkFootprintWhenIdle();
+    }
     GCController::singleton().garbageCollectNow();
 }
 

--- a/Source/bmalloc/bmalloc/AvailableMemory.cpp
+++ b/Source/bmalloc/bmalloc/AvailableMemory.cpp
@@ -63,6 +63,15 @@ namespace bmalloc {
 
 static constexpr size_t availableMemoryGuess = 512 * bmalloc::MB;
 
+double from_env_or_default(const char *envname, size_t defaultValue) {
+    double val = defaultValue;
+    const char *ev = getenv(envname);
+    if (ev) {
+        val = atof(ev);
+    }
+    return val;
+}
+
 #if BOS(DARWIN)
 static size_t memorySizeAccordingToKernel()
 {
@@ -149,6 +158,29 @@ struct LinuxMemory {
 };
 #endif
 
+static size_t customRAMSize()
+{
+    // Syntax: Case insensitive, unit multipliers (M=Mb, K=Kb, <empty>=bytes).
+    // Example: WPE_RAM_SIZE='500M'
+
+    size_t customSize = 0;
+
+    const char *s = getenv("WPE_RAM_SIZE");
+    if (s) {
+        size_t len = strlen(s);
+        size_t val = atoi(s);
+        size_t units = 1;
+        if (s[len-1] == 'k' || s[len-1] == 'K')
+            units = 1024;
+        else if (s[len-1] == 'm' || s[len-1] == 'M')
+            units = 1024*1024;
+        return units * val;
+    }
+
+    return customSize;
+}
+
+
 static size_t computeAvailableMemory()
 {
 #if BOS(DARWIN)
@@ -162,6 +194,10 @@ static size_t computeAvailableMemory()
     // (for example) and we have code that depends on those boundaries.
     return ((sizeAccordingToKernel + multiple - 1) / multiple) * multiple;
 #elif BOS(FREEBSD) || BOS(LINUX)
+    size_t customRamSize = customRAMSize();
+    if (customRamSize) {
+        return customRamSize;
+    }
     struct sysinfo info;
     if (!sysinfo(&info))
         return info.totalram * info.mem_unit;

--- a/Source/bmalloc/bmalloc/AvailableMemory.h
+++ b/Source/bmalloc/bmalloc/AvailableMemory.h
@@ -32,6 +32,8 @@ namespace bmalloc {
 
 BEXPORT size_t availableMemory();
 
+double from_env_or_default(const char *envname, size_t defaultValue);
+
 #if BPLATFORM(IOS_FAMILY) || BOS(LINUX) || BOS(FREEBSD)
 struct MemoryStatus {
     MemoryStatus(size_t memoryFootprint, double percentAvailableMemoryInUse)
@@ -62,7 +64,8 @@ inline double percentAvailableMemoryInUse()
 inline bool isUnderMemoryPressure()
 {
 #if BPLATFORM(IOS_FAMILY) || BOS(LINUX) || BOS(FREEBSD)
-    return percentAvailableMemoryInUse() > memoryPressureThreshold;
+    static const double effective_memoryPressureThreshold = from_env_or_default("WPE_BMALLOC_MEMORY_PRESSURE_THRESHOLD", memoryPressureThreshold);
+    return percentAvailableMemoryInUse() > effective_memoryPressureThreshold;
 #else
     return false;
 #endif

--- a/Source/bmalloc/bmalloc/Scavenger.cpp
+++ b/Source/bmalloc/bmalloc/Scavenger.cpp
@@ -50,6 +50,8 @@ namespace bmalloc {
 
 static constexpr bool verbose = false;
 
+double from_env_or_default(const char *envname, size_t defaultValue);
+
 struct PrintTime {
     PrintTime(const char* str) 
         : string(str)
@@ -126,8 +128,9 @@ void Scavenger::scheduleIfUnderMemoryPressure(size_t bytes)
 
 void Scavenger::scheduleIfUnderMemoryPressure(const LockHolder& lock, size_t bytes)
 {
+    static const size_t effective_scavengerBytesPerMemoryPressureCheck = (size_t) from_env_or_default("WPE_BMALLOC_SCAVENGER_BYTES_PER_MEMORY_PRESSURE_CHECK", scavengerBytesPerMemoryPressureCheck);
     m_scavengerBytes += bytes;
-    if (m_scavengerBytes < scavengerBytesPerMemoryPressureCheck)
+    if (m_scavengerBytes < effective_scavengerBytesPerMemoryPressureCheck)
         return;
 
     m_scavengerBytes = 0;

--- a/Source/bmalloc/bmalloc/Sizes.h
+++ b/Source/bmalloc/bmalloc/Sizes.h
@@ -68,7 +68,9 @@ static constexpr size_t largeAlignmentMask = largeAlignment - 1;
 static constexpr size_t deallocatorLogCapacity = 512;
 static constexpr size_t bumpRangeCacheCapacity = 3;
 
+// can be overriden with WPE_BMALLOC_SCAVENGER_BYTES_PER_MEMORY_PRESSURE_CHECK env
 static constexpr size_t scavengerBytesPerMemoryPressureCheck = 16 * MB;
+// can be overriden with WPE_BMALLOC_MEMORY_PRESSURE_THRESHOLD env
 static constexpr double memoryPressureThreshold = 0.75;
 
 static constexpr size_t maskSizeClassCount = maskSizeClassMax / alignment;


### PR DESCRIPTION
Several changes making it possible to better control GC, especially on Broadcom platforms:

- some IOS branches related to GC applied also for BROADCOM cases
- MemoryPressureHandler threshold made configurable with envs: WPE_MEMORY_PRESSURE_HANDLER_CONSERVATIVE_THRESHOLD_FRACTION WPE_MEMORY_PRESSURE_HANDLER_STRICT_THRESHOLD_FRACTION
- bmalloc memoryPressureThreshold made configurable with WPE_BMALLOC_MEMORY_PRESSURE_THRESHOLD env
- bmalloc scavengerBytesPerMemoryPressureCheck configurable with WPE_BMALLOC_SCAVENGER_BYTES_PER_MEMORY_PRESSURE_CHECK env
- garbageCollectJavaScriptObjects: also use shrinkFootprintWhenIdle, to improve memory cleanup
- bmalloc should take WPE_RAM_SIZE env into account when determining total available memory