### PR TITLE
[css-flexbox] incorrect layout with max-height and flex-direction col…

### DIFF
--- a/LayoutTests/css3/flexbox/nested-flexbox-max-height-expected.txt
+++ b/LayoutTests/css3/flexbox/nested-flexbox-max-height-expected.txt
@@ -1,0 +1,5 @@
+Only red square should be visible
+
+
+PASS #container 1
+A

--- a/LayoutTests/css3/flexbox/nested-flexbox-max-height.html
+++ b/LayoutTests/css3/flexbox/nested-flexbox-max-height.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<link href="resources/flexbox.css" rel="stylesheet">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../resources/check-layout-th.js"></script>
+<script>
+function run() {
+  checkLayout('#container');
+}
+</script>
+<body onload="run()">
+<p>Only red square should be visible</p>
+<div id="log"></div>
+<div id="container" class="flexbox column" style="max-height: 100px; height: 100px; width: 100px; background: green">
+    <div class="flexbox column justify-content-center" style="height: 400px; background: red" data-expected-height="100">A</div>
+</div>


### PR DESCRIPTION
…umn and justify-content center

https://bugs.webkit.org/show_bug.cgi?id=282036

Reviewed by NOBODY (OOPS!).

After calculation of the flex item size and adjusting it to min/max size of the flex item we should also check how the calculated size corresponds to specified max size of the whole container. In case the adjusted flex item size is bigger than the max size of the whole container we should use the flex item size calculated before adjusting to flex item min/max size.

There is new layout test which tests the problem.

* LayoutTests/css3/flexbox/nested-flexbox-max-height-expected.txt: Added.
* LayoutTests/css3/flexbox/nested-flexbox-max-height.html: Added.
* Source/WebCore/rendering/RenderFlexibleBox.cpp: (WebCore::RenderFlexibleBox::resolveFlexibleLengths):
<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/cb045d2934cd8789081f924f1fed7e172dc40c1b

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| [  ~~🛠 wpe-amd64-build~~](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/3 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-amd64-layout~~](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/3 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🛠 wpe-arm32-build~~](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/5 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-arm32-layout~~](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/5 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
<!--EWS-Status-Bubble-End-->