### PR TITLE
fix crash with playing playback on RPi

### DIFF
--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkOpenMAX.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkOpenMAX.h
@@ -30,6 +30,7 @@ class GStreamerQuirkOpenMAX final : public GStreamerQuirk {
 public:
     GStreamerQuirkOpenMAX();
     const ASCIILiteral identifier() const final { return "OpenMAX"_s; }
+    unsigned getAdditionalPlaybinFlags() const final { return getGstPlayFlag("text") | getGstPlayFlag("native-video"); }
 
     bool processWebAudioSilentBuffer(GstBuffer*) const final;
 };


### PR DESCRIPTION
Without this change WPE crashes when we try to start to play a playback on RPi. The reason is with OMX quirk(GStreamerQuirkOpenMAX) which used playbin flags ("soft-colorbalance") from base class: GStreamerQuirk.
<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/4aad871d9dbb575748c10fe46ed8902d587bcfbd

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| [✅ 🛠 wpe-238-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/1/builds/39 "Built successfully") | [✅ 🧪 wpe-238-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/5/builds/26 "Passed tests") 
| [✅ 🛠 wpe-238-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/8/builds/38 "Built successfully") | [✅ 🧪 wpe-238-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/6/builds/37 "Passed tests") 
| | 
| | 
<!--EWS-Status-Bubble-End-->