### PR TITLE
[SOUP] WPENetworkProcess crashed on process exit

### DIFF
--- a/Source/WebCore/platform/network/soup/SoupNetworkSession.cpp
+++ b/Source/WebCore/platform/network/soup/SoupNetworkSession.cpp
@@ -139,7 +139,10 @@ SoupNetworkSession::SoupNetworkSession(PAL::SessionID sessionID)
     setupLogger();
 }
 
-SoupNetworkSession::~SoupNetworkSession() = default;
+SoupNetworkSession::~SoupNetworkSession()
+{
+    soup_session_abort(m_soupSession.get());
+}
 
 void SoupNetworkSession::setupLogger()
 {


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=290446

Reviewed by Michael Catanzaro.

To cancel all pending requests before network process exits, we have to abort the current soup session. This will cancell all pending cancellable task in glib-network backends (e.g.: OpenSSL, GnuTLS).

Original author: Volodymyr Ogorodnik()
See: https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1482

* Source/WebCore/platform/network/soup/SoupNetworkSession.cpp: (WebCore::SoupNetworkSession::~SoupNetworkSession):

Canonical link: https://commits.webkit.org/294000@main<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/4b08a8c0bf17648e5e17558ef58b01dcddfa7aa8

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/111 "Built successfully") | [✅ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/27 "Passed tests") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/112 "Built successfully") | [✅ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/10/builds/31 "Passed tests") 
<!--EWS-Status-Bubble-End-->