### PR TITLE
Mute functionality is not working on video element by calling volume API by 0/1

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -1751,7 +1751,10 @@ void MediaPlayerPrivateGStreamer::setVolume(float volume)
         return;
 
     GST_DEBUG_OBJECT(pipeline(), "Setting volume: %f", volume);
-    gst_stream_volume_set_volume(m_volumeElement.get(), GST_STREAM_VOLUME_FORMAT_LINEAR, static_cast<double>(volume));
+    gst_stream_volume_set_volume(m_volumeElement.get(), GST_STREAM_VOLUME_FORMAT_LINEAR, static_cast<double>(volume)); 
+
+    m_isMuted = (volume == 0) ? true : false;
+    g_object_set(m_volumeElement.get(), "mute", static_cast<gboolean>(m_isMuted), nullptr);
     configureMediaStreamAudioTracks();
 }
 


### PR DESCRIPTION
Audio is not muted when application call a volume API by setting a zero.
Request came for Apple TV application.
Scenario:
Launch the apple TV URL.
Playback any content
set the volume command from web inspector console like below
document.querySelector("video").volume = 0 --> Audio should mute
or 
document.querySelector("video").volume = 1--> Audio should unmute it.
<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/e4c585b9488ac231702686baa5e7d6344b9d263b

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| [✅ 🛠 wpe-238-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/1/builds/57 "Built successfully") | [❌ 🧪 wpe-238-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/5/builds/38 "Found 105 new test failures: http/wpt/css/css-highlight-api/highlight-text-replace.html, http/wpt/css/css-highlight-api/highlight-text.html, http/wpt/html/dom/scroll-to-text-fragment/scroll-to-text-fragment-start-emoji.html, http/wpt/html/dom/scroll-to-text-fragment/scroll-to-text-fragment-start-sentence.html, http/wpt/html/dom/scroll-to-text-fragment/scroll-to-text-fragment-start.html, imported/w3c/web-platform-tests/compat/webkit-box-clamp-bottom-border.html, imported/w3c/web-platform-tests/css/css-align/baseline-rules/grid-item-input-type-number.html, imported/w3c/web-platform-tests/css/css-align/baseline-rules/grid-item-input-type-text.html, imported/w3c/web-platform-tests/css/css-backgrounds/background-repeat-space-10.html, imported/w3c/web-platform-tests/css/css-backgrounds/background-repeat-space-1a.html ... (failure)") 
| [✅ 🛠 wpe-238-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/8/builds/56 "Built successfully") | [✅ 🧪 wpe-238-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/6/builds/48 "Passed tests") 
| | 
| | 
<!--EWS-Status-Bubble-End-->