### PR TITLE
[SpeechSynthesis] Emit error event for all cancelled utterances

### DIFF
--- a/Source/WebCore/Modules/speech/SpeechSynthesis.cpp
+++ b/Source/WebCore/Modules/speech/SpeechSynthesis.cpp
@@ -169,15 +169,27 @@ void SpeechSynthesis::cancel()
     // Remove all the items from the utterance queue.
     // Hold on to the current utterance so the platform synthesizer can have a chance to clean up.
     RefPtr current = protectedCurrentSpeechUtterance();
-    m_utteranceQueue.clear();
     if (m_speechSynthesisClient) {
+        m_utteranceQueue.clear();
         m_speechSynthesisClient->cancel();
         // If we wait for cancel to callback speakingErrorOccurred, then m_currentSpeechUtterance will be null
         // and the event won't be processed. Instead we process the error immediately.
         speakingErrorOccurred(SpeechSynthesisErrorCode::Canceled);
         m_currentSpeechUtterance = nullptr;
-    } else if (m_platformSpeechSynthesizer)
+    } else if (m_platformSpeechSynthesizer) {
+        // Clear m_utteranceQueue before calling cancel to avoid picking up new utterances
+        // on platform completion callback
+        Deque<Ref<SpeechSynthesisUtterance>> utteranceQueue = WTFMove(m_utteranceQueue);
         m_platformSpeechSynthesizer->cancel();
+
+        // Trigger canceled events for queued utterances
+        while (!utteranceQueue.isEmpty()) {
+            Ref<SpeechSynthesisUtterance> utterance = utteranceQueue.takeFirst();
+            // Current utterance is handled in platform cancel()
+            if (current.get() != utterance.ptr())
+                utterance.get().errorEventOccurred(eventNames().errorEvent, SpeechSynthesisErrorCode::Canceled);
+        }
+    }
 
     current = nullptr;
 }


### PR DESCRIPTION
Dispatch an error event "canceled" for queued utterances.

Spec:
https://dvcs.w3.org/hg/speech-api/raw-file/tip/webspeechapi 5.2.5.1 SpeechSynthesisErrorEvent Attributes:

"canceled"
    A cancel method call caused the SpeechSynthesisUtterance
    to be removed from the queue before it had begun being spoken.<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/76700de9752e9ada792520c7bb03632ef16b885c

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/93 "Built successfully") | [✅ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/20 "Passed tests") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/94 "Built successfully") | [✅ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/10/builds/23 "Passed tests") 
<!--EWS-Status-Bubble-End-->