### PR TITLE
Use analogButtonChanged with proper libwpe

### DIFF
--- a/Source/WebCore/platform/gamepad/wpe/WPEGamepad.cpp
+++ b/Source/WebCore/platform/gamepad/wpe/WPEGamepad.cpp
@@ -30,7 +30,6 @@
 #if ENABLE(GAMEPAD)
 
 #include "WPEGamepadProvider.h"
-#include <wpe/wpe.h>
 
 namespace WebCore {
 
@@ -58,12 +57,15 @@ WPEGamepad::WPEGamepad(struct wpe_gamepad_provider* provider, uintptr_t gamepadI
             auto& self = *static_cast<WPEGamepad*>(data);
             self.absoluteAxisChanged(static_cast<unsigned>(axis), value);
         },
+#if WPE_CHECK_VERSION(1, 16, 1)
         // analog_button_value
-        [](void* data, enum wpe_gamepad_button button, double value) {
+        [](void* data, enum wpe_gamepad_button button, double value) {1111
             auto& self = *static_cast<WPEGamepad*>(data);
             self.analogButtonChanged(static_cast<unsigned>(button), value);
-        },
-        nullptr, nullptr,
+        }, nullptr, nullptr
+#else
+        nullptr, nullptr, nullptr
+#endif
     };
     wpe_gamepad_set_client(m_gamepad.get(), &s_client, this);
 }
@@ -89,6 +91,7 @@ void WPEGamepad::absoluteAxisChanged(unsigned axis, double value)
     WPEGamepadProvider::singleton().scheduleInputNotification(*this, WPEGamepadProvider::ShouldMakeGamepadsVisible::Yes);
 }
 
+#if WPE_CHECK_VERSION(1, 16, 1)
 void WPEGamepad::analogButtonChanged(unsigned button, double value)
 {
     m_lastUpdateTime = MonotonicTime::now();
@@ -97,6 +100,7 @@ void WPEGamepad::analogButtonChanged(unsigned button, double value)
     WPEGamepadProvider::singleton().scheduleInputNotification(*this, WPEGamepadProvider::ShouldMakeGamepadsVisible::Yes);
 
 }
+#endif
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/gamepad/wpe/WPEGamepad.h
+++ b/Source/WebCore/platform/gamepad/wpe/WPEGamepad.h
@@ -29,6 +29,7 @@
 #if ENABLE(GAMEPAD)
 
 #include "PlatformGamepad.h"
+#include <wpe/wpe.h>
 
 struct wpe_gamepad;
 struct wpe_gamepad_provider;
@@ -48,7 +49,9 @@ public:
 private:
     void buttonPressedOrReleased(unsigned, bool);
     void absoluteAxisChanged(unsigned, double);
+#if WPE_CHECK_VERSION(1, 16, 1)
     void analogButtonChanged(unsigned, double);
+#endif
 
     Vector<SharedGamepadValue> m_buttonValues;
     Vector<SharedGamepadValue> m_axisValues;


### PR DESCRIPTION
analogButtonChanged can be used only with libwpe >= 1.16.1
<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/aeb87836bacdf7bba69979a91d8f227318d8ff67

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| [✅ 🛠 wpe-238-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/1/builds/32 "Built successfully") | [  ~~🧪 wpe-238-amd64-layout~~](https://ews-wpe-rdk.igalia.com/#/builders/5/builds/20 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🛠 wpe-238-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/8/builds/31 "Built successfully") | [  ~~🧪 wpe-238-arm32-layout~~](https://ews-wpe-rdk.igalia.com/#/builders/6/builds/31 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | 
| | 
<!--EWS-Status-Bubble-End-->