### PR TITLE
[2.38] Taking some IOS GC branches for WPE as well

### DIFF
--- a/Source/JavaScriptCore/heap/FullGCActivityCallback.cpp
+++ b/Source/JavaScriptCore/heap/FullGCActivityCallback.cpp
@@ -41,7 +41,7 @@ void FullGCActivityCallback::doCollection(VM& vm)
     Heap& heap = vm.heap;
     m_didGCRecently = false;
 
-#if !PLATFORM(IOS_FAMILY) || PLATFORM(MACCATALYST)
+#if (!PLATFORM(IOS_FAMILY) && !PLATFORM(WPE)) || PLATFORM(MACCATALYST)
     MonotonicTime startTime = MonotonicTime::now();
     if (MemoryPressureHandler::singleton().isUnderMemoryPressure() && heap.isPagedOut()) {
         cancel();

--- a/Source/WebCore/page/MemoryRelease.cpp
+++ b/Source/WebCore/page/MemoryRelease.cpp
@@ -126,7 +126,7 @@ static void releaseCriticalMemory(Synchronous synchronous, MaintainBackForwardCa
         GCController::singleton().deleteAllCode(JSC::DeleteAllCodeIfNotCollecting);
         GCController::singleton().garbageCollectNow();
     } else {
-#if PLATFORM(IOS_FAMILY)
+#if PLATFORM(IOS_FAMILY) || PLATFORM(WPE)
         GCController::singleton().garbageCollectNowIfNotDoneRecently();
 #else
         GCController::singleton().garbageCollectSoon();

--- a/Source/WebCore/workers/WorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/WorkerGlobalScope.cpp
@@ -606,7 +606,7 @@ void WorkerGlobalScope::deleteJSCodeAndGC(Synchronous synchronous)
             return;
         }
     }
-#if PLATFORM(IOS_FAMILY)
+#if PLATFORM(IOS_FAMILY) || PLATFORM(WPE)
     if (!vm().heap.currentThreadIsDoingGCWork()) {
         vm().heap.collectNowFullIfNotDoneRecently(JSC::Async);
         return;


### PR DESCRIPTION
The aim is to make the GC more reliable on low-memory platforms. IOS branches applied:

- FullGCActivityCallback::doCollection - do not bail out of GC early
- MemoryPressureHandler - apply IOS defaults for conservative/strict mode thresholds
- MemoryRelease / releaseCriticalMemory - request immediate GC
- WorkerGlobalScope::deleteJSCodeAndGC - collect even if called with Synchronous::No