### PR TITLE
[GST] Dynamic insertion of decryptor element

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
@@ -108,6 +108,10 @@ static RefPtr<MediaPlayerPrivateGStreamerMSE> webKitMediaSrcPlayer(WebKitMediaSr
 
 struct WebKitMediaSrcPadPrivate {
     ThreadSafeWeakPtr<Stream> stream;
+
+#if ENABLE(ENCRYPTED_MEDIA)
+    gulong decryptorProbeId;
+#endif
 };
 
 struct WebKitMediaSrcPad {
@@ -317,6 +321,203 @@ static void webKitMediaSrcConstructed(GObject* object)
     GST_OBJECT_FLAG_SET(object, GST_ELEMENT_FLAG_SOURCE);
 }
 
+#if ENABLE(ENCRYPTED_MEDIA)
+GstElement* createDecryptor(const char* requestedProtectionSystemUuid)
+{
+    GST_DEBUG("createDecryptor for %s", requestedProtectionSystemUuid);
+    GstElement* decryptor = nullptr;
+    GList* decryptors = gst_element_factory_list_get_elements(GST_ELEMENT_FACTORY_TYPE_DECRYPTOR, GST_RANK_MARGINAL);
+
+    // Prefer WebKit decryptors
+    decryptors = g_list_sort(decryptors, [](gconstpointer p1, gconstpointer p2) -> gint {
+        GstPluginFeature *f1, *f2;
+        const gchar* name;
+        f1 = (GstPluginFeature *) p1;
+        f2 = (GstPluginFeature *) p2;
+        if ((name = gst_plugin_feature_get_name(f1)) && g_str_has_prefix(name, "webkit"))
+            return -1;
+        if ((name = gst_plugin_feature_get_name(f2)) && g_str_has_prefix(name, "webkit"))
+            return 1;
+        return gst_plugin_feature_rank_compare_func(p1, p2);
+    });
+
+    for (GList* walk = decryptors; !decryptor && walk; walk = g_list_next(walk)) {
+        GstElementFactory* factory = reinterpret_cast<GstElementFactory*>(walk->data);
+
+        for (const GList* current = gst_element_factory_get_static_pad_templates(factory); current && !decryptor; current = g_list_next(current)) {
+            GstStaticPadTemplate* staticPadTemplate = static_cast<GstStaticPadTemplate*>(current->data);
+            GRefPtr<GstCaps> caps = adoptGRef(gst_static_pad_template_get_caps(staticPadTemplate));
+            unsigned length = gst_caps_get_size(caps.get());
+
+            GST_TRACE("factory %s caps has size %u", GST_OBJECT_NAME(factory), length);
+            for (unsigned i = 0; !decryptor && i < length; ++i) {
+                GstStructure* structure = gst_caps_get_structure(caps.get(), i);
+                GST_TRACE("checking structure %s", gst_structure_get_name(structure));
+                if (gst_structure_has_field_typed(structure, GST_PROTECTION_SYSTEM_ID_CAPS_FIELD, G_TYPE_STRING)) {
+                    const char* protectionSystemUuid = gst_structure_get_string(structure, GST_PROTECTION_SYSTEM_ID_CAPS_FIELD);
+                    GST_TRACE("structure %s has protection system %s", gst_structure_get_name(structure), protectionSystemUuid);
+                    if (!requestedProtectionSystemUuid || !g_ascii_strcasecmp(requestedProtectionSystemUuid, protectionSystemUuid)) {
+                        GST_DEBUG("found decryptor %s for %s", GST_OBJECT_NAME(factory), requestedProtectionSystemUuid);
+                        decryptor = gst_element_factory_create(factory, nullptr);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    gst_plugin_feature_list_free(decryptors);
+    GST_TRACE("returning decryptor %p", decryptor);
+    return decryptor;
+}
+
+bool attachPayloaderIfNeeded(WebKitMediaSrc* source, GstPad* srcPad, GstCaps* caps) {
+    // payloader is needed for video streams only
+    if (!WebCore::doCapsHaveType(caps, GST_VIDEO_CAPS_TYPE_PREFIX))
+        return true;
+
+    // svppay element is always inserted even for non encrypted caps
+    // to force secure memory video parser so we don't need to replace
+    // parser when encrypted samples arrive
+
+    GRefPtr<GstElementFactory> payloaderFactory = adoptGRef(gst_element_factory_find("svppay"));
+    if (!payloaderFactory)
+        return true;
+
+    GST_DEBUG("Try to create payloader for pad %s", GST_PAD_NAME(srcPad));
+    GRefPtr<GstElement> payloader = gst_element_factory_create(payloaderFactory.get(), nullptr);
+    if (!payloader)
+        return false;
+    GST_INFO("Attach payloader %s on pad %s for CAPS %" GST_PTR_FORMAT, GST_OBJECT_NAME(payloader.get()), GST_PAD_NAME(srcPad), caps);
+
+    // Parent bin is urisourcebin
+    GRefPtr<GstBin> parentBin = adoptGRef(GST_BIN(gst_element_get_parent(source)));
+    ASSERT(parentBin);
+    gst_bin_add(GST_BIN(parentBin.get()), payloader.get());
+    gst_element_sync_state_with_parent(payloader.get());
+
+    // Insert payloader between srcPad (src pad of WebKitMediaSource) and its peer pad (typefind)
+    GRefPtr<GstPad> peerPad = adoptGRef(gst_pad_get_peer(srcPad));
+    GRefPtr<GstPad> payloaderSinkPad = adoptGRef(gst_element_get_static_pad(payloader.get(), "sink"));
+    GRefPtr<GstPad> payloaderSrcPad = adoptGRef(gst_element_get_static_pad(payloader.get(), "src"));
+    ASSERT(peerPad);
+    ASSERT(payloaderSinkPad);
+    ASSERT(payloaderSrcPad);
+
+    // Don't check CAPS here becasue encrypted ones are not supported by svppay directly
+    // Decryptor element will be inserted in the pipeline if needed, before svppay element
+    GstPadLinkReturn rc;
+    if (!gst_pad_unlink(srcPad, peerPad.get()))
+        GST_ERROR("Failed to unlink '%s' src pad", GST_PAD_NAME(srcPad));
+    else if (GST_PAD_LINK_OK != (rc = gst_pad_link_full(srcPad, payloaderSinkPad.get(), GST_PAD_LINK_CHECK_NOTHING)))
+        GST_ERROR("Failed to link srcPad to payloaderSinkPad, rc = %d", rc);
+    else if (GST_PAD_LINK_OK != (rc = gst_pad_link_full(payloaderSrcPad.get(), peerPad.get(), GST_PAD_LINK_CHECK_NOTHING)))
+        GST_ERROR("Failed to link payloaderSrcPad to peerPad, rc = %d", rc);
+    return true;
+}
+
+typedef struct _DecryptorProbeData DecryptorProbeData;
+struct _DecryptorProbeData
+{
+    _DecryptorProbeData(WebKitMediaSrc* parent)
+        : parent(parent) {
+    }
+    ~_DecryptorProbeData() {
+        GST_DEBUG("Destroying Decryptor probe, decryptor=%p(attached: %s)",
+                  decryptor.get(), decryptorAttached ? "yes" : "no");
+    }
+    WebKitMediaSrc* parent { nullptr };
+    bool didTryCreatePayloader { false };
+    GRefPtr<GstElement> decryptor;
+    bool decryptorAttached { false };
+    bool didFail { false };
+    WTF_MAKE_NONCOPYABLE(_DecryptorProbeData);
+};
+
+GstPadProbeReturn onWebKitMediaSourcePadEvent(GstPad* srcPad, GstPadProbeInfo* info, gpointer data)
+{
+    if (!(GST_PAD_PROBE_INFO_TYPE (info) & GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM))
+        return GST_PAD_PROBE_OK;
+
+    GstEvent *event = GST_PAD_PROBE_INFO_EVENT (info);
+    if (GST_EVENT_TYPE (event) != GST_EVENT_CAPS)
+        return GST_PAD_PROBE_OK;
+
+    DecryptorProbeData* probData = reinterpret_cast<DecryptorProbeData*>(data);
+    if (probData->didFail)
+        return GST_PAD_PROBE_OK;
+
+    GstCaps* caps = nullptr;
+    gst_event_parse_caps(event, &caps);
+
+    if (!caps)
+        return GST_PAD_PROBE_OK;
+
+    if (!probData->didTryCreatePayloader) {
+        probData->didTryCreatePayloader = true;
+        attachPayloaderIfNeeded(probData->parent, srcPad, caps);
+    }
+
+    // Dynamically attach the decryptor to the pipeline for encrypted streams
+    // and remove it for unencrypted streams.
+    if (!probData->decryptorAttached && WebCore::areEncryptedCaps(caps)) {
+        if (!probData->decryptor) {
+            GstStructure* structure = gst_caps_get_structure(caps, 0);
+            probData->decryptor = createDecryptor(gst_structure_get_string(structure, "protection-system"));
+            if (!probData->decryptor) {
+                GST_ERROR("Failed to create decryptor");
+                probData->didFail = true;
+                return GST_PAD_PROBE_OK;
+            }
+            GST_DEBUG("Decryptor %s created for pad %s", GST_OBJECT_NAME(probData->decryptor.get()), GST_PAD_NAME(srcPad));
+
+            // Parent bin is urisourcebin
+            GRefPtr<GstBin> parentBin = adoptGRef(GST_BIN(gst_element_get_parent(probData->parent)));
+            ASSERT(parentBin);
+            gst_bin_add(parentBin.get(), probData->decryptor.get());
+        }
+
+        GST_INFO("Add decryptor %" GST_PTR_FORMAT " on pad: %s for encrypted CAPS=%" GST_PTR_FORMAT, probData->decryptor.get(), GST_PAD_NAME(srcPad), caps);
+        gst_element_sync_state_with_parent(probData->decryptor.get());
+        GRefPtr<GstPad> decryptorSinkPad = adoptGRef(gst_element_get_static_pad(probData->decryptor.get(), "sink"));
+        GRefPtr<GstPad> decryptorSrcPad = adoptGRef(gst_element_get_static_pad(probData->decryptor.get(), "src"));
+        GRefPtr<GstPad> peerPad = adoptGRef(gst_pad_get_peer(srcPad));
+        ASSERT(decryptorSinkPad);
+        ASSERT(decryptorSrcPad);
+        ASSERT(peerPad);
+
+        GstPadLinkReturn rc;
+        if (!gst_pad_unlink(srcPad, peerPad.get()))
+            GST_ERROR("Failed to unlink '%s' src pad", GST_PAD_NAME(srcPad));
+        else if (GST_PAD_LINK_OK != (rc = gst_pad_link(srcPad, decryptorSinkPad.get())))
+            GST_ERROR("Failed to link srcPad to decryptorSinkPad, rc = %d", rc);
+        else if (GST_PAD_LINK_OK != (rc = gst_pad_link(decryptorSrcPad.get(), peerPad.get())))
+            GST_ERROR("Failed to link decryptorSrcPad to peerPad, rc = %d", rc);
+        else {
+            probData->decryptorAttached = true;
+        }
+    } else if (probData->decryptorAttached && !WebCore::areEncryptedCaps(caps)) {
+        GST_INFO("Remove decryptor %" GST_PTR_FORMAT " on pad: %s for clear CAPS=%" GST_PTR_FORMAT, probData->decryptor.get() , GST_PAD_NAME(srcPad), caps);
+        ASSERT(probData->decryptor);
+
+        GRefPtr<GstPad> decryptorSinkPad = adoptGRef(gst_element_get_static_pad(probData->decryptor.get(), "sink"));
+        GRefPtr<GstPad> decryptorSrcPad = adoptGRef(gst_element_get_static_pad(probData->decryptor.get(), "src"));
+        GRefPtr<GstPad> peerPad = adoptGRef(gst_pad_get_peer(decryptorSrcPad.get()));
+        GstPadLinkReturn rc;
+
+        if (!gst_pad_unlink(decryptorSrcPad.get(), peerPad.get()))
+            GST_ERROR("Failed to unlink decryptorSrcPad");
+        else if (!gst_pad_unlink(srcPad, decryptorSinkPad.get()))
+            GST_ERROR("Failed to unlink decryptorSinkPad");
+        else if (GST_PAD_LINK_OK != (rc = gst_pad_link(srcPad, peerPad.get())))
+            GST_ERROR("Failed to link '%s' to peer pad, rc = %d", GST_PAD_NAME(srcPad), rc);
+
+        probData->decryptorAttached = false;
+    }
+
+    return GST_PAD_PROBE_OK;
+}
+#endif
+
 void webKitMediaSrcEmitStreams(WebKitMediaSrc* source, const Vector<RefPtr<MediaSourceTrackGStreamer>>& tracks)
 {
     ASSERT(isMainThread());
@@ -367,6 +568,12 @@ void webKitMediaSrcEmitStreams(WebKitMediaSrc* source, const Vector<RefPtr<Media
             if (state > GST_STATE_READY)
                 gst_pad_set_active(GST_PAD(stream->pad.get()), true);
         }
+#if ENABLE(ENCRYPTED_MEDIA)
+        WEBKIT_MEDIA_SRC_PAD(stream->pad.get())->priv->decryptorProbeId =
+            gst_pad_add_probe(stream->pad.get(), GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM,
+                    onWebKitMediaSourcePadEvent, new DecryptorProbeData(source),
+                    [](gpointer data) { delete static_cast<DecryptorProbeData*>(data); });
+#endif
         GST_DEBUG_OBJECT(source, "Adding pad '%s' for stream with id '%" PRIu64 "'", GST_OBJECT_NAME(stream->pad.get()), stream->track->id());
         gst_element_add_pad(GST_ELEMENT(source), GST_PAD(stream->pad.get()));
         gst_pad_remove_probe(GST_PAD(stream->pad.get()), blockId);
@@ -398,6 +605,9 @@ static void webKitMediaSrcTearDownStream(WebKitMediaSrc* source, TrackID id)
     if (source->priv->isStarted()) {
         WebKitMediaSrcPad* pad = WEBKIT_MEDIA_SRC_PAD(stream->pad.get());
         gst_element_remove_pad(GST_ELEMENT(source), GST_PAD(pad));
+#if ENABLE(ENCRYPTED_MEDIA)
+        gst_pad_remove_probe(stream->pad.get(), WEBKIT_MEDIA_SRC_PAD(stream->pad.get())->priv->decryptorProbeId);
+#endif
         pad->priv->stream = nullptr;
     }
     source->priv->streams.remove(id);


### PR DESCRIPTION
We have a use-case in one of our web apps where MSE encrypted playback is mixed with a clear one in single SourceBuffer. This is because of add-insertion where clear add is appended to the same SourceBuffer during encrypted video playback. As a result there is CAPS change in GST pipeline between encrypted and clear ones. 

There are two main cases:
1) Main content (encrypted) starts first and add starts later in time. In such case initial encrypted CAPS make parsebin to set up a pipeline with a decryptor element (thunder decrypt in our case). Switching to clear CAPS is not a big deal as the decryptor will enter passthrough mode and the playback will continue. Going back to encrypted makes CAPS switch again and the decryptor operates in regular mode.
2) Add playback (clear) starts first and the pipeline is prepared for clear playback only. Switching to encrypted in such case causes buffer push failure from source (webkit media src) with "not-negotiated" error. CAPS doesn't match. No decrypter is in the pipeline and parsebin/decodebin/playbin don't auto adjust to new CAPS.

We have a change to handle that, created when playback pipeline was using appsource element instead of webkit media src (2.22 or earlier)  where the decrypter is inserted dynamically into the playback pipeline based on caps from source element.
It's not the perfect solution but good enough to start discussion on how we can handle that, and if that's the valid use-case at all. 
There are two parts there:
1) Insert a decryptor when encrypted caps are detected
2) Always insert svppay payloader element to force secure video path on Amlogic device. Without that the pipeline will be set in regular memory so on encrypted caps we will have to replace more elements, for sure a parser element

Please let me know what you think on that?<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/202bd4eb8d05ee5c9cc878e80c0f478b6ef81f94

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/100 "Built successfully") | [❌ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/23 "Found 2 new test failures: media/encrypted-media/clearKey/clearKey-encrypted-webm-event-mse.html, media/encrypted-media/clearKey/clearKey-webm-video-playback-mse.html (failure)") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/101 "Built successfully") | [❌ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/10/builds/26 "Found 1 new test failure: media/encrypted-media/clearKey/clearKey-webm-video-playback-mse.html (failure)") 
<!--EWS-Status-Bubble-End-->