### PR TITLE
Upstream: WPE 2.38 - Video playback plays slowly instead of pausing v…

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -2621,7 +2621,8 @@ void MediaPlayerPrivateGStreamer::updateStates()
             shouldPauseForBuffering = (!m_wasBuffering && m_isBuffering && !m_isLiveStream.value_or(false));
             if (shouldPauseForBuffering || !m_playbackRate) {
                 GST_INFO_OBJECT(pipeline(), "[Buffering] Pausing stream for buffering or because of zero playback rate.");
-                changePipelineState(GST_STATE_PAUSED);
+                m_playbackRatePausedState = PlaybackRatePausedState::RatePaused;
+		changePipelineState(GST_STATE_PAUSED);
             }
         } else
             m_isPaused = true;


### PR DESCRIPTION
Video playback plays slowly instead of pausing video during buffering when bandwidth is lower than video bitrate for progressive video

Severity:
Major

Replication path/steps:

1. Limit network connection to ~2Mbps

 connect an ethernet directly between pc and box
create a new profile in settings->network->wired and choose "shared to other computers" option while creating profile
run script given in https://wikiprojects.upc.biz/display/CTOM/Debugging#Debugging-Networkthrottling 
2. Start to play some progressive video e.g Euronews



Actual results:
In situation when bandwidth is lower than video bitrate, video should be paused during buffering state, and then play with normal speed.

Expected results:
Video is not paused during buffering but it still keeps playing in slow motion

Frequency (percentage):
100<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/5004aa52ddfb1de0f8319ec4d45e500e55b6ff04

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| [❌ 🛠 wpe-238-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/1/builds/51 "Failed to checkout and rebase branch from PR 1455") | [✅ 🧪 wpe-238-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/5/builds/35 "Passed tests") 
| [❌ 🛠 wpe-238-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/8/builds/50 "Failed to checkout and rebase branch from PR 1455") | [✅ 🧪 wpe-238-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/6/builds/45 "Passed tests") 
| | 
| | 
<!--EWS-Status-Bubble-End-->