### PR TITLE
ThreadedCompositor: resize wayland surfaces at suspend painting

### DIFF
--- a/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.cpp
+++ b/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.cpp
@@ -169,6 +169,14 @@ void ThreadedCompositor::resume()
         m_scene->setActive(true);
         m_suspendToTransparentState = SuspendToTransparentState::None;
     });
+#if ENABLE(RESIZE_WAYLAND_SURFACES_ON_SUSPEND_PAINTING)
+    if (!m_nonCompositedWebGLEnabled) {
+        // need to resize the view on resume
+        Locker locker { m_attributes.lock };
+        m_attributes.needsResize = true;
+    }
+#endif
+
     m_compositingRunLoop->resume();
     m_compositingRunLoop->scheduleUpdate();
 }
@@ -281,9 +289,20 @@ void ThreadedCompositor::renderLayerTree()
     // GL viewport is updated separately, if necessary. This establishes sequencing where
     // everything inside the will-render and did-render scope is done for a constant-sized scene,
     // and similarly all GL operations are done inside that specific scope.
-
+#if !ENABLE(RESIZE_WAYLAND_SURFACES_ON_SUSPEND_PAINTING)
     if (needsResize)
         m_client.resize(viewportSize);
+#else
+    // since we got this far, we know m_nonCompositedWebGLEnabled is false, no need to check
+    if (needsResize && m_suspendToTransparentState != SuspendToTransparentState::Requested) {
+        m_client.resize(viewportSize);
+    } else if (m_suspendToTransparentState == SuspendToTransparentState::Requested) {
+        // resizing the surfaces, to conserve the memory; going too small (like 1x1) will not properly work
+        // on some platformns, so choosing 16x16 (should only take around 3*1kB in suspended, instead of eg. 3*8MB for HD)
+        constexpr IntSize suspendedSize(16, 16);
+        m_client.resize(suspendedSize);
+    }
+#endif
 
     m_client.willRenderFrame();
 
@@ -300,6 +319,21 @@ void ThreadedCompositor::renderLayerTree()
         m_suspendToTransparentState = SuspendToTransparentState::WaitingForFrameComplete;
 
     m_context->swapBuffers();
+
+#if ENABLE(RESIZE_WAYLAND_SURFACES_ON_SUSPEND_PAINTING)
+    // since we got this far, we know m_nonCompositedWebGLEnabled is false, no need to check
+    if (m_suspendToTransparentState == SuspendToTransparentState::WaitingForFrameComplete) {
+        /*  With triple buffering we normally have 3 screen buffers. The backing surfaces may only be really
+            resized when they're presented - so we need 3 buffer swaps to make sure all these surfaces
+            are resized to the requested suspendedSize, thus saving the memory in suspend
+            (one swapBuffers is already done above) */
+        for (int i=0; i<2; ++i) {
+            glClearColor(0, 0, 0, 0);
+            glClear(GL_COLOR_BUFFER_BIT);
+            m_context->swapBuffers();
+        }
+    }
+#endif
 
     if (m_scene->isActive())
         m_client.didRenderFrame();

--- a/Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.cpp
+++ b/Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.cpp
@@ -97,7 +97,7 @@ uint64_t AcceleratedSurfaceLibWPE::surfaceID() const
 void AcceleratedSurfaceLibWPE::clientResize(const IntSize& size)
 {
     ASSERT(m_backend);
-    wpe_renderer_backend_egl_target_resize(m_backend, std::max(1, m_size.width()), std::max(1, m_size.height()));
+    wpe_renderer_backend_egl_target_resize(m_backend, std::max(1, size.width()), std::max(1, size.height()));
 }
 
 void AcceleratedSurfaceLibWPE::willRenderFrame()

--- a/Source/cmake/OptionsWPE.cmake
+++ b/Source/cmake/OptionsWPE.cmake
@@ -107,6 +107,7 @@ WEBKIT_OPTION_DEFINE(USE_EXTERNAL_HOLEPUNCH "Whether to enable external holepunc
 WEBKIT_OPTION_DEFINE(ENABLE_ACCELERATED_2D_CANVAS "Whether to enable accelerated 2D canvas" PRIVATE OFF)
 WEBKIT_OPTION_DEFINE(ENABLE_OIPF_VK "Whether to enable OIPF keys for DAE applications" PRIVATE OFF)
 WEBKIT_OPTION_DEFINE(USE_LINUX_FTRACE "Whether to use ftrace based webkit tracing" PRIVATE OFF)
+WEBKIT_OPTION_DEFINE(ENABLE_RESIZE_WAYLAND_SURFACES_ON_SUSPEND_PAINTING "Whether to enable resizing of wayland surfaces when painting is suspended" PRIVATE OFF)
 
 # Supported platforms.
 WEBKIT_OPTION_DEFINE(USE_WPEWEBKIT_PLATFORM_WESTEROS "Whether to enable support for the Westeros platform" PUBLIC OFF)


### PR DESCRIPTION
Resize surfaces at suspendToTransparent - the aim is to save the memory allocated for swapchain surfaces when wpe is going invisible.

The problem addressed: in case when multiple wpe instances are running in parallel with one of them visible, all of them are still keeping their wayland swapchain surfaces in the memory. In typical case, there will be 3 buffers, so each instance keeps additional 24MB allocated (assuming HD, 8MB per full screen surface). This change allows to temporarily resize these surfaces down to 16x16, reducing the overhead to just around 3kB.

The logic (if enabled via ENABLE_RESIZE_WAYLAND_SURFACES_ON_SUSPEND_PAINTING cmake option, OFF by default) is activated eg. when glib api webkit_web_view_hide/webkit_web_view_show is invoked (through ThreadedCompositor::suspendToTransparent call in such case).

The change has been tested on LGI boxes, and checked on Sagecom rdk accelerator for regressions.<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/c82128a26f9fa761f76f38326cda3d548a9d9cc7

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| [✅ 🛠 wpe-238-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/1/builds/98 "Built successfully") | [✅ 🧪 wpe-238-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/5/builds/50 "Passed tests") 
| [✅ 🛠 wpe-238-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/8/builds/97 "Built successfully") | [✅ 🧪 wpe-238-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/6/builds/60 "Passed tests") 
| | 
| | 
<!--EWS-Status-Bubble-End-->