### PR TITLE
During seek flow avoid play call before finishseek call

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -5768,7 +5768,7 @@ void HTMLMediaElement::updatePlayState()
     if (shouldBePlaying) {
         invalidateCachedTime();
 
-        if (playerPaused) {
+        if (playerPaused && !m_seeking) {
             mediaSession().clientWillBeginPlayback();
 
             // Set rate, muted and volume before calling play in case they were set before the media engine was set up.


### PR DESCRIPTION
During the video playback ideally states must flow as play -> pause -> seek_start -> seek_done -> play but randomly it is observed that play event is being sent before finishing the seek (seek_done) i.e, play -> pause -> seek_start -> play -> seek_done .
Ideally play call will be triggered continuously when we are playing a video. So In our scenario between seek_start and seek_done we must avoid the play call.
So I have added the below condition that during m_seeking variable is true execution of following if condition must skip as playplayer() api which is responsible to change the pipeline state to play is being called from here...In order to avoid play event being called before finishing the seek this change has been done.
Also I performed all the possible scenarios wrt play, pause, seek but no regression have been found so far.<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/1065a1e9c54e4cf755f7ab6dcfbd7b9711c725ef

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| [❌ 🛠 wpe-238-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/1/builds/43 "Failed to checkout and rebase branch from PR 1423") | [❌ 🧪 wpe-238-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/1/builds/43 "Failed to checkout and rebase branch from PR 1423") 
| [❌ 🛠 wpe-238-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/8/builds/42 "Failed to checkout and rebase branch from PR 1423") | [❌ 🧪 wpe-238-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/8/builds/42 "Failed to checkout and rebase branch from PR 1423") 
| | 
| | 
<!--EWS-Status-Bubble-End-->