### PR TITLE
[SOUP] WPENetworkProcess crashed on process exit

### DIFF
--- a/Source/WebCore/platform/network/soup/SoupNetworkSession.cpp
+++ b/Source/WebCore/platform/network/soup/SoupNetworkSession.cpp
@@ -152,7 +152,10 @@ SoupNetworkSession::SoupNetworkSession(PAL::SessionID sessionID)
     setupLogger();
 }
 
-SoupNetworkSession::~SoupNetworkSession() = default;
+SoupNetworkSession::~SoupNetworkSession()
+{
+    soup_session_abort(m_soupSession.get());
+}
 
 void SoupNetworkSession::setupLogger()
 {


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=290446

Reviewed by Michael Catanzaro.

To cancel all pending requests before network process exits, we have to abort the current soup session. This will cancell all pending cancellable task in glib-network backends (e.g.: OpenSSL, GnuTLS).

Original author: Volodymyr Ogorodnik()
See: https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1482

* Source/WebCore/platform/network/soup/SoupNetworkSession.cpp: (WebCore::SoupNetworkSession::~SoupNetworkSession):

Canonical link: https://commits.webkit.org/294000@main<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/78f5d8948a0d956c78f1422fa77c99ff2621fda8

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| [✅ 🛠 wpe-238-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/1/builds/95 "Built successfully") | [✅ 🧪 wpe-238-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/5/builds/49 "Passed tests") 
| [✅ 🛠 wpe-238-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/8/builds/94 "Built successfully") | [✅ 🧪 wpe-238-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/6/builds/59 "Passed tests") 
| | 
| | 
<!--EWS-Status-Bubble-End-->