### PR TITLE
[WebInspector] minimize the number of data kept in m_requestIdToResou…

### DIFF
--- a/Source/WTF/Scripts/Preferences/WebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferences.yaml
@@ -1021,6 +1021,19 @@ InspectorStartsAttached:
     WebKit:
       default: true
 
+InspectorSupportsShowingCertificate:
+  type: bool
+  status: embedder
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      "PLATFORM(COCOA) || PLATFORM(WIN)": true
+      default: false
+    WebCore:
+      "PLATFORM(COCOA) || PLATFORM(WIN)": true
+      default: false
+
 InspectorWindowFrame:
   type: String
   webcoreBinding: none

--- a/Source/WebCore/inspector/InspectorFrontendHost.cpp
+++ b/Source/WebCore/inspector/InspectorFrontendHost.cpp
@@ -634,11 +634,7 @@ void InspectorFrontendHost::setAllowsInspectingInspector(bool allow)
 
 bool InspectorFrontendHost::supportsShowCertificate() const
 {
-#if PLATFORM(COCOA)
-    return true;
-#else
-    return false;
-#endif
+    return m_frontendPage->settings().inspectorSupportsShowingCertificate();
 }
 
 bool InspectorFrontendHost::showCertificate(const String& serializedCertificate)

--- a/Source/WebCore/inspector/NetworkResourcesData.cpp
+++ b/Source/WebCore/inspector/NetworkResourcesData.cpp
@@ -40,8 +40,6 @@ namespace WebCore {
 
 using namespace Inspector;
 
-static const unsigned maximumSingleResourceContentSizeMB = 50; // 50MB
-
 NetworkResourcesData::ResourceData::ResourceData(const String& requestId, const String& loaderId)
     : m_requestId(requestId)
     , m_loaderId(loaderId)
@@ -76,6 +74,7 @@ unsigned NetworkResourcesData::ResourceData::removeContent()
 unsigned NetworkResourcesData::ResourceData::evictContent()
 {
     m_isContentEvicted = true;
+    setDecoder(nullptr);
     return removeContent();
 }
 
@@ -113,9 +112,8 @@ void NetworkResourcesData::ResourceData::decodeDataToContent()
     ASSERT(m_content.sizeInBytes() >= buffer->size());
 }
 
-NetworkResourcesData::NetworkResourcesData(uint32_t maximumResourcesContentSize)
-    : m_maximumResourcesContentSize(maximumResourcesContentSize * MB)
-    , m_maximumSingleResourceContentSize(maximumSingleResourceContentSizeMB * MB)
+NetworkResourcesData::NetworkResourcesData(const Settings& settings)
+    : m_settings(settings)
 {
 }
 
@@ -160,8 +158,10 @@ void NetworkResourcesData::responseReceived(const String& requestId, const Strin
     if (InspectorNetworkAgent::shouldTreatAsText(response.mimeType()))
         resourceData->setDecoder(InspectorNetworkAgent::createTextDecoder(response.mimeType(), response.textEncodingName()));
 
-    if (auto& certificateInfo = response.certificateInfo())
-        resourceData->setCertificateInfo(certificateInfo);
+    if (m_settings.supportsShowingCertificate) {
+        if (auto& certificateInfo = response.certificateInfo())
+            resourceData->setCertificateInfo(certificateInfo);
+    }
 }
 
 void NetworkResourcesData::setResourceType(const String& requestId, InspectorPageAgent::ResourceType type)
@@ -190,7 +190,7 @@ void NetworkResourcesData::setResourceContent(const String& requestId, const Str
         return;
 
     size_t dataLength = content.sizeInBytes();
-    if (dataLength > m_maximumSingleResourceContentSize)
+    if (dataLength > m_settings.maximumSingleResourceContentSize)
         return;
     if (resourceData->isContentEvicted())
         return;
@@ -229,7 +229,7 @@ NetworkResourcesData::ResourceData const* NetworkResourcesData::maybeAddResource
     if (!shouldBufferResourceData(*resourceData))
         return resourceData;
 
-    if (resourceData->dataLength() + data.size() > m_maximumSingleResourceContentSize)
+    if (resourceData->dataLength() + data.size() > m_settings.maximumSingleResourceContentSize)
         m_contentSize -= resourceData->evictContent();
     if (resourceData->isContentEvicted())
         return resourceData;
@@ -257,7 +257,7 @@ void NetworkResourcesData::maybeDecodeDataToContent(const String& requestId)
 
     resourceData->decodeDataToContent();
     byteCount = resourceData->content().sizeInBytes();
-    if (byteCount > m_maximumSingleResourceContentSize) {
+    if (byteCount > m_settings.maximumSingleResourceContentSize) {
         resourceData->evictContent();
         return;
     }
@@ -365,11 +365,11 @@ void NetworkResourcesData::ensureNoDataForRequestId(const String& requestId)
 
 bool NetworkResourcesData::ensureFreeSpace(size_t size)
 {
-    if (size > m_maximumResourcesContentSize)
+    if (size > m_settings.maximumResourcesContentSize)
         return false;
 
-    ASSERT(m_maximumResourcesContentSize >= m_contentSize);
-    while (size > m_maximumResourcesContentSize - m_contentSize) {
+    ASSERT(m_settings.maximumResourcesContentSize >= m_contentSize);
+    while (size > m_settings.maximumResourcesContentSize - m_contentSize) {
         String requestId = m_requestIdsDeque.takeFirst();
         ResourceData* resourceData = resourceDataForRequestId(requestId);
         if (resourceData)

--- a/Source/WebCore/inspector/NetworkResourcesData.h
+++ b/Source/WebCore/inspector/NetworkResourcesData.h
@@ -31,6 +31,7 @@
 
 #include "InspectorPageAgent.h"
 #include "SharedBuffer.h"
+#include "TextResourceDecoder.h"
 #include <wtf/ListHashSet.h>
 #include <wtf/RobinHoodHashMap.h>
 #include <wtf/WallTime.h>
@@ -40,7 +41,6 @@ namespace WebCore {
 
 class CachedResource;
 class ResourceResponse;
-class TextResourceDecoder;
 
 class NetworkResourcesData {
     WTF_MAKE_FAST_ALLOCATED;
@@ -132,7 +132,17 @@ public:
         WallTime m_responseTimestamp;
     };
 
-    NetworkResourcesData(uint32_t maximumResourcesContentSize);
+    struct Settings {
+        Settings(size_t maxResourcesContentSize, bool showingCertificate)
+            : maximumResourcesContentSize(maxResourcesContentSize * MB)
+            , supportsShowingCertificate(showingCertificate)
+        { }
+        size_t maximumResourcesContentSize;
+        size_t maximumSingleResourceContentSize { 50 * MB };
+        bool supportsShowingCertificate;
+    };
+
+    NetworkResourcesData(const Settings&);
     ~NetworkResourcesData();
 
     void resourceCreated(const String& requestId, const String& loaderId, InspectorPageAgent::ResourceType);
@@ -159,8 +169,7 @@ private:
     ListHashSet<String> m_requestIdsDeque;
     MemoryCompactRobinHoodHashMap<String, std::unique_ptr<ResourceData>> m_requestIdToResourceDataMap;
     size_t m_contentSize { 0 };
-    size_t m_maximumResourcesContentSize;
-    size_t m_maximumSingleResourceContentSize;
+    Settings m_settings;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
@@ -57,7 +57,6 @@
 #include "LoaderStrategy.h"
 #include "MIMETypeRegistry.h"
 #include "MemoryCache.h"
-#include "NetworkResourcesData.h"
 #include "Page.h"
 #include "PlatformStrategies.h"
 #include "ProgressTracker.h"
@@ -180,12 +179,12 @@ Ref<Protocol::Network::WebSocketFrame> buildWebSocketMessage(const WebSocketFram
 
 } // namespace
 
-InspectorNetworkAgent::InspectorNetworkAgent(WebAgentContext& context, uint32_t maximumResourcesContentSize)
+InspectorNetworkAgent::InspectorNetworkAgent(WebAgentContext& context, const NetworkResourcesData::Settings& networkResourcesDataSettings)
     : InspectorAgentBase("Network"_s, context)
     , m_frontendDispatcher(makeUnique<Inspector::NetworkFrontendDispatcher>(context.frontendRouter))
     , m_backendDispatcher(Inspector::NetworkBackendDispatcher::create(context.backendDispatcher, this))
     , m_injectedScriptManager(context.injectedScriptManager)
-    , m_resourcesData(makeUnique<NetworkResourcesData>(maximumResourcesContentSize))
+    , m_resourcesData(makeUnique<NetworkResourcesData>(networkResourcesDataSettings))
 {
 }
 

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.h
@@ -34,6 +34,7 @@
 #include "InspectorInstrumentation.h"
 #include "InspectorPageAgent.h"
 #include "InspectorWebAgentBase.h"
+#include "NetworkResourcesData.h"
 #include "WebSocket.h"
 #include <JavaScriptCore/InspectorBackendDispatchers.h>
 #include <JavaScriptCore/InspectorFrontendDispatchers.h>
@@ -137,7 +138,7 @@ public:
     void searchInRequest(Inspector::Protocol::ErrorString&, const Inspector::Protocol::Network::RequestId&, const String& query, bool caseSensitive, bool isRegex, RefPtr<JSON::ArrayOf<Inspector::Protocol::GenericTypes::SearchMatch>>&);
 
 protected:
-    InspectorNetworkAgent(WebAgentContext&, uint32_t);
+    InspectorNetworkAgent(WebAgentContext&, const NetworkResourcesData::Settings&);
 
     virtual Inspector::Protocol::Network::LoaderId loaderIdentifier(DocumentLoader*) = 0;
     virtual Inspector::Protocol::Network::FrameId frameIdentifier(DocumentLoader*) = 0;

--- a/Source/WebCore/inspector/agents/page/PageNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageNetworkAgent.cpp
@@ -42,7 +42,7 @@ namespace WebCore {
 using namespace Inspector;
 
 PageNetworkAgent::PageNetworkAgent(PageAgentContext& context, InspectorClient* client)
-    : InspectorNetworkAgent(context, context.inspectedPage.settings().inspectorMaximumResourcesContentSize())
+    : InspectorNetworkAgent(context, { context.inspectedPage.settings().inspectorMaximumResourcesContentSize(), context.inspectedPage.settings().inspectorSupportsShowingCertificate() })
     , m_inspectedPage(context.inspectedPage)
     , m_client(client)
 {

--- a/Source/WebCore/inspector/agents/worker/WorkerNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/worker/WorkerNetworkAgent.cpp
@@ -36,7 +36,7 @@ namespace WebCore {
 using namespace Inspector;
 
 WorkerNetworkAgent::WorkerNetworkAgent(WorkerAgentContext& context)
-    : InspectorNetworkAgent(context, context.globalScope.settingsValues().inspectorMaximumResourcesContentSize)
+    : InspectorNetworkAgent(context, { context.globalScope.settingsValues().inspectorMaximumResourcesContentSize, context.globalScope.settingsValues().inspectorSupportsShowingCertificate })
     , m_globalScope(context.globalScope)
 {
     ASSERT(context.globalScope.isContextThread());


### PR DESCRIPTION
…rceDataMap after content eviction

https://bugs.webkit.org/show_bug.cgi?id=290161

Reviewed by Devin Rousso.

After eviction of the content of the resource data due to exceeding the threshold for maximum memory usage for gathered resources, WebKit still keeps the structure of resource data in `m_requestIdToResourceDataMap` because it is the primary structure used to track all other metadata used by Web Inspector.
We can minimize the data kept there after eviction by resetting the decoder which is not needed if we remove the content of resource data.

Additionally in case of platforms different than Cocoa we can skip storing the certificate info because it is not used. The certificate info is used only if supportsShowCertificate(), which is true only in case of Cocoa platform.

This change adds a web preference `InspectorSupportsShowingCertificate` which is true only in case of Cocoa and Win platform and enabling storing of the certificate info for resource data in Web Inspector.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/inspector/InspectorFrontendHost.cpp: (WebCore::InspectorFrontendHost::supportsShowCertificate const):
* Source/WebCore/inspector/NetworkResourcesData.cpp: (WebCore::NetworkResourcesData::ResourceData::evictContent): (WebCore::NetworkResourcesData::NetworkResourcesData): (WebCore::NetworkResourcesData::responseReceived): (WebCore::NetworkResourcesData::setResourceContent): (WebCore::NetworkResourcesData::maybeAddResourceData): (WebCore::NetworkResourcesData::maybeDecodeDataToContent): (WebCore::NetworkResourcesData::ensureFreeSpace):
* Source/WebCore/inspector/NetworkResourcesData.h: (WebCore::NetworkResourcesData::Settings::Settings):
* Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp: (WebCore::InspectorNetworkAgent::InspectorNetworkAgent):
* Source/WebCore/inspector/agents/InspectorNetworkAgent.h:
* Source/WebCore/inspector/agents/page/PageNetworkAgent.cpp: (WebCore::PageNetworkAgent::PageNetworkAgent):
* Source/WebCore/inspector/agents/worker/WorkerNetworkAgent.cpp: (WebCore::WorkerNetworkAgent::WorkerNetworkAgent):

Canonical link: https://commits.webkit.org/293535@main<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/dbad0ee00246aca6790e6f6339ca72b580c9c7a6

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| [✅ 🛠 wpe-238-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/1/builds/88 "Built successfully") | [✅ 🧪 wpe-238-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/5/builds/46 "Passed tests") 
| [✅ 🛠 wpe-238-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/8/builds/87 "Built successfully") | [✅ 🧪 wpe-238-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/6/builds/56 "Passed tests") 
| | 
| | 
<!--EWS-Status-Bubble-End-->