### PR TITLE
wpe-2.38 Improve memory usage during GCHeap snapshot

### DIFF
--- a/Source/JavaScriptCore/heap/HeapSnapshotBuilder.cpp
+++ b/Source/JavaScriptCore/heap/HeapSnapshotBuilder.cpp
@@ -39,6 +39,52 @@
 
 namespace JSC {
 
+namespace {
+
+class FileOutputStingBuilder {
+    WTF_MAKE_NONCOPYABLE(FileOutputStingBuilder);
+
+    FileSystem::PlatformFileHandle fileHandle;
+    StringBuilder builder;
+
+public:
+    FileOutputStingBuilder(FileSystem::PlatformFileHandle fileHandle)
+        : fileHandle(WTFMove(fileHandle))
+    {
+    }
+
+    ~FileOutputStingBuilder()
+    {
+        flush(true);
+    }
+
+    template<typename... StringTypes> void append(StringTypes... fragment)
+    {
+        builder.append(fragment...);
+        flush();
+    }
+
+    void appendQuotedJSONString(const String& string)
+    {
+        builder.appendQuotedJSONString(string);
+        flush();
+    }
+
+    void flush(bool force = false)
+    {
+        constexpr size_t kBufferLengthLimit = 4 * WTF::KB;
+        if ((force && !builder.isEmpty()) ||  builder.length() >= kBufferLengthLimit)
+        {
+            CString utf8String = builder.toStringPreserveCapacity().utf8();
+            FileSystem::writeToFile(fileHandle, utf8String.data(), utf8String.length());
+            builder.clear();
+            builder.reserveCapacity(kBufferLengthLimit);
+        }
+    }
+};
+
+} // namespace
+
 NodeIdentifier HeapSnapshotBuilder::nextAvailableObjectIdentifier = 1;
 NodeIdentifier HeapSnapshotBuilder::getNextObjectIdentifier() { return nextAvailableObjectIdentifier++; }
 void HeapSnapshotBuilder::resetNextAvailableObjectIdentifier() { HeapSnapshotBuilder::nextAvailableObjectIdentifier = 1; }
@@ -330,6 +376,20 @@ String HeapSnapshotBuilder::descriptionForCell(JSCell *cell) const
 
 String HeapSnapshotBuilder::json(Function<bool (const HeapSnapshotNode&)> allowNodeCallback)
 {
+    StringBuilder json;
+    writeJson(WTFMove(allowNodeCallback), json);
+    return json.toString();
+}
+
+void HeapSnapshotBuilder::writeJsonToFile(FileSystem::PlatformFileHandle fileHandle)
+{
+    FileOutputStingBuilder json(fileHandle);
+    writeJson([] (const HeapSnapshotNode&) { return true; }, json);
+}
+
+template<typename OutputStingBuilder>
+void HeapSnapshotBuilder::writeJson(Function<bool (const HeapSnapshotNode&)>&& allowNodeCallback, OutputStingBuilder &json)
+{
     VM& vm = m_profiler.vm();
     DeferGCForAWhile deferGC(vm);
 
@@ -350,7 +410,6 @@ String HeapSnapshotBuilder::json(Function<bool (const HeapSnapshotNode&)> allowN
     HashMap<UniquedStringImpl*, unsigned> edgeNameIndexes;
     unsigned nextEdgeNameIndex = 0;
 
-    StringBuilder json;
 
     auto appendNodeJSON = [&] (const HeapSnapshotNode& node) {
         // Let the client decide if they want to allow or disallow certain nodes.
@@ -615,7 +674,6 @@ String HeapSnapshotBuilder::json(Function<bool (const HeapSnapshotNode&)> allowN
     }
 
     json.append('}');
-    return json.toString();
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/heap/HeapSnapshotBuilder.h
+++ b/Source/JavaScriptCore/heap/HeapSnapshotBuilder.h
@@ -31,6 +31,7 @@
 #include <wtf/HashSet.h>
 #include <wtf/Lock.h>
 #include <wtf/Vector.h>
+#include <wtf/FileSystem.h>
 
 namespace JSC {
 
@@ -130,6 +131,7 @@ public:
 
     String json();
     String json(Function<bool (const HeapSnapshotNode&)> allowNodeCallback);
+    void writeJsonToFile(FileSystem::PlatformFileHandle fileHandle);
 
 private:
     static NodeIdentifier nextAvailableObjectIdentifier;
@@ -140,6 +142,9 @@ private:
     bool previousSnapshotHasNodeForCell(JSCell*, NodeIdentifier&);
     
     String descriptionForCell(JSCell*) const;
+
+    template<typename OutputStingBuilder>
+    void writeJson(Function<bool (const HeapSnapshotNode&)>&& allowNodeCallback, OutputStingBuilder &json);
     
     struct RootData {
         const char* reachabilityFromOpaqueRootReasons { nullptr };

--- a/Source/WebCore/bindings/js/GCController.cpp
+++ b/Source/WebCore/bindings/js/GCController.cpp
@@ -140,10 +140,26 @@ void GCController::deleteAllLinkedCode(DeleteAllCodeEffort effort)
 
 void GCController::dumpHeap()
 {
+    static const char* sHeapDumpDirOverride = []() {
+        return getenv("WEBKIT_HEAP_SNAPSHOT_DIR");
+    }();
+
     FileSystem::PlatformFileHandle fileHandle;
-    String tempFilePath = FileSystem::openTemporaryFile("GCHeap"_s, fileHandle);
+    String tempFilePath;
+    if (sHeapDumpDirOverride) {
+        char buf[32];
+        time_t now = time(nullptr);
+        struct tm* tstruct = localtime(&now);
+        std::strftime(buf, sizeof(buf), "%Y%m%d_%H%M%S", tstruct);
+
+        tempFilePath = WTF::String::fromUTF8(sHeapDumpDirOverride) + "/GCHeap_" + WTF::String::fromUTF8(buf);
+        fileHandle = FileSystem::openFile(tempFilePath, FileSystem::FileOpenMode::ReadWrite);
+    } else {
+        tempFilePath = FileSystem::openTemporaryFile("GCHeap"_s, fileHandle);
+    }
+
     if (!FileSystem::isHandleValid(fileHandle)) {
-        WTFLogAlways("Dumping GC heap failed to open temporary file");
+        WTFLogAlways("Dumping GC heap failed to open temporary file: %s", tempFilePath.utf8().data());
         return;
     }
 
@@ -152,19 +168,14 @@ void GCController::dumpHeap()
 
     sanitizeStackForVM(vm);
 
-    String jsonData;
     {
         DeferGCForAWhile deferGC(vm); // Prevent concurrent GC from interfering with the full GC that the snapshot does.
 
         HeapSnapshotBuilder snapshotBuilder(vm.ensureHeapProfiler(), HeapSnapshotBuilder::SnapshotType::GCDebuggingSnapshot);
         snapshotBuilder.buildSnapshot();
-
-        jsonData = snapshotBuilder.json();
+        snapshotBuilder.writeJsonToFile(fileHandle);
     }
 
-    CString utf8String = jsonData.utf8();
-
-    FileSystem::writeToFile(fileHandle, utf8String.data(), utf8String.length());
     FileSystem::closeFile(fileHandle);
     
     WTFLogAlways("Dumped GC heap to %s", tempFilePath.utf8().data());


### PR DESCRIPTION
This is kind of improvement for GC heap snapshot generation that prints the snapshot directly to file instead keeping it all in json string (and then print into file). This helps to reduce memory usage spike that was required for huge json string and also eliminates a crash caused by string size limit exceed.

I think it can be useful for WPE, embedded case when memory is limited, not sure if suitable for upstream webkit repo.
With this patch I'm able to dump pretty big GC heap into file without getting OOM from kernel

The second change is to allow different dir for heap snapshot. With containers enabled /tmp space is limited usually so better to use other location, vendor specific

```
0
__libc_do_syscall
‎:
1
__pthread_kill_implementation
‎/usr/src/debug/glibc/2.35-r0/git/nptl/pthread_kill.c:43
2
raise
‎/usr/src/debug/glibc/2.35-r0/git/signal/../sysdeps/posix/raise.c:26
3
abort
‎/usr/src/debug/glibc/2.35-r0/git/stdlib/abort.c:79
4
void WTF::StringBuilder::allocateBuffer
‎/usr/src/debug/wpe-webkit/2.38.8+gitAUTOINC+d893a3ed1d-r1/build/../git/Source/WTF/wtf/text/StringBuilder.cpp:46
5
WTF::StringBuilder::extendBufferForAppendingWithUpconvert
‎/usr/src/debug/wpe-webkit/2.38.8+gitAUTOINC+d893a3ed1d-r1/build/../git/Source/WTF/wtf/text/StringBuilder.cpp:144
6
WTF::StringBuilder::appendQuotedJSONString
‎/usr/src/debug/wpe-webkit/2.38.8+gitAUTOINC+d893a3ed1d-r1/build/../git/Source/WTF/wtf/text/StringBuilderJSON.cpp:98
7
JSC::HeapSnapshotBuilder::json
‎/usr/src/debug/wpe-webkit/2.38.8+gitAUTOINC+d893a3ed1d-r1/build/../git/Source/JavaScriptCore/heap/HeapSnapshotBuilder.cpp:552
8
JSC::HeapSnapshotBuilder::json
‎/usr/src/debug/wpe-webkit/2.38.8+gitAUTOINC+d893a3ed1d-r1/build/../git/Source/JavaScriptCore/heap/HeapSnapshotBuilder.cpp:308
9
WebCore::GCController::dumpHeap
‎/usr/src/debug/wpe-webkit/2.38.8+gitAUTOINC+d893a3ed1d-r1/build/../git/Source/WebCore/bindings/js/GCController.cpp:162
10
_g_cclosure_marshal_VOID__OBJECT_OBJECT_ENUMv
‎/usr/src/debug/glib-2.0/1_2.72.3-r0/build/../glib-2.72.3/gio/gmarshal-internal.c:1380
11
_g_closure_invoke_va
‎/usr/src/debug/glib-2.0/1_2.72.3-r0/build/../glib-2.72.3/gobject/gclosure.c:893
12
g_signal_emit_valist
‎/usr/src/debug/glib-2.0/1_2.72.3-r0/build/../glib-2.72.3/gobject/gsignal.c:3406
13
g_signal_emit
‎/usr/src/debug/glib-2.0/1_2.72.3-r0/build/../glib-2.72.3/gobject/gsignal.c:3553
14
g_file_monitor_emit_event
‎/usr/src/debug/glib-2.0/1_2.72.3-r0/build/../glib-2.72.3/gio/gfilemonitor.c:294
```<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/38ae47ceffb7a2c00e24cf59c26bdcd55ff434e4

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| [✅ 🛠 wpe-238-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/1/builds/29 "Built successfully") | [✅ 🧪 wpe-238-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/5/builds/18 "Passed tests") 
| [✅ 🛠 wpe-238-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/8/builds/28 "Built successfully") | [✅ 🧪 wpe-238-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/6/builds/29 "Passed tests") 
| | 
| | 
<!--EWS-Status-Bubble-End-->