### PR TITLE
Fix build with clang-14

### DIFF
--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
@@ -290,7 +290,7 @@ String AccessibilityObjectAtspi::text() const
     if (!value.isNull())
         return value;
 
-    auto text = m_coreObject->textUnderElement(TextUnderElementMode(TextUnderElementMode::Children::IncludeAllChildren));
+    auto text = m_coreObject->textUnderElement(TextUnderElementMode{TextUnderElementMode::Children::IncludeAllChildren});
     if (auto* renderer = m_coreObject->renderer()) {
         if (is<RenderListItem>(*renderer) && downcast<RenderListItem>(*renderer).markerRenderer()) {
             if (renderer->style().direction() == TextDirection::LTR) {
@@ -316,7 +316,7 @@ unsigned AccessibilityObject::getLengthForTextRange() const
         textLength = downcast<RenderText>(*renderer).text().length();
 
     if (!textLength && allowsTextRanges())
-        textLength = textUnderElement(TextUnderElementMode(TextUnderElementMode::Children::IncludeAllChildren)).length();
+        textLength = textUnderElement(TextUnderElementMode{TextUnderElementMode::Children::IncludeAllChildren}).length();
 
     return textLength;
 }

--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
@@ -792,7 +792,7 @@ void GraphicsContextSkia::beginTransparencyLayer(CompositeOperator operation, Bl
         return;
 
     GraphicsContext::beginTransparencyLayer(operation, blendMode);
-    m_layerStateStack.append({ CompositeMode(operation, blendMode) });
+    m_layerStateStack.append({ CompositeMode{operation, blendMode} });
 
     SkPaint paint;
     paint.setBlendMode(toSkiaBlendMode(operation, blendMode));


### PR DESCRIPTION
Fixes build errors:

```
In file included from WebCore/DerivedSources/unified-sources/UnifiedSource-aba958d6-7.cpp:7:
../git/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp:319:39: error: no matching conversion for functional-style cast from 'WebCore::TextUnderElementMode::Children' to 'WebCore::TextUnderElementMode'          
        textLength = textUnderElement(TextUnderElementMode(TextUnderElementMode::Children::IncludeAllChildren)).length();
                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../git/Source/WebCore/accessibility/AXCoreObject.h:664:8: note: candidate constructor (the implicit copy constructor) not viable: no known conversion from 'WebCore::TextUnderElementMode::Children' to 'const WebCore::TextUnderElem\
entMode' for 1st argument
struct TextUnderElementMode {
       ^
../git/Source/WebCore/accessibility/AXCoreObject.h:664:8: note: candidate constructor (the implicit move constructor) not viable: no known conversion from 'WebCore::TextUnderElementMode::Children' to 'WebCore::TextUnderElementMod\
e' for 1st argument
../git/Source/WebCore/accessibility/AXCoreObject.h:664:8: note: candidate constructor (the implicit default constructor) not viable: requires 0 arguments, but 1 was provided
23 warnings and 2 errors generated.
```<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/cb1d40e3978e595651972f5b52b9353659001e47

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/79 "Built successfully") | [✅ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/11 "Passed tests") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/81 "Built successfully") | [✅ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/10/builds/13 "Passed tests") 
<!--EWS-Status-Bubble-End-->