### PR TITLE
Send analog button values based on W3C GamePad

### DIFF
--- a/Source/WebCore/platform/gamepad/wpe/WPEGamepad.cpp
+++ b/Source/WebCore/platform/gamepad/wpe/WPEGamepad.cpp
@@ -58,7 +58,12 @@ WPEGamepad::WPEGamepad(struct wpe_gamepad_provider* provider, uintptr_t gamepadI
             auto& self = *static_cast<WPEGamepad*>(data);
             self.absoluteAxisChanged(static_cast<unsigned>(axis), value);
         },
-        nullptr, nullptr, nullptr,
+        // analog_button_value
+        [](void* data, enum wpe_gamepad_button button, double value) {
+            auto& self = *static_cast<WPEGamepad*>(data);
+            self.analogButtonChanged(static_cast<unsigned>(button), value);
+        },
+        nullptr, nullptr,
     };
     wpe_gamepad_set_client(m_gamepad.get(), &s_client, this);
 }
@@ -82,6 +87,15 @@ void WPEGamepad::absoluteAxisChanged(unsigned axis, double value)
     m_axisValues[axis].setValue(value);
 
     WPEGamepadProvider::singleton().scheduleInputNotification(*this, WPEGamepadProvider::ShouldMakeGamepadsVisible::Yes);
+}
+
+void WPEGamepad::analogButtonChanged(unsigned button, double value)
+{
+    m_lastUpdateTime = MonotonicTime::now();
+    m_buttonValues[button].setValue(clampTo(value, 0.0, 1.0));
+
+    WPEGamepadProvider::singleton().scheduleInputNotification(*this, WPEGamepadProvider::ShouldMakeGamepadsVisible::Yes);
+
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/gamepad/wpe/WPEGamepad.h
+++ b/Source/WebCore/platform/gamepad/wpe/WPEGamepad.h
@@ -48,6 +48,7 @@ public:
 private:
     void buttonPressedOrReleased(unsigned, bool);
     void absoluteAxisChanged(unsigned, double);
+    void analogButtonChanged(unsigned, double);
 
     Vector<SharedGamepadValue> m_buttonValues;
     Vector<SharedGamepadValue> m_axisValues;


### PR DESCRIPTION
This PR dependent on libWPE changes for getting Gamepad button values from 0.0 to 1.0. WebPlatformForEmbedded/libwpe#134

https://www.w3.org/TR/gamepad/#dom-gamepadbutton-value

value attribute:
For buttons that have an analog sensor, this property MUST represent the amount which the button has been pressed. All button values MUST be linearly normalized to the range [0.0 .. 1.0]. 0.0 MUST mean fully unpressed, and 1.0 MUST mean fully pressed. For buttons without an analog sensor, only the values 0.0 and 1.0 for fully unpressed and fully pressed respectively, MUST be provided.

Original Author: manoj_bhatta@comcast.com
See: https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1410


* Source/WebCore/platform/gamepad/wpe/WPEGamepad.cpp
  (WPEGamepad::WPEGamepad)
  (WPEGamepad::analogButtonChanged)
* Source/WebCore/platform/gamepad/wpe/WPEGamepad.h:

<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/6aa8bee38048a9058fc335e52e09736485e8dd4f

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| [❌ 🛠 wpe-238-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/1/builds/28 "Hash 6aa8bee3 for PR 1442 does not build (failure)") | [❌ 🧪 wpe-238-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/1/builds/28 "Hash 6aa8bee3 for PR 1442 does not build (failure)") 
| [❌ 🛠 wpe-238-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/8/builds/23 "Hash 6aa8bee3 for PR 1442 does not build (failure)") | [❌ 🧪 wpe-238-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/8/builds/23 "Hash 6aa8bee3 for PR 1442 does not build (failure)") 
| | 
| | 
<!--EWS-Status-Bubble-End-->