### PR TITLE
wpe-2.46 - Workaround bmalloc hang with RT thread priorities.

### DIFF
--- a/Source/bmalloc/bmalloc/Mutex.cpp
+++ b/Source/bmalloc/bmalloc/Mutex.cpp
@@ -31,6 +31,7 @@
 #include <mach/mach_traps.h>
 #include <mach/thread_switch.h>
 #endif
+#include <cstring>
 #include <thread>
 #include <unistd.h>
 
@@ -46,7 +47,7 @@ static inline void yield()
     static std::once_flag onceFlag;
     std::call_once(onceFlag, [] {
         const char* env = getenv("WEBKIT_WPE_BMALLOC_MICROSECONDS_SLEEP");
-        if (env) {
+        if (env && env[strnlen(env, 5)] == '\0') {
             int value;
             if (sscanf(env, "%d", &value) == 1 && value > 0)
                 bmallocMicrosecondsSleep = value;


### PR DESCRIPTION
Cherry-picked from wpe-2.38 branch. Original PR https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1435<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/b02a056257efafa84cd7ababc9698720fa98fe71

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/115 "Built successfully") | [✅ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/29 "Passed tests") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/116 "Built successfully") | [✅ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/10/builds/33 "Passed tests") 
<!--EWS-Status-Bubble-End-->