### PR TITLE
[2.38] shrinkFootprintWhenIdle in garbageCollectJavaScriptObjects

### DIFF
--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -1042,6 +1042,10 @@ void WebProcess::isJITEnabled(CompletionHandler<void(bool)>&& completionHandler)
 
 void WebProcess::garbageCollectJavaScriptObjects()
 {
+    {
+        JSLockHolder lock(commonVM());
+        commonVM().shrinkFootprintWhenIdle();
+    }
     GCController::singleton().garbageCollectNow();
 }
 


### PR DESCRIPTION
Adding VM::shrinkFootprintWhenIdle invocation to garbageCollectJavaScriptObjects
to increase the amount of memory released.