### PR TITLE
[2.46] Fix hole punch without video sink (crash)

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -4829,7 +4829,7 @@ void MediaPlayerPrivateGStreamer::setPageIsVisible(bool visible)
     if (m_visible == visible)
         return;
 
-    if (!isHolePunchRenderingEnabled()) {
+    if (!isHolePunchRenderingEnabled() || !m_videoSink) {
         m_visible = visible;
         return;
     }
@@ -4853,7 +4853,7 @@ void MediaPlayerPrivateGStreamer::setPageIsSuspended(bool suspended)
     if (m_suspended == suspended)
         return;
 
-    if (!isHolePunchRenderingEnabled()) {
+    if (!isHolePunchRenderingEnabled() || !m_videoSink) {
         m_suspended = suspended;
         return;
     }


### PR DESCRIPTION
When hiding a page playing audio only (no video sink), the nullptr video sink gets de-referenced when trying to set the hole punch video rectangle in the quirks handler<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/4e2206ce571a2e995bf2f5e2093f3763f4fd6f15

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/112 "Built successfully") | [✅ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/28 "Passed tests") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/113 "Built successfully") | [✅ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/10/builds/32 "Passed tests") 
<!--EWS-Status-Bubble-End-->