### PR TITLE
Use AllowWebGLInWorkers only if WEBGL is enabled

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
@@ -245,7 +245,9 @@ void DrawingAreaCoordinatedGraphics::updatePreferences(const WebPreferencesStore
         settings.setAsyncOverflowScrollingEnabled(false);
     }
 
+#if ENABLE(WEBGL)
     settings.setAllowWebGLInWorkers(!store.getBoolValueForKey(WebPreferencesKey::nonCompositedWebGLEnabledKey()));
+#endif
 }
 
 void DrawingAreaCoordinatedGraphics::mainFrameContentSizeChanged(WebCore::FrameIdentifier, const IntSize& size)


### PR DESCRIPTION
Downstream commit 09ee2015390c1c4f9f0e73ec13baf6bc64bbb617 implements NonCompositedWebGL. In there, `DrawingAreaCoordinatedGraphics.cpp` unconditionally tries to invoke `setAllowWebGLInWorkers` which won't exist as the property is only exposed when `WEBGL` is enabled. 

This commit fixes it, protecting the setting behind the same guard.<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/ac956aff3eef8c415ebcfc5909d0942c46c67985

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/42 "Built successfully") | [✅ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/4 "Passed tests") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/44 "Built successfully") | [✅ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/10/builds/4 "Passed tests") 
<!--EWS-Status-Bubble-End-->