### PR TITLE
[2.46][CDMProxyThunder] Pass CAPS to decrypt function

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/eme/CDMProxyThunder.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/CDMProxyThunder.cpp
@@ -90,8 +90,7 @@ bool CDMProxyThunder::decrypt(CDMProxyThunder::DecryptionContext& input)
 
     GST_TRACE("decrypting");
     // Decrypt cipher.
-    OpenCDMError errorCode = opencdm_gstreamer_session_decrypt(session->get(), input.dataBuffer, input.subsamplesBuffer, input.numSubsamples,
-        input.ivBuffer, input.keyIDBuffer, 0);
+    OpenCDMError errorCode = opencdm_gstreamer_session_decrypt_buffer(session->get(), input.dataBuffer, input.caps.get());
     if (errorCode) {
         GST_ERROR("decryption failed, error code %X", errorCode);
         return false;

--- a/Source/WebCore/platform/graphics/gstreamer/eme/CDMProxyThunder.h
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/CDMProxyThunder.h
@@ -52,6 +52,7 @@ public:
         GstBuffer* ivBuffer;
         GstBuffer* dataBuffer;
         GstBuffer* subsamplesBuffer;
+        GRefPtr<GstCaps> caps;
         size_t numSubsamples;
         WeakPtr<CDMProxyDecryptionClient> cdmProxyDecryptionClient;
     };

--- a/Source/WebCore/platform/graphics/gstreamer/eme/WebKitThunderDecryptorGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/WebKitThunderDecryptorGStreamer.cpp
@@ -155,6 +155,13 @@ static bool decrypt(WebKitMediaCommonEncryptionDecrypt* decryptor, GstBuffer* iv
         return false;
     }
 
+    GRefPtr<GstPad> sinkpad = adoptGRef(gst_element_get_static_pad(reinterpret_cast<GstElement*>(self), "sink"));
+    GRefPtr<GstCaps> caps = adoptGRef(gst_pad_get_current_caps(sinkpad.get()));
+
+    GstStructure *capstruct = gst_caps_get_structure(caps.get(), 0);
+    const gchar* capsinfo = gst_structure_get_string(capstruct, "original-media-type");
+    GST_DEBUG_OBJECT(self, "CAPS %p - Stream Type = %s", caps.get(), capsinfo);
+
     CDMProxyThunder::DecryptionContext context = { };
     context.keyIDBuffer = keyIDBuffer;
     context.ivBuffer = ivBuffer;
@@ -162,6 +169,7 @@ static bool decrypt(WebKitMediaCommonEncryptionDecrypt* decryptor, GstBuffer* iv
     context.numSubsamples = subsampleCount;
     context.subsamplesBuffer = subsampleCount ? subsamplesBuffer : nullptr;
     context.cdmProxyDecryptionClient = webKitMediaCommonEncryptionDecryptGetCDMProxyDecryptionClient(decryptor);
+    context.caps = caps;
     bool result = priv->cdmProxy->decrypt(context);
 
     return result;


### PR DESCRIPTION
Use new version of decrypt function
  opencdm_gstreamer_session_decrypt_buffer()
to handle CAPS/stream properties

New API is available in all Thunder releases, R2, R3, R4 and newer:
OpenCDMError opencdm_gstreamer_session_decrypt_buffer(struct OpenCDMSession* session, GstBuffer* buffer, GstCaps* caps);
It takes all decryption info from protection meta structure attached to GstBuffer - pretty similar to what WebKitCommonEncryptionDecryptorGStreamer::transformInPlace() does.
I'm not sure if there is/or can be any other implementation of WebKit Decryptor interface other than Thunder, especially decrypt() function. But if thunder is the only one then most of transformInPlace() impl can be removed, parts to parse protection_meta as it is done inside opencdm_gstreamer_session_decrypt_buffer() now<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/30c7ea08ee34c063f6d76d33c40cd541cd0daf50

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [❌ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/99 "Hash 30c7ea08 for PR 1489 does not build (failure)") | [❌ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/99 "Hash 30c7ea08 for PR 1489 does not build (failure)") 
| [❌ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/100 "Hash 30c7ea08 for PR 1489 does not build (failure)") | [❌ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/100 "Hash 30c7ea08 for PR 1489 does not build (failure)") 
<!--EWS-Status-Bubble-End-->