### PR TITLE
Images with loading="lazy" have uncontrollable gray border while load…

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -783,7 +783,6 @@ imported/w3c/web-platform-tests/html/rendering/widgets/the-select-element/option
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe-modify-scrolling-attr-to-yes.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/adopt-from-image-document.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-loading-lazy-slow-aspect-ratio.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-loading-lazy-slow.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-option-element/dynamic-content-change-rendering.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-selectmenu-element/selectmenu-option-arbitrary-content-displayed.tentative.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-popup-element/popup-hidden-display.tentative.html [ ImageOnlyFailure ]

--- a/Source/WebCore/rendering/RenderImage.cpp
+++ b/Source/WebCore/rendering/RenderImage.cpp
@@ -479,14 +479,17 @@ void RenderImage::paintReplaced(PaintInfo& paintInfo, const LayoutPoint& paintOf
     float deviceScaleFactor = document().deviceScaleFactor();
     LayoutUnit missingImageBorderWidth(1 / deviceScaleFactor);
 
+    if (isDeferredImage(element()))
+        return;
+
     if (context.detectingContentfulPaint()) {
-        if (!context.contenfulPaintDetected() && !isDeferredImage(element()) && cachedImage() && cachedImage()->canRender(this, deviceScaleFactor) && !contentSize.isEmpty())
+        if (!context.contenfulPaintDetected() && cachedImage() && cachedImage()->canRender(this, deviceScaleFactor) && !contentSize.isEmpty())
             context.setContentfulPaintDetected();
 
         return;
     }
 
-    if (!imageResource().cachedImage() || isDeferredImage(element()) || shouldDisplayBrokenImageIcon()) {
+    if (!imageResource().cachedImage() || shouldDisplayBrokenImageIcon()) {
         if (paintInfo.phase == PaintPhase::Selection)
             return;
 

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
@@ -222,6 +222,8 @@ void InjectedBundle::didReceiveMessageToPage(WKBundlePageRef page, WKStringRef m
         m_state = Idle;
         m_dumpPixels = false;
         m_pixelResultIsPending = false;
+        // Needed for pixel result pending mode, otherwise a no-op.
+        InjectedBundle::page()->stopLoading();
 
         setlocale(LC_ALL, "");
         TestRunner::removeAllWebNotificationPermissions();
@@ -552,7 +554,10 @@ void InjectedBundle::done()
 
     m_useWorkQueue = false;
 
-    page()->stopLoading();
+    // Postpone page load stop if pixel result is still pending since
+    // cancelled image loads will paint as broken images.
+    if (!m_pixelResultIsPending)
+        page()->stopLoading();
     setTopLoadingFrame(0);
 
 #if ENABLE(ACCESSIBILITY)


### PR DESCRIPTION
…ing https://bugs.webkit.org/show_bug.cgi?id=243601

Reviewed by Darin Adler.

Do not paint border while an image is in deferred state. The test image-loading-lazy-slow.html covers this. However, the current test runner logic stops page loads before making a pixel snapshot, causing the image to be painted as a broken image instead of the empty image at the time of calling takeScreenshot. To fix this, postpone the stopping of page loads and instead always stop page loads when reseting after the test.

Note that printing tests are not affected since they already made a pixel snapshot before stopping the page loads.

* LayoutTests/TestExpectations:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/WebCore/rendering/RenderImage.cpp: (WebCore::RenderImage::paintReplaced):
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp: (WTR::InjectedBundle::didReceiveMessageToPage):
(WTR::InjectedBundle::done):

Canonical link: https://commits.webkit.org/253960@main

Cherry pick of https://github.com/WebKit/WebKit/commit/7d844a4e948d225ba2f0504fa4a264b03bd9d8c8