### PR TITLE
[GTK][WPE][GStreamer] support the 'eotf' additional MIME type paramet…

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
@@ -889,6 +889,15 @@ MediaPlayerEnums::SupportsType GStreamerRegistryScanner::isContentTypeSupported(
         if (!isCodecSupported(configuration, codec, requiresHardwareSupport, caseSensitive))
             return SupportsType::IsNotSupported;
     }
+
+    // The 'eotf' additional mime-type parameter must be supported to be compliant with
+    // "YouTube TV HTML5 Technical Requirements"
+    // (point 16.3.1 from https://developers.google.com/youtube/devices/living-room/files/pdf-guides/YouTube_TV_HTML5_Technical_Requirements_2018.pdf).
+    const auto eotf = contentType.parameter("eotf"_s);
+    if (!eotf.isEmpty()) {
+        if (eotf != "bt709"_s && eotf != "smpte2084"_s && eotf != "arib-std-b67"_s)
+            return SupportsType::IsNotSupported;
+    }
     return SupportsType::IsSupported;
 }
 


### PR DESCRIPTION
…er by isSupportedType

https://bugs.webkit.org/show_bug.cgi?id=287560

Reviewed by Philippe Normand.

MediaSource.isSupportedType method must support the 'eotf' additional MIME type parameter and support the following values:
* 'bt709', indicating ITU-R BT.1886 support
* 'smpte2084', to indicate SMPTE 2084 EOTF support
* 'arib-std-b67', to indicate ARIB STD-B67 support

to be compliant with "YouTube TV HTML5 Technical Requirements" (defined in point 16.3.1 of https://developers.google.com/youtube/devices/living-room/files/pdf-guides/YouTube_TV_HTML5_Technical_Requirements_2018.pdf).

* Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp: (WebCore::GStreamerRegistryScanner::isContentTypeSupported const):

Canonical link: https://commits.webkit.org/290396@main<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/de1c0c647829b216f49982665b9e386bac207c20

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [❌ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/64 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/64 "Unable to build WebKit without PR, please check manually (failure)") 
| [❌ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/66 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/66 "Unable to build WebKit without PR, please check manually (failure)") 
<!--EWS-Status-Bubble-End-->