### PR TITLE
[GTK][WPE][GStreamer] support the 'eotf' additional MIME type paramet…

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
@@ -778,6 +778,15 @@ MediaPlayerEnums::SupportsType GStreamerRegistryScanner::isContentTypeSupported(
         if (!isCodecSupported(configuration, codec, requiresHardwareSupport))
             return SupportsType::IsNotSupported;
     }
+
+    // The 'eotf' additional mime-type parameter must be supported to be compliant with
+    // "YouTube TV HTML5 Technical Requirements"
+    // (point 16.3.1 from https://developers.google.com/youtube/devices/living-room/files/pdf-guides/YouTube_TV_HTML5_Technical_Requirements_2018.pdf).
+    const auto eotf = contentType.parameter("eotf"_s);
+    if (!eotf.isEmpty()) {
+        if (eotf != "bt709"_s && eotf != "smpte2084"_s && eotf != "arib-std-b67"_s)
+            return SupportsType::IsNotSupported;
+    }
     return SupportsType::IsSupported;
 }
 


### PR DESCRIPTION
…er by isSupportedType

https://bugs.webkit.org/show_bug.cgi?id=287560

Reviewed by Philippe Normand.

MediaSource.isSupportedType method must support the 'eotf' additional MIME type parameter and support the following values:
* 'bt709', indicating ITU-R BT.1886 support
* 'smpte2084', to indicate SMPTE 2084 EOTF support
* 'arib-std-b67', to indicate ARIB STD-B67 support

to be compliant with "YouTube TV HTML5 Technical Requirements" (defined in point 16.3.1 of https://developers.google.com/youtube/devices/living-room/files/pdf-guides/YouTube_TV_HTML5_Technical_Requirements_2018.pdf).

* Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp: (WebCore::GStreamerRegistryScanner::isContentTypeSupported const):

Canonical link: https://commits.webkit.org/290396@main<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/b5cf513170734642190775ec0c4bad02068b809c

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| [✅ 🛠 wpe-238-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/1/builds/45 "Built successfully") | [  ~~🧪 wpe-238-amd64-layout~~](https://ews-wpe-rdk.igalia.com/#/builders/5/builds/32 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🛠 wpe-238-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/8/builds/44 "Built successfully") | [  ~~🧪 wpe-238-arm32-layout~~](https://ews-wpe-rdk.igalia.com/#/builders/6/builds/42 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | 
| | 
<!--EWS-Status-Bubble-End-->