### PR TITLE
[Modern Media Controls] remove window event listeners at deinitializa…

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/controls/media-controls.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/media-controls.js
@@ -234,4 +234,10 @@ class MediaControls extends LayoutNode
         this.element.removeEventListener("focusin", this);
         window.removeEventListener("dragstart", this, true);
     }
+
+    reenable()
+    {
+        this.element.addEventListener("focusin", this);
+        window.addEventListener("dragstart", this, true);
+    }
 }

--- a/Source/WebCore/Modules/modern-media-controls/media/media-controller.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/media-controller.js
@@ -293,6 +293,9 @@ class MediaController
     deinitialize()
     {
         this.shadowRoot.removeChild(this.container);
+        window.removeEventListener("keydown", this);
+        if (this.controls)
+            this.controls.disable();
         return true;
     }
 
@@ -303,6 +306,9 @@ class MediaController
         this.mediaWeakRef = new WeakRef(media);
         this.host = host;
         shadowRoot.appendChild(this.container);
+        window.addEventListener("keydown", this);
+        if (this.controls)
+            this.controls.reenable();
         return true;
     }
 


### PR DESCRIPTION
…tion

https://bugs.webkit.org/show_bug.cgi?id=280503

Reviewed by Ryan Reno.

DOMWindow keeps media controls object alive because of installed event listeners (see JSDOMWindow::visitAdditionalChildren). This results in extra memory usage undil DOMWindow cleared (on top level navigation).

Original patch by Eugene Mutavchi <Ievgen_Mutavchi@comcast.com>.

* Source/WebCore/Modules/modern-media-controls/controls/media-controls.js: (MediaControls.prototype.reenable):
* Source/WebCore/Modules/modern-media-controls/media/media-controller.js: (MediaController.prototype.deinitialize):
(MediaController.prototype.reinitialize):

Canonical link: https://commits.webkit.org/284440@main


cherry-picked from https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/73f49fdda1f6eeb39c516f5e5fb3e58f79769f9b
<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/ede3116b34f73439d07710351e9b31532882da04

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/89 "Built successfully") | [✅ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/18 "Passed tests") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/90 "Built successfully") | [✅ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/10/builds/21 "Passed tests") 
<!--EWS-Status-Bubble-End-->