### PR TITLE
[JSC] Opportunistically exclude environment variable from stack scann…

### DIFF
--- a/Source/WTF/wtf/StackBounds.cpp
+++ b/Source/WTF/wtf/StackBounds.cpp
@@ -132,7 +132,19 @@ StackBounds StackBounds::currentThreadStackBoundsInternal()
         // account for a guard page
         size -= static_cast<rlim_t>(sysconf(_SC_PAGESIZE));
         void* bound = static_cast<char*>(origin) - size;
-        return StackBounds { origin, bound };
+
+        static char** oldestEnviron = environ;
+
+        // In 32bit architecture, it is possible that environment variables are having a characters which looks like a pointer,
+        // and conservative GC will find it as a live pointer. We would like to avoid that to precisely exclude non user stack
+        // data region from this stack bounds. As the article (https://lwn.net/Articles/631631/) and the elf loader implementation
+        // explain how Linux main thread stack is organized, environment variables vector is placed on the stack, so we can exclude
+        // environment variables if we use `environ` global variable as a origin of the stack.
+        // But `setenv` / `putenv` may alter `environ` variable's content. So we record the oldest `environ` variable content, and use it.
+        StackBounds stackBounds { origin, bound };
+        if (stackBounds.contains(oldestEnviron))
+            stackBounds = { oldestEnviron, bound };
+        return stackBounds;
     }
 #endif
     return ret;


### PR DESCRIPTION
…ing on Linux

https://bugs.webkit.org/show_bug.cgi?id=289774
rdar://147017776

Reviewed by Justin Michaud.

As it is suggested in
https://webkit.slack.com/archives/CTV4FGWF4/p1737380355218399, we should leverage Linux's ELF loader's stack setup mechanism to exclude environment variables from the stack.

* Source/WTF/wtf/StackBounds.cpp: (WTF::StackBounds::currentThreadStackBoundsInternal):

Canonical link: https://commits.webkit.org/292171@main<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/5695a8a60033a74bb50537a1ab9a76a5069b2bcd

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| [✅ 🛠 wpe-238-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/1/builds/77 "Built successfully") | [✅ 🧪 wpe-238-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/5/builds/40 "Passed tests") 
| [✅ 🛠 wpe-238-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/8/builds/76 "Built successfully") | [✅ 🧪 wpe-238-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/6/builds/50 "Passed tests") 
| | 
| | 
<!--EWS-Status-Bubble-End-->