### PR TITLE
[GStreamer] Add quirk supporting instant rate change with custom event

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -709,7 +709,19 @@ void MediaPlayerPrivateGStreamer::updatePlaybackRate()
     GST_INFO_OBJECT(pipeline(), mute ? "Need to mute audio" : "Do not need to mute audio");
 
     if (m_lastPlaybackRate != m_playbackRate) {
-        if (doSeek(SeekTarget { playbackPosition() }, m_playbackRate)) {
+        auto& quirksManager = GStreamerQuirksManager::singleton();
+        bool didInstantRateChange = false;
+        if (m_isPipelinePlaying && quirksManager.shouldUseCustomInstantRateChange() &&
+            !isPipelineWaitingPreroll()) {
+            GstStructure* s = gst_structure_new("custom-instant-rate-change",
+                "rate", G_TYPE_DOUBLE, m_playbackRate, nullptr);
+            didInstantRateChange = gst_element_send_event(
+                pipeline(), gst_event_new_custom(GST_EVENT_CUSTOM_DOWNSTREAM_OOB, s));
+        }
+        if (didInstantRateChange) {
+            g_object_set(m_pipeline.get(), "mute", mute, nullptr);
+            m_lastPlaybackRate = m_playbackRate;
+        } else if (doSeek(SeekTarget { playbackPosition() }, m_playbackRate)) {
             g_object_set(m_pipeline.get(), "mute", mute, nullptr);
             m_lastPlaybackRate = m_playbackRate;
         } else {
@@ -3267,7 +3279,7 @@ void MediaPlayerPrivateGStreamer::createGSTPlayBin(const URL& url)
 
     g_object_set(m_pipeline.get(), "audio-sink", m_audioSink.get(), "video-sink", createVideoSink(), nullptr);
 
-    if (m_shouldPreservePitch && !isMediaStream) {
+    if (m_shouldPreservePitch && !isMediaStream && !GStreamerQuirksManager::singleton().shouldUseCustomInstantRateChange()) {
         if (auto* scale = makeGStreamerElement("scaletempo", nullptr))
             g_object_set(m_pipeline.get(), "audio-filter", scale, nullptr);
     }

--- a/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
@@ -702,6 +702,7 @@ static void webKitMediaSrcStreamFlush(Stream* stream, bool isSeekingFlush)
                 GST_DEBUG_OBJECT(stream->source, "Resetting segment to current pipeline running time (%" GST_TIME_FORMAT " and stream time (%" GST_TIME_FORMAT " = %s)",
                     GST_TIME_ARGS(pipelineRunningTime), GST_TIME_ARGS(pipelineStreamTime), streamTime.toString().ascii().data());
                 streamingMembers->segment.base = pipelineRunningTime;
+                streamingMembers->segment.rate = stream->source->priv->rate;
                 streamingMembers->segment.start = streamingMembers->segment.time = static_cast<GstClockTime>(pipelineStreamTime);
             }
         }
@@ -835,6 +836,18 @@ static gboolean webKitMediaSrcSendEvent(GstElement* element, GstEvent* eventTran
         GST_DEBUG_OBJECT(element, "Handling seek event: %" GST_PTR_FORMAT, event.get());
         webKitMediaSrcSeek(WEBKIT_MEDIA_SRC(element), start, rate);
         return true;
+    }
+    case GST_EVENT_CUSTOM_DOWNSTREAM_OOB: {
+        WebKitMediaSrc* source = WEBKIT_MEDIA_SRC(element);
+        gboolean result = !source->priv->streams.isEmpty();
+        for (const RefPtr<Stream>& stream : source->priv->streams.values())
+            result &= gst_pad_push_event(stream->pad.get(), gst_event_ref(event.get()));
+        if (gst_event_has_name(event.get(), "custom-instant-rate-change")) {
+            gdouble rate = 1.0;
+            if (gst_structure_get_double(gst_event_get_structure(event.get()), "rate", &rate))
+                source->priv->rate = rate;
+        }
+        return result;
     }
     default:
         return GST_ELEMENT_CLASS(webkit_media_src_parent_class)->send_event(element, event.leakRef());

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkAmLogic.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkAmLogic.cpp
@@ -61,6 +61,11 @@ void GStreamerQuirkAmLogic::configureElement(GstElement* element, const OptionSe
     }
 }
 
+bool GStreamerQuirkAmLogic::shouldUseCustomInstantRateChange() const
+{
+    return true;
+}
+
 #undef GST_CAT_DEFAULT
 
 } // namespace WebCore

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkAmLogic.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkAmLogic.h
@@ -33,6 +33,7 @@ public:
 
     GstElement* createWebAudioSink() final;
     void configureElement(GstElement*, const OptionSet<ElementRuntimeCharacteristics>&) final;
+    bool shouldUseCustomInstantRateChange() const final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcom.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcom.cpp
@@ -64,6 +64,11 @@ std::optional<bool> GStreamerQuirkBroadcom::isHardwareAccelerated(GstElementFact
     return std::nullopt;
 }
 
+bool GStreamerQuirkBroadcom::shouldUseCustomInstantRateChange() const
+{
+    return true;
+}
+
 #undef GST_CAT_DEFAULT
 
 } // namespace WebCore

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcom.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcom.h
@@ -39,6 +39,7 @@ public:
     Vector<String> disallowedWebAudioDecoders() const final { return m_disallowedWebAudioDecoders; }
     unsigned getAdditionalPlaybinFlags() const final { return getGstPlayFlag("text") | getGstPlayFlag("native-audio"); }
     bool shouldParseIncomingLibWebRTCBitStream() const final { return false; }
+    bool shouldUseCustomInstantRateChange() const final;
 
 private:
     Vector<String> m_disallowedWebAudioDecoders;

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkRealtek.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkRealtek.cpp
@@ -79,6 +79,11 @@ std::optional<bool> GStreamerQuirkRealtek::isHardwareAccelerated(GstElementFacto
     return std::nullopt;
 }
 
+bool GStreamerQuirkRealtek::shouldUseCustomInstantRateChange() const
+{
+    return true;
+}
+
 #undef GST_CAT_DEFAULT
 
 } // namespace WebCore

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkRealtek.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkRealtek.h
@@ -36,6 +36,7 @@ public:
     std::optional<bool> isHardwareAccelerated(GstElementFactory*) final;
     Vector<String> disallowedWebAudioDecoders() const final { return m_disallowedWebAudioDecoders; }
     bool shouldParseIncomingLibWebRTCBitStream() const final { return false; }
+    bool shouldUseCustomInstantRateChange() const final;
 
 private:
     Vector<String> m_disallowedWebAudioDecoders;

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.cpp
@@ -100,6 +100,11 @@ std::optional<bool> GStreamerQuirkRialto::isHardwareAccelerated(GstElementFactor
     return std::nullopt;
 }
 
+bool GStreamerQuirkRialto::shouldUseCustomInstantRateChange() const
+{
+    return true;
+}
+
 #undef GST_CAT_DEFAULT
 
 } // namespace WebCore

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.h
@@ -42,6 +42,7 @@ public:
     std::optional<bool> isHardwareAccelerated(GstElementFactory*) final;
     bool shouldParseIncomingLibWebRTCBitStream() const final { return false; }
     unsigned getAdditionalPlaybinFlags() const { return getGstPlayFlag("text") | getGstPlayFlag("native-audio") | getGstPlayFlag("native-video"); }
+    bool shouldUseCustomInstantRateChange() const final;
 
 private:
     GRefPtr<GstCaps> m_sinkCaps;

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.cpp
@@ -79,6 +79,11 @@ std::optional<bool> GStreamerQuirkWesteros::isHardwareAccelerated(GstElementFact
     return std::nullopt;
 }
 
+bool GStreamerQuirkWesteros::shouldUseCustomInstantRateChange() const
+{
+    return true;
+}
+
 #undef GST_CAT_DEFAULT
 
 } // namespace WebCore

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.h
@@ -34,6 +34,7 @@ public:
     void configureElement(GstElement*, const OptionSet<ElementRuntimeCharacteristics>&) final;
     std::optional<bool> isHardwareAccelerated(GstElementFactory*) final;
     unsigned getAdditionalPlaybinFlags() const final { return getGstPlayFlag("text") | getGstPlayFlag("native-video"); }
+    bool shouldUseCustomInstantRateChange() const final;
 
 private:
     GRefPtr<GstCaps> m_sinkCaps;

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp
@@ -343,6 +343,16 @@ void GStreamerQuirksManager::processWebAudioSilentBuffer(GstBuffer* buffer) cons
     }
 }
 
+bool GStreamerQuirksManager::shouldUseCustomInstantRateChange() const
+{
+    for (auto& quirk : m_quirks) {
+        if (quirk->shouldUseCustomInstantRateChange())
+            return true;
+    }
+    return false;
+}
+
+
 #undef GST_CAT_DEFAULT
 
 } // namespace WebCore

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirks.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirks.h
@@ -94,6 +94,8 @@ public:
         GST_BUFFER_FLAG_SET(buffer, GST_BUFFER_FLAG_DROPPABLE);
         return false;
     }
+
+    virtual bool shouldUseCustomInstantRateChange() const { return false; }
 };
 
 class GStreamerHolePunchQuirk : public GStreamerQuirkBase {
@@ -147,6 +149,8 @@ public:
     void setupBufferingPercentageCorrection(MediaPlayerPrivateGStreamer*, GstState currentState, GstState newState, GRefPtr<GstElement>&&) const;
 
     void processWebAudioSilentBuffer(GstBuffer*) const;
+
+    bool shouldUseCustomInstantRateChange() const;
 private:
     GStreamerQuirksManager(bool, bool);
 


### PR DESCRIPTION
Enabled for platforms that don't use GstClock for A/V sync and/or don't support existing GST_SEEK_FLAG_INSTANT_RATE_CHANGE (or it doesn't work well in all use cases).<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/c7ddb93fada28599c8af407a1f0cba2415e6d7ae

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/78 "Built successfully") | [✅ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/10 "Passed tests") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/80 "Built successfully") | [✅ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/10/builds/12 "Passed tests") 
<!--EWS-Status-Bubble-End-->