### PR TITLE
[2.38][GStreamerQuirks] Add isPlatformSupported() impl

### DIFF
--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkAmLogic.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkAmLogic.cpp
@@ -36,6 +36,11 @@ GStreamerQuirkAmLogic::GStreamerQuirkAmLogic()
     GST_DEBUG_CATEGORY_INIT(webkit_amlogic_quirks_debug, "webkitquirksamlogic", 0, "WebKit AmLogic Quirks");
 }
 
+bool GStreamerQuirkAmLogic::isPlatformSupported() const
+{
+    return adoptGRef(gst_element_factory_find("amlhalasink"));
+}
+
 GstElement* GStreamerQuirkAmLogic::createWebAudioSink()
 {
     // autoaudiosink changes child element state to READY internally in auto detection phase

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkAmLogic.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkAmLogic.h
@@ -30,6 +30,7 @@ class GStreamerQuirkAmLogic final : public GStreamerQuirk {
 public:
     GStreamerQuirkAmLogic();
     const ASCIILiteral identifier() const final { return "AmLogic"_s; }
+    bool isPlatformSupported() const final;
 
     GstElement* createWebAudioSink() final;
     void configureElement(GstElement*, const OptionSet<ElementRuntimeCharacteristics>&) final;

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcom.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcom.cpp
@@ -37,6 +37,11 @@ GStreamerQuirkBroadcom::GStreamerQuirkBroadcom()
     m_disallowedWebAudioDecoders = { "brcmaudfilter"_s };
 }
 
+bool GStreamerQuirkBroadcom::isPlatformSupported() const
+{
+    return adoptGRef(gst_element_factory_find("brcmaudiosink"));
+}
+
 void GStreamerQuirkBroadcom::configureElement(GstElement* element, const OptionSet<ElementRuntimeCharacteristics>& characteristics)
 {
     if (!g_strcmp0(G_OBJECT_TYPE_NAME(element), "Gstbrcmaudiosink"))

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcom.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcom.h
@@ -32,6 +32,7 @@ class GStreamerQuirkBroadcom final : public GStreamerQuirkBroadcomBase {
 public:
     GStreamerQuirkBroadcom();
     const ASCIILiteral identifier() const final { return "Broadcom"_s; }
+    bool isPlatformSupported() const final;
 
     void configureElement(GstElement*, const OptionSet<ElementRuntimeCharacteristics>&) final;
     std::optional<bool> isHardwareAccelerated(GstElementFactory*) final;

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkRealtek.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkRealtek.cpp
@@ -47,6 +47,11 @@ GStreamerQuirkRealtek::GStreamerQuirkRealtek()
     };
 }
 
+bool GStreamerQuirkRealtek::isPlatformSupported() const
+{
+    return adoptGRef(gst_element_factory_find("rtkaudiosink"));
+}
+
 GstElement* GStreamerQuirkRealtek::createWebAudioSink()
 {
     auto sink = makeGStreamerElement("rtkaudiosink", nullptr);

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkRealtek.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkRealtek.h
@@ -30,6 +30,7 @@ class GStreamerQuirkRealtek final : public GStreamerQuirk {
 public:
     GStreamerQuirkRealtek();
     const ASCIILiteral identifier() const final { return "Realtek"_s; }
+    bool isPlatformSupported() const final;
 
     GstElement* createWebAudioSink() final;
     void configureElement(GstElement*, const OptionSet<ElementRuntimeCharacteristics>&) final;

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.cpp
@@ -68,6 +68,15 @@ GStreamerQuirkRialto::GStreamerQuirkRialto()
     }
 }
 
+bool GStreamerQuirkRialto::isPlatformSupported() const
+{
+    auto sinkFactory = adoptGRef(gst_element_factory_find("rialtomsevideosink"));
+    if (!sinkFactory)
+        return false;
+    auto rank = gst_plugin_feature_get_rank(GST_PLUGIN_FEATURE(sinkFactory.get()));
+    return rank > GST_RANK_MARGINAL;
+}
+
 void GStreamerQuirkRialto::configureElement(GstElement* element, const OptionSet<ElementRuntimeCharacteristics>&)
 {
     if (!g_strcmp0(G_OBJECT_TYPE_NAME(G_OBJECT(element)), "GstURIDecodeBin3")) {

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.h
@@ -35,6 +35,7 @@ class GStreamerQuirkRialto final : public GStreamerQuirk {
 public:
     GStreamerQuirkRialto();
     const ASCIILiteral identifier() const final { return "Rialto"_s; }
+    bool isPlatformSupported() const final;
 
     void configureElement(GstElement*, const OptionSet<ElementRuntimeCharacteristics>&) final;
     GstElement* createAudioSink() final;

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.cpp
@@ -51,6 +51,11 @@ GStreamerQuirkWesteros::GStreamerQuirkWesteros()
     }
 }
 
+bool GStreamerQuirkWesteros::isPlatformSupported() const
+{
+    return adoptGRef(gst_element_factory_find("westerossink"));
+}
+
 void GStreamerQuirkWesteros::configureElement(GstElement* element, const OptionSet<ElementRuntimeCharacteristics>& characteristics)
 {
     if (!characteristics.contains(ElementRuntimeCharacteristics::IsMediaStream))

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.h
@@ -30,6 +30,7 @@ class GStreamerQuirkWesteros final : public GStreamerQuirk {
 public:
     GStreamerQuirkWesteros();
     const ASCIILiteral identifier() const final { return "Westeros"_s; }
+    bool isPlatformSupported() const final;
 
     void configureElement(GstElement*, const OptionSet<ElementRuntimeCharacteristics>&) final;
     std::optional<bool> isHardwareAccelerated(GstElementFactory*) final;

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp
@@ -96,7 +96,7 @@ GStreamerQuirksManager::GStreamerQuirksManager(bool isForTesting, bool loadQuirk
     GST_DEBUG("Attempting to parse requested quirks: %s", quirks.ascii().data());
     if (!quirks.isEmpty()) {
         if (WTF::equalLettersIgnoringASCIICase(quirks, "help"_s)) {
-            WTFLogAlways("Supported quirks for WEBKIT_GST_QUIRKS are: amlogic, broadcom, bcmnexus, openmax, realtek, westeros");
+            WTFLogAlways("Supported quirks for WEBKIT_GST_QUIRKS are: amlogic, broadcom, bcmnexus, openmax, realtek, rialto, westeros");
             return;
         }
 
@@ -145,7 +145,7 @@ GStreamerQuirksManager::GStreamerQuirksManager(bool isForTesting, bool loadQuirk
         return;
 
     if (WTF::equalLettersIgnoringASCIICase(holePunchQuirk, "help"_s)) {
-        WTFLogAlways("Supported quirks for WEBKIT_GST_HOLE_PUNCH_QUIRK are: fake, westeros, bcmnexus");
+        WTFLogAlways("Supported quirks for WEBKIT_GST_HOLE_PUNCH_QUIRK are: fake, bcmnexus, rialto, westeros");
         return;
     }
 


### PR DESCRIPTION
Implement the isPlatformSupported() function by verifying the availability of the required GStreamer elements. Amlogic, Broadcom, Realtek and Westeros<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/3751771f6ed8aaaa264aa9b5b61d339b067247ba

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| [✅ 🛠 wpe-238-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/1/builds/82 "Built successfully") | [✅ 🧪 wpe-238-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/5/builds/43 "Passed tests") 
| [✅ 🛠 wpe-238-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/8/builds/81 "Built successfully") | [  ~~🧪 wpe-238-arm32-layout~~](https://ews-wpe-rdk.igalia.com/#/builders/6/builds/53 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | 
| | 
<!--EWS-Status-Bubble-End-->