### PR TITLE
[wpe-2.46] Hide KHR/khrplatform.h header under ANGLE directory

### DIFF
--- a/Source/ThirdParty/ANGLE/CMakeLists.txt
+++ b/Source/ThirdParty/ANGLE/CMakeLists.txt
@@ -129,7 +129,7 @@ WEBKIT_INCLUDE_CONFIG_FILES_IF_EXISTS()
 add_subdirectory(include)
 
 add_library(ANGLEFramework INTERFACE)
-add_dependencies(ANGLEFramework GLSLANGHeaders ANGLEHeaders)
+add_dependencies(ANGLEFramework GLSLANGHeaders KHRHeaders ANGLEHeaders)
 
 if (USE_ANGLE_EGL OR ENABLE_WEBGL)
     add_library(ANGLE ${ANGLE_LIBRARY_TYPE}

--- a/Source/ThirdParty/ANGLE/include/CMakeLists.txt
+++ b/Source/ThirdParty/ANGLE/include/CMakeLists.txt
@@ -20,10 +20,9 @@ set(glslang_headers
     GLSLANG/ShaderVars.h
 )
 
-set(ANGLE_PUBLIC_HEADERS ${khr_headers})
-
 if (USE_ANGLE_EGL)
     list(APPEND ANGLE_PUBLIC_HEADERS
+        ${khr_headers}
         ${egl_headers}
         ${gles_headers}
         ${gles2_headers}
@@ -53,6 +52,12 @@ WEBKIT_COPY_FILES(GLSLANGHeaders
     DESTINATION ${ANGLE_FRAMEWORK_HEADERS_DIR}/ANGLE
     FILES ${glslang_headers}
     FLATTENED
+)
+
+# needed by GLSLANGHeaders
+WEBKIT_COPY_FILES(KHRHeaders
+    DESTINATION ${ANGLE_FRAMEWORK_HEADERS_DIR}/ANGLE
+    FILES ${khr_headers}
 )
 
 WEBKIT_COPY_FILES(ANGLEHeaders


### PR DESCRIPTION
ANGLE installs KHR/khrplatform.h header even if ANGLE is disabled. That makes other components pick this header instead of vendor provided one

This change will install khrplatform.h inside ANGLE/KHR/khrplatform.h instead of KHR/khrplatform.h so it can be still used internally by ANGLE but will not override platform khr

Usually, all webkit components use epoxy egl that provides its own khr api impl. In some cases, e.g. enderer-backend-egl.h includes eglplatform.h directly, just to get native display type. This results with inclusion of ANGLE khrplatform.h instead of the one in /usr/include/KRH/khrplatform.h and breaks compilation on our broadcom platform as it miss vendor adjustments.<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/315dec3f5596db8388d05ffafc8221666532b9b4

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [❌ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/71 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/71 "Unable to build WebKit without PR, please check manually (failure)") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/73 "Built successfully") | [✅ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/10/builds/7 "Passed tests") 
<!--EWS-Status-Bubble-End-->