### PR TITLE
[SpeechSynthesis] Emit error event for all cancelled utterances

### DIFF
--- a/LayoutTests/fast/speechsynthesis/speech-synthesis-cancel-expected.txt
+++ b/LayoutTests/fast/speechsynthesis/speech-synthesis-cancel-expected.txt
@@ -7,6 +7,8 @@ Speech started
 PASS speechSynthesis.pending is true
 Speech error received because we cancelled and speech should no longer be pending.
 PASS speechSynthesis.pending is false
+Speech error received because we cancelled and speech should no longer be pending.
+Speech error received because we cancelled and speech should no longer be pending.
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/speechsynthesis/speech-synthesis-cancel.html
+++ b/LayoutTests/fast/speechsynthesis/speech-synthesis-cancel.html
@@ -27,7 +27,6 @@
     u.onerror = function(event) {
        debug("Speech error received because we cancelled and speech should no longer be pending.");
        shouldBeFalse("speechSynthesis.pending");
-       finishJSTest();
     }
 
     // Queue the first job which will start speaking immediately.
@@ -35,10 +34,17 @@
 
     // Make a few more jobs, so that when we cancel, it will clear the entire queue.
     var u2 = new SpeechSynthesisUtterance("this is a second test");
+    u2.onerror = function(event) {
+       debug("Speech error received because we cancelled and speech should no longer be pending.");
+    }
     speechSynthesis.speak(u2);
 
     // Make a few more jobs, so that when we cancel, it will clear the entire queue.
     var u3 = new SpeechSynthesisUtterance("this is a third test");
+    u3.onerror = function(event) {
+       debug("Speech error received because we cancelled and speech should no longer be pending.");
+       finishJSTest();
+    }
     speechSynthesis.speak(u3);
 
     // While we have two jobs, speech synthesis should report that it's pending.

--- a/Source/WebCore/Modules/speech/SpeechSynthesis.cpp
+++ b/Source/WebCore/Modules/speech/SpeechSynthesis.cpp
@@ -162,17 +162,24 @@ void SpeechSynthesis::cancel()
     // Remove all the items from the utterance queue.
     // Hold on to the current utterance so the platform synthesizer can have a chance to clean up.
     RefPtr<SpeechSynthesisUtterance> current = m_currentSpeechUtterance;
-    m_utteranceQueue.clear();
+    // Clear m_utteranceQueue before calling cancel to avoid picking up new utterances
+    // on completion callback
+    auto utteranceQueue = WTFMove(m_utteranceQueue);
     if (m_speechSynthesisClient) {
         m_speechSynthesisClient->cancel();
         // If we wait for cancel to callback speakingErrorOccurred, then m_currentSpeechUtterance will be null
         // and the event won't be processed. Instead we process the error immediately.
         speakingErrorOccurred(SpeechSynthesisErrorCode::Canceled);
         m_currentSpeechUtterance = nullptr;
-    } else if (m_platformSpeechSynthesizer) {
+    } else if (m_platformSpeechSynthesizer)
         m_platformSpeechSynthesizer->cancel();
-        // The platform should have called back immediately and cleared the current utterance.
-        ASSERT(!m_currentSpeechUtterance);
+
+    // Trigger canceled events for queued utterances
+    while (!utteranceQueue.isEmpty()) {
+        const auto utterance = utteranceQueue.takeFirst();
+        // Current utterance is handled in platform cancel()
+        if (current.get() != utterance.ptr())
+            utterance.get().errorEventOccurred(eventNames().errorEvent, SpeechSynthesisErrorCode::Canceled);
     }
     current = nullptr;
 }


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=290750

Reviewed by Sihui Liu.

Dispatch an error event "canceled" for queued utterances.

Specification: https://dvcs.w3.org/hg/speech-api/raw-file/tip/webspeechapi, point: 5.2.5.1.

Original author: Andrzej Surdej <Andrzej_Surdej@comcast.com>

See: https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1474

* LayoutTests/fast/speechsynthesis/speech-synthesis-cancel-expected.txt:
* LayoutTests/fast/speechsynthesis/speech-synthesis-cancel.html:
* Source/WebCore/Modules/speech/SpeechSynthesis.cpp: (WebCore::SpeechSynthesis::cancel):

Canonical link: https://commits.webkit.org/293536@main<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/7f93d70858b542ec631d2a185e42fe6581362bc0

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| [✅ 🛠 wpe-238-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/1/builds/91 "Built successfully") | [✅ 🧪 wpe-238-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/5/builds/47 "Passed tests") 
| [✅ 🛠 wpe-238-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/8/builds/90 "Built successfully") | [✅ 🧪 wpe-238-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/6/builds/57 "Passed tests") 
| | 
| | 
<!--EWS-Status-Bubble-End-->