### PR TITLE
[wpe-2.38] Add ftrace based system tracing

### DIFF
--- a/Source/WTF/wtf/PlatformWPE.cmake
+++ b/Source/WTF/wtf/PlatformWPE.cmake
@@ -13,6 +13,7 @@ list(APPEND WTF_PUBLIC_HEADERS
     linux/ProcessMemoryFootprint.h
     linux/CurrentProcessMemoryStatus.h
     linux/RealTimeThreads.h
+    linux/SystemTracingFTrace.h
 
     unix/UnixFileDescriptor.h
 )

--- a/Source/WTF/wtf/SystemTracing.h
+++ b/Source/WTF/wtf/SystemTracing.h
@@ -146,12 +146,21 @@ enum TracePointCode {
 
 #ifdef __cplusplus
 
+#if USE(LINUX_FTRACE)
+#include <wtf/linux/SystemTracingFTrace.h>
+#endif
+
 namespace WTF {
 
 inline void tracePoint(TracePointCode code, uint64_t data1 = 0, uint64_t data2 = 0, uint64_t data3 = 0, uint64_t data4 = 0)
 {
 #if HAVE(KDEBUG_H)
     kdebug_trace(ARIADNEDBG_CODE(WEBKIT_COMPONENT, code), data1, data2, data3, data4);
+#elif USE(LINUX_FTRACE)
+    SystemTracingFTrace::instance().tracePoint(code, data1);
+    UNUSED_PARAM(data2);
+    UNUSED_PARAM(data3);
+    UNUSED_PARAM(data4);
 #else
     UNUSED_PARAM(code);
     UNUSED_PARAM(data1);

--- a/Source/WTF/wtf/linux/SystemTracingFTrace.h
+++ b/Source/WTF/wtf/linux/SystemTracingFTrace.h
@@ -1,0 +1,404 @@
+/*
+ * Copyright (C) 2024 Igalia, S.L.
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Library General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Library General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Library General Public License
+ *  along with this library; see the file COPYING.LIB.  If not, write to
+ *  the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ *  Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#if USE(LINUX_FTRACE)
+
+#include <wtf/Assertions.h>
+#include <wtf/SystemTracing.h>
+#include <wtf/text/ASCIILiteral.h>
+
+#include <cstdio>
+#include <cstring>
+#include <mutex>
+#include <string>
+#include <fcntl.h>
+#include <unistd.h>
+
+namespace WTF {
+
+class SystemTracingFTrace {
+public:
+    static SystemTracingFTrace& instance() {
+        static SystemTracingFTrace instance;
+        return instance;
+    }
+
+    inline void tracePoint(TracePointCode code, uint64_t cookie) {
+        // ftrace disabled in runtime
+        if (m_traceMarkerFd < 0) return;
+
+        switch (code) {
+        case VMEntryScopeStart:
+        case WebAssemblyCompileStart:
+        case WebAssemblyExecuteStart:
+        case DumpJITMemoryStart:
+        case FromJSStart:
+        case FetchCookiesStart:
+        case StyleRecalcStart:
+        case LayoutStart:
+        case RenderTreeBuildStart:
+        case PaintLayerStart:
+        case AsyncImageDecodeStart:
+        case RAFCallbackStart:
+        case MemoryPressureHandlerStart:
+        case UpdateTouchRegionsStart:
+        case DisplayListRecordStart:
+        case ComputeEventRegionsStart:
+        case RenderingUpdateStart:
+        case CompositingUpdateStart:
+        case DispatchTouchEventsStart:
+        case ParseHTMLStart:
+        case DisplayListReplayStart:
+        case ScrollingThreadRenderUpdateSyncStart:
+        case ScrollingThreadDisplayDidRefreshStart:
+        case WebHTMLViewPaintStart:
+        case BackingStoreFlushStart:
+        case BuildTransactionStart:
+        case SyncMessageStart:
+        case SyncTouchEventStart:
+        case InitializeWebProcessStart:
+        case RenderingUpdateRunLoopObserverStart:
+        case LayerTreeFreezeStart:
+        case FlushRemoteImageBufferStart:
+        case CreateInjectedBundleStart:
+        case PaintSnapshotStart:
+        case RenderServerSnapshotStart:
+        case TakeSnapshotStart:
+        case SyntheticMomentumStart:
+        case CommitLayerTreeStart:
+        case ProcessLaunchStart:
+        case InitializeSandboxStart:
+        case WakeUpAndApplyDisplayListStart:
+            beginSyncMark(code);
+            return;
+
+        case VMEntryScopeEnd:
+        case WebAssemblyCompileEnd:
+        case WebAssemblyExecuteEnd:
+        case DumpJITMemoryStop:
+        case FromJSStop:
+        case FetchCookiesEnd:
+        case StyleRecalcEnd:
+        case LayoutEnd:
+        case RenderTreeBuildEnd:
+        case PaintLayerEnd:
+        case AsyncImageDecodeEnd:
+        case RAFCallbackEnd:
+        case MemoryPressureHandlerEnd:
+        case UpdateTouchRegionsEnd:
+        case DisplayListRecordEnd:
+        case ComputeEventRegionsEnd:
+        case RenderingUpdateEnd:
+        case CompositingUpdateEnd:
+        case DispatchTouchEventsEnd:
+        case ParseHTMLEnd:
+        case DisplayListReplayEnd:
+        case ScrollingThreadRenderUpdateSyncEnd:
+        case ScrollingThreadDisplayDidRefreshEnd:
+        case WebHTMLViewPaintEnd:
+        case BackingStoreFlushEnd:
+        case BuildTransactionEnd:
+        case SyncMessageEnd:
+        case SyncTouchEventEnd:
+        case InitializeWebProcessEnd:
+        case RenderingUpdateRunLoopObserverEnd:
+        case LayerTreeFreezeEnd:
+        case FlushRemoteImageBufferEnd:
+        case CreateInjectedBundleEnd:
+        case PaintSnapshotEnd:
+        case RenderServerSnapshotEnd:
+        case TakeSnapshotEnd:
+        case SyntheticMomentumEnd:
+        case CommitLayerTreeEnd:
+        case ProcessLaunchEnd:
+        case InitializeSandboxEnd:
+        case WakeUpAndApplyDisplayListEnd:
+            endSyncMark(code);
+            return;
+
+        case MainResourceLoadDidStartProvisional:
+        case SubresourceLoadWillStart:
+            beginAsyncMark(code, cookie);
+            return;
+
+        case MainResourceLoadDidEnd:
+        case SubresourceLoadDidEnd:
+            endAsyncMark(code, cookie);
+            return;
+
+        case DisplayRefreshDispatchingToMainThread:
+        case ScheduleRenderingUpdate:
+        case TriggerRenderingUpdate:
+        case ScrollingTreeDisplayDidRefresh:
+        case SyntheticMomentumEvent:
+            instantMark(code);
+            return;
+
+        case WTFRange:
+        case JavaScriptRange:
+        case WebCoreRange:
+        case WebKitRange:
+        case WebKit2Range:
+        case UIProcessRange:
+        case GPUProcessRange:
+            break;
+        }
+
+        WTFLogAlways("Invalid trace point code %d", code);
+    }
+
+    ~SystemTracingFTrace() {
+        if (m_traceMarkerFd >= 0) {
+            close(m_traceMarkerFd);
+        }
+    }
+
+private:
+
+    inline void beginSyncMark(TracePointCode code) {
+        // "B|<pid>|<name>"
+        std::string message = std::string("B|") + std::to_string(m_pid) + "|" + tracePointCodeName(code).characters();
+        writeFTraceMarker(message.c_str());
+    }
+
+    inline void endSyncMark(TracePointCode code) {
+        UNUSED_PARAM(code);
+        // "E|<pid>"
+        std::string message = std::string("E|") + std::to_string(m_pid);
+        writeFTraceMarker(message.c_str());
+    }
+
+    inline void beginAsyncMark(TracePointCode code, uint64_t cookie) {
+        // "S|<pid>|<name>|<cookie>"
+        std::string message = std::string("S|") + std::to_string(m_pid) + "|" + tracePointCodeName(code).characters() + "|" + std::to_string(cookie);
+        writeFTraceMarker(message.c_str());
+    }
+
+    inline void endAsyncMark(TracePointCode code, uint64_t cookie) {
+        // "F|<pid>|<name>|<cookie>"
+        std::string message = std::string("F|") + std::to_string(m_pid) + "|" + tracePointCodeName(code).characters() + "|" + std::to_string(cookie);
+        writeFTraceMarker(message.c_str());
+    }
+
+    inline void instantMark(TracePointCode code) {
+        // "I|<pid>|<name>"
+        std::string message = std::string("I|") + std::to_string(m_pid) + "|" + tracePointCodeName(code).characters();
+        writeFTraceMarker(message.c_str());
+    }
+
+    inline void writeFTraceMarker(const char* message) {
+        RELEASE_ASSERT(m_traceMarkerFd >= 0);
+
+        // make sure no other thread is writing at the same time
+        std::lock_guard<std::mutex> lock(m_mutex);
+        write(m_traceMarkerFd, message, strlen(message));
+    }
+
+    SystemTracingFTrace() {
+        // Need to enable in runtime with WEBKIT_USE_FTRACE
+        const char* env = getenv("WEBKIT_USE_FTRACE");
+        if (!env || strcmp(env, "1") != 0) {
+            return;
+        }
+
+        static constexpr const char* trace_marker = "/sys/kernel/debug/tracing/trace_marker";
+        m_traceMarkerFd = open(trace_marker, O_WRONLY);
+        if (m_traceMarkerFd < 0) {
+            WTFLogAlways("Failed to open %s", trace_marker);
+            return;
+        }
+
+        m_pid = getpid();
+    }
+
+    inline ASCIILiteral tracePointCodeName(TracePointCode code) {
+        switch (code) {
+        case VMEntryScopeStart:
+        case VMEntryScopeEnd:
+            return "VMEntryScope"_s;
+        case WebAssemblyCompileStart:
+        case WebAssemblyCompileEnd:
+            return "WebAssemblyCompile"_s;
+        case WebAssemblyExecuteStart:
+        case WebAssemblyExecuteEnd:
+            return "WebAssemblyExecute"_s;
+        case DumpJITMemoryStart:
+        case DumpJITMemoryStop:
+            return "DumpJITMemory"_s;
+        case FromJSStart:
+        case FromJSStop:
+            return "FromJS"_s;
+
+        case MainResourceLoadDidStartProvisional:
+        case MainResourceLoadDidEnd:
+            return "MainResourceLoad"_s;
+        case SubresourceLoadWillStart:
+        case SubresourceLoadDidEnd:
+            return "SubresourceLoad"_s;
+        case FetchCookiesStart:
+        case FetchCookiesEnd:
+            return "FetchCookies"_s;
+        case StyleRecalcStart:
+        case StyleRecalcEnd:
+            return "StyleRecalc"_s;
+        case LayoutStart:
+        case LayoutEnd:
+            return "Layout"_s;
+        case RenderTreeBuildStart:
+        case RenderTreeBuildEnd:
+            return "RenderTreeBuild"_s;
+        case PaintLayerStart:
+        case PaintLayerEnd:
+            return "PaintLayer"_s;
+        case AsyncImageDecodeStart:
+        case AsyncImageDecodeEnd:
+            return "AsyncImageDecode"_s;
+        case RAFCallbackStart:
+        case RAFCallbackEnd:
+            return "RAFCallback"_s;
+        case MemoryPressureHandlerStart:
+        case MemoryPressureHandlerEnd:
+            return "MemoryPressureHandler"_s;
+        case UpdateTouchRegionsStart:
+        case UpdateTouchRegionsEnd:
+            return "UpdateTouchRegions"_s;
+        case DisplayListRecordStart:
+        case DisplayListRecordEnd:
+            return "DisplayListRecord"_s;
+        case DisplayRefreshDispatchingToMainThread:
+            return "DisplayRefreshDispatchingToMainThread"_s;
+        case ComputeEventRegionsStart:
+        case ComputeEventRegionsEnd:
+            return "ComputeEventRegions"_s;
+        case ScheduleRenderingUpdate:
+            return "ScheduleRenderingUpdate"_s;
+        case TriggerRenderingUpdate:
+            return "TriggerRenderingUpdate"_s;
+        case RenderingUpdateStart:
+        case RenderingUpdateEnd:
+            return "RenderingUpdate"_s;
+        case CompositingUpdateStart:
+        case CompositingUpdateEnd:
+            return "CompositingUpdate"_s;
+        case DispatchTouchEventsStart:
+        case DispatchTouchEventsEnd:
+            return "DispatchTouchEvents"_s;
+        case ParseHTMLStart:
+        case ParseHTMLEnd:
+            return "ParseHTML"_s;
+        case DisplayListReplayStart:
+        case DisplayListReplayEnd:
+            return "DisplayListReplay"_s;
+        case ScrollingThreadRenderUpdateSyncStart:
+        case ScrollingThreadRenderUpdateSyncEnd:
+            return "ScrollingThreadRenderUpdateSync"_s;
+        case ScrollingThreadDisplayDidRefreshStart:
+        case ScrollingThreadDisplayDidRefreshEnd:
+            return "ScrollingThreadDisplayDidRefresh"_s;
+        case ScrollingTreeDisplayDidRefresh:
+            return "ScrollingTreeDisplayDidRefresh"_s;
+
+        case WebHTMLViewPaintStart:
+        case WebHTMLViewPaintEnd:
+            return "WebHTMLViewPaint"_s;
+
+        case BackingStoreFlushStart:
+        case BackingStoreFlushEnd:
+            return "BackingStoreFlush"_s;
+        case BuildTransactionStart:
+        case BuildTransactionEnd:
+            return "BuildTransaction"_s;
+        case SyncMessageStart:
+        case SyncMessageEnd:
+            return "SyncMessage"_s;
+        case SyncTouchEventStart:
+        case SyncTouchEventEnd:
+            return "SyncTouchEvent"_s;
+        case InitializeWebProcessStart:
+        case InitializeWebProcessEnd:
+            return "InitializeWebProcess"_s;
+        case RenderingUpdateRunLoopObserverStart:
+        case RenderingUpdateRunLoopObserverEnd:
+            return "RenderingUpdateRunLoopObserver"_s;
+        case LayerTreeFreezeStart:
+        case LayerTreeFreezeEnd:
+            return "LayerTreeFreeze"_s;
+        case FlushRemoteImageBufferStart:
+        case FlushRemoteImageBufferEnd:
+            return "FlushRemoteImageBuffer"_s;
+        case CreateInjectedBundleStart:
+        case CreateInjectedBundleEnd:
+            return "CreateInjectedBundle"_s;
+        case PaintSnapshotStart:
+        case PaintSnapshotEnd:
+            return "PaintSnapshot"_s;
+        case RenderServerSnapshotStart:
+        case RenderServerSnapshotEnd:
+            return "RenderServerSnapshot"_s;
+        case TakeSnapshotStart:
+        case TakeSnapshotEnd:
+            return "TakeSnapshot"_s;
+        case SyntheticMomentumStart:
+        case SyntheticMomentumEnd:
+            return "SyntheticMomentum"_s;
+        case SyntheticMomentumEvent:
+            return "SyntheticMomentumEvent"_s;
+
+        case CommitLayerTreeStart:
+        case CommitLayerTreeEnd:
+            return "CommitLayerTree"_s;
+        case ProcessLaunchStart:
+        case ProcessLaunchEnd:
+            return "ProcessLaunch"_s;
+        case InitializeSandboxStart:
+        case InitializeSandboxEnd:
+            return "InitializeSandbox"_s;
+
+        case WakeUpAndApplyDisplayListStart:
+        case WakeUpAndApplyDisplayListEnd:
+            return "WakeUpAndApplyDisplayList"_s;
+
+        // Markers, not intended to be used in tracePoint calls.
+        case WTFRange:
+        case JavaScriptRange:
+        case WebCoreRange:
+        case WebKitRange:
+        case WebKit2Range:
+        case UIProcessRange:
+        case GPUProcessRange:
+            break;
+        }
+        WTFLogAlways("Invalid trace point code %d", code);
+        return ""_s;
+    }
+
+    SystemTracingFTrace(const SystemTracingFTrace&) = delete;
+    SystemTracingFTrace& operator=(const SystemTracingFTrace&) = delete;
+
+private:
+    int m_traceMarkerFd = -1;
+    std::mutex m_mutex;
+    unsigned m_pid = -1;
+};
+
+} // namespace WTF
+
+#endif // USE(LINUX_FTRACE)

--- a/Source/cmake/OptionsWPE.cmake
+++ b/Source/cmake/OptionsWPE.cmake
@@ -106,6 +106,7 @@ WEBKIT_OPTION_DEFINE(USE_GSTREAMER_HOLEPUNCH "Whether to enable GStreamer holepu
 WEBKIT_OPTION_DEFINE(USE_EXTERNAL_HOLEPUNCH "Whether to enable external holepunch" PRIVATE OFF)
 WEBKIT_OPTION_DEFINE(ENABLE_ACCELERATED_2D_CANVAS "Whether to enable accelerated 2D canvas" PRIVATE OFF)
 WEBKIT_OPTION_DEFINE(ENABLE_OIPF_VK "Whether to enable OIPF keys for DAE applications" PRIVATE OFF)
+WEBKIT_OPTION_DEFINE(USE_LINUX_FTRACE "Whether to use ftrace based webkit tracing" PRIVATE OFF)
 
 # Supported platforms.
 WEBKIT_OPTION_DEFINE(USE_WPEWEBKIT_PLATFORM_WESTEROS "Whether to enable support for the Westeros platform" PUBLIC OFF)


### PR DESCRIPTION
    [wpe-2.38] Add ftrace based system tracing
    
    Add WebKit tracing with linux 'ftrace' that can be used on STB devices.
    Write tracing points into 'trace_marker' file with 'perfetto'
    compatible format.
    The results can be collected and visualized by 'perfetto'

Quite similar to what is available in 2.46 with sysprof but ftrace can be used directly on the device (ftrace needs to be enabled in kernel). This is initial version to discuss, probably needs to be extended with more tracing points/scopes to mark painting, compositing, etc

<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/fe50f1a8cc037bf32c5f5abfc6411f84b4ea642e

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| [✅ 🛠 wpe-238-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/1/builds/49 "Built successfully") | [✅ 🧪 wpe-238-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/5/builds/34 "Passed tests") 
| [✅ 🛠 wpe-238-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/8/builds/48 "Built successfully") | [✅ 🧪 wpe-238-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/6/builds/44 "Passed tests") 
| | 
| | 
<!--EWS-Status-Bubble-End-->