### PR TITLE
[wpe-2.38][soup] RDKDEV-1120: close sessions on exit

### DIFF
--- a/Source/WebCore/platform/network/soup/SoupNetworkSession.cpp
+++ b/Source/WebCore/platform/network/soup/SoupNetworkSession.cpp
@@ -152,7 +152,10 @@ SoupNetworkSession::SoupNetworkSession(PAL::SessionID sessionID)
     setupLogger();
 }
 
-SoupNetworkSession::~SoupNetworkSession() = default;
+SoupNetworkSession::~SoupNetworkSession()
+{
+    soup_session_abort(m_soupSession.get());
+}
 
 void SoupNetworkSession::setupLogger()
 {


### PR DESCRIPTION
Proposed solution for [WPENetworkProcess crash issue](https://bugs.webkit.org/show_bug.cgi?id=290446)
 (also reported as [#1481](https://github.com/WebPlatformForEmbedded/WPEWebKit/issues/1481) )

Main idea is to close all active soup sessions before the lower layers start doing cleanup, sometimes causing access to resources that are already released.
<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/ead4a489bdeabdd4fc42bd9efe9143c1507533ee

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| [✅ 🛠 wpe-238-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/1/builds/75 "Built successfully") | [✅ 🧪 wpe-238-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/5/builds/39 "Passed tests") 
| [✅ 🛠 wpe-238-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/8/builds/74 "Built successfully") | [✅ 🧪 wpe-238-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/6/builds/49 "Passed tests") 
| | 
| | 
<!--EWS-Status-Bubble-End-->