### PR TITLE
[WPE] Increased memory consumption of WebProcess during regular video…

### DIFF
--- a/Source/WebCore/inspector/NetworkResourcesData.cpp
+++ b/Source/WebCore/inspector/NetworkResourcesData.cpp
@@ -96,7 +96,7 @@ void NetworkResourcesData::ResourceData::appendData(const SharedBuffer& data)
     m_dataBuffer.append(data);
 }
 
-unsigned NetworkResourcesData::ResourceData::decodeDataToContent()
+void NetworkResourcesData::ResourceData::decodeDataToContent()
 {
     ASSERT(!hasContent());
 
@@ -111,7 +111,7 @@ unsigned NetworkResourcesData::ResourceData::decodeDataToContent()
         m_content = base64EncodeToString(buffer->data(), dataLength);
     }
 
-    return m_content.sizeInBytes() - dataLength;
+    ASSERT(m_content.sizeInBytes() >= buffer->size());
 }
 
 NetworkResourcesData::NetworkResourcesData()
@@ -200,7 +200,7 @@ void NetworkResourcesData::setResourceContent(const String& requestId, const Str
         // We can not be sure that we didn't try to save this request data while it was loading, so remove it, if any.
         if (resourceData->hasContent() || resourceData->hasData())
             m_contentSize -= resourceData->removeContent();
-        m_requestIdsDeque.append(requestId);
+        m_requestIdsDeque.appendOrMoveToLast(requestId);
         resourceData->setContent(content, base64Encoded);
         m_contentSize += dataLength;
     }
@@ -236,7 +236,7 @@ NetworkResourcesData::ResourceData const* NetworkResourcesData::maybeAddResource
         return resourceData;
 
     if (ensureFreeSpace(data.size()) && !resourceData->isContentEvicted()) {
-        m_requestIdsDeque.append(requestId);
+        m_requestIdsDeque.appendOrMoveToLast(requestId);
         resourceData->appendData(data);
         m_contentSize += data.size();
     }
@@ -253,10 +253,18 @@ void NetworkResourcesData::maybeDecodeDataToContent(const String& requestId)
     if (!resourceData->hasData())
         return;
 
-    m_contentSize += resourceData->decodeDataToContent();
-    size_t dataLength = resourceData->content().sizeInBytes();
-    if (dataLength > m_maximumSingleResourceContentSize)
-        m_contentSize -= resourceData->evictContent();
+    auto byteCount = resourceData->dataLength();
+    m_contentSize -= byteCount;
+
+    resourceData->decodeDataToContent();
+    byteCount = resourceData->content().sizeInBytes();
+    if (byteCount > m_maximumSingleResourceContentSize) {
+        resourceData->evictContent();
+        return;
+    }
+
+    if (ensureFreeSpace(byteCount) && !resourceData->isContentEvicted())
+        m_contentSize += byteCount;
 }
 
 void NetworkResourcesData::addCachedResource(const String& requestId, CachedResource* cachedResource)
@@ -313,19 +321,23 @@ Vector<String> NetworkResourcesData::removeCachedResource(CachedResource* cached
 
 void NetworkResourcesData::clear(std::optional<String> preservedLoaderId)
 {
-    m_requestIdsDeque.clear();
-    m_contentSize = 0;
-
-    if (!preservedLoaderId)
+    if (!preservedLoaderId) {
         m_requestIdToResourceDataMap.clear();
-    else {
-        Vector<String> keysToRemove;
-        for (auto& [key, value] : m_requestIdToResourceDataMap) {
-            if (value->loaderId() != *preservedLoaderId)
-                keysToRemove.append(key);
+        m_requestIdsDeque.clear();
+        m_contentSize = 0;
+        return;
+    }
+
+    for (auto&& requestId : std::exchange(m_requestIdsDeque, { })) {
+        auto resourceData = resourceDataForRequestId(requestId);
+        if (!resourceData)
+            continue;
+        if (resourceData->loaderId() == *preservedLoaderId)
+            m_requestIdsDeque.add(requestId);
+        else {
+            m_contentSize -= resourceData->evictContent();
+            m_requestIdToResourceDataMap.remove(requestId);
         }
-        for (auto& keyToRemove : keysToRemove)
-            m_requestIdToResourceDataMap.remove(keyToRemove);
     }
 }
 
@@ -357,6 +369,7 @@ bool NetworkResourcesData::ensureFreeSpace(size_t size)
     if (size > m_maximumResourcesContentSize)
         return false;
 
+    ASSERT(m_maximumResourcesContentSize >= m_contentSize);
     while (size > m_maximumResourcesContentSize - m_contentSize) {
         String requestId = m_requestIdsDeque.takeFirst();
         ResourceData* resourceData = resourceDataForRequestId(requestId);

--- a/Source/WebCore/inspector/NetworkResourcesData.h
+++ b/Source/WebCore/inspector/NetworkResourcesData.h
@@ -31,7 +31,7 @@
 
 #include "InspectorPageAgent.h"
 #include "SharedBuffer.h"
-#include <wtf/Deque.h>
+#include <wtf/ListHashSet.h>
 #include <wtf/RobinHoodHashMap.h>
 #include <wtf/WallTime.h>
 #include <wtf/text/WTFString.h>
@@ -109,7 +109,7 @@ public:
         bool hasData() const;
         size_t dataLength() const;
         void appendData(const SharedBuffer&);
-        unsigned decodeDataToContent();
+        void decodeDataToContent();
 
         String m_requestId;
         String m_loaderId;
@@ -156,7 +156,7 @@ private:
     void ensureNoDataForRequestId(const String& requestId);
     bool ensureFreeSpace(size_t);
 
-    Deque<String> m_requestIdsDeque;
+    ListHashSet<String> m_requestIdsDeque;
     MemoryCompactRobinHoodHashMap<String, std::unique_ptr<ResourceData>> m_requestIdToResourceDataMap;
     size_t m_contentSize { 0 };
     size_t m_maximumResourcesContentSize;


### PR DESCRIPTION
… playback and RWI

https://bugs.webkit.org/show_bug.cgi?id=284108

Reviewed by Devin Rousso.

When WebInspector is used, the downloaded data is cached also for it in NetworkResourcesData. The single resource data cannot be greater than maximumSingleResourceContentSize (50MB) and the total size of resources content cannot be greater than maximumResourcesContentSize (200MB). At the end of downloading the resource, the binary data is decoded to the string represantation (base64 or other depends on decoder). Decoding process can increased the size of the kept resource data. The limit maximumSingleResourceContentSize is checked but maximumResourcesContentSize limit is not checked which can lead to situation that m_contentSize (the total size of resources content) is greater than maximumResourcesContentSize. This causes that condition checked in NetworkResourcesData::ensureFreeSpace is invalid because subtraction unsigned values where first value(minuend) is smaller than the second one(subtrahend) gives a huge number (instead of negative number).

This change ensures that after decoding binary data into string representation the total size of resources content (m_contentSize) is not greater than maximumResourcesContentSize. The assert is added in NetworkResourcesData::ensureFreeSpace to check that m_contentSize is not greater than maximumResourcesContentSize.

I fixed implementation of function NetworkResourcesData::clear in case passing the preservedLoaderId. In that case we should update m_requestIdsDeque and m_contentSize and not just clear them.

Additionally I changed the type of m_requestIdsDeque from Deque<String> to ListHashSet<String>. This change fixes adding to m_requestIdsDeque the same requestId many times.

* Source/WebCore/inspector/NetworkResourcesData.cpp: (WebCore::NetworkResourcesData::ResourceData::decodeDataToContent): (WebCore::NetworkResourcesData::setResourceContent): (WebCore::NetworkResourcesData::maybeAddResourceData): (WebCore::NetworkResourcesData::maybeDecodeDataToContent): (WebCore::NetworkResourcesData::clear):
(WebCore::NetworkResourcesData::ensureFreeSpace):
* Source/WebCore/inspector/NetworkResourcesData.h:

Canonical link: https://commits.webkit.org/289143@main
<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/2b42028d47edc875f65b34b30e2841c27bd0fa55

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| [✅ 🛠 wpe-238-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/1/builds/35 "Built successfully") | [  ~~🧪 wpe-238-amd64-layout~~](https://ews-wpe-rdk.igalia.com/#/builders/5/builds/23 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🛠 wpe-238-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/8/builds/34 "Built successfully") | [  ~~🧪 wpe-238-arm32-layout~~](https://ews-wpe-rdk.igalia.com/#/builders/6/builds/34 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | 
| | 
<!--EWS-Status-Bubble-End-->