### PR TITLE
Fix 'offline renderer' thread cleanup

### DIFF
--- a/Source/WebCore/Modules/webaudio/OfflineAudioDestinationNode.cpp
+++ b/Source/WebCore/Modules/webaudio/OfflineAudioDestinationNode.cpp
@@ -86,10 +86,6 @@ void OfflineAudioDestinationNode::uninitialize()
         return;
 
     if (m_startedRendering) {
-        if (m_renderThread) {
-            m_renderThread->waitForCompletion();
-            m_renderThread = nullptr;
-        }
         if (auto* workletProxy = context().audioWorklet().proxy()) {
             BinarySemaphore semaphore;
             workletProxy->postTaskForModeToWorkletGlobalScope([&semaphore](ScriptExecutionContext&) mutable {
@@ -97,6 +93,11 @@ void OfflineAudioDestinationNode::uninitialize()
             }, WorkerRunLoop::defaultMode());
             semaphore.wait();
         }
+    }
+
+    if (m_renderThread) {
+        m_renderThread->waitForCompletion();
+        m_renderThread = nullptr;
     }
 
     AudioNode::uninitialize();


### PR DESCRIPTION
Offline renderer thread in most of the cases doesn't clean up its resources.
Thread should be joined on every exit, not only when rendering process is in progress.
This problem was detected during webaudio testing which revealed memory leakage.<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/bc53de1ad811f078b8bbca616c45e1b3a227eaab

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| [✅ 🛠 wpe-238-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/1/builds/40 "Built successfully") | [✅ 🧪 wpe-238-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/5/builds/27 "Passed tests") 
| [✅ 🛠 wpe-238-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/8/builds/39 "Built successfully") | [✅ 🧪 wpe-238-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/6/builds/38 "Passed tests") 
| | 
| | 
<!--EWS-Status-Bubble-End-->