### PR TITLE
GLContextEGL: Ensure EGL context is bound before destruction

### DIFF
--- a/Source/WebCore/platform/graphics/egl/GLContext.cpp
+++ b/Source/WebCore/platform/graphics/egl/GLContext.cpp
@@ -378,6 +378,7 @@ GLContext::~GLContext()
 {
     EGLDisplay display = m_display.eglDisplay();
     if (m_context) {
+        makeContextCurrent();
         glBindFramebuffer(GL_FRAMEBUFFER, 0);
         eglMakeCurrent(display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
         eglDestroyContext(display, m_context);


### PR DESCRIPTION
This change addresses a crash occurring during WebKit shutdown, where a call to glBindFramebuffer was made without EGL context bound.

Stack trace:
```
#0  __libc_do_syscall () at ../sysdeps/unix/sysv/linux/arm/libc-do-syscall.S:47
#1  0xb0e0e300 in __pthread_kill_implementation (threadid=<optimized out>, signo=6, no_tid=<optimized out>) at pthread_kill.c:43
#2  0xb0ddfbb6 in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
#3  0xb0dd15d4 in __GI_abort () at abort.c:79
#4  0xae723eaa in epoxy_load_gl () at ../libepoxy-1.5.9/src/dispatch_common.c:703
#5  epoxy_gl_dlsym (name=0xae7358d7 <entrypoint_strings+25867> "glGetString") at ../libepoxy-1.5.9/src/dispatch_common.c:712
#6  0xae6dcb66 in gl_single_resolver (provider=provider@entry=PROVIDER_always_present, entrypoint_offset=<optimized out>, entrypoint_offset@entry=25867) at src/gl_generated_dispatch.c:75810
#7  0xae6e82de in epoxy_glGetString_resolver () at src/gl_generated_dispatch.c:89821
#8  epoxy_glGetString_global_rewrite_ptr (name=7938) at src/gl_generated_dispatch.c:115690
#9  0xae723cae in epoxy_is_desktop_gl () at ../libepoxy-1.5.9/src/dispatch_common.c:397
#10 0xae6d9508 in gl_provider_resolver (name=0xae72f949 <entrypoint_strings+1405> "glBindFramebuffer", providers=0xae727008 <providers>, entrypoints=0xae726ff8 <entrypoints>) at src/gl_generated_dispatch.c:74162
#11 0xae6fd484 in epoxy_glBindFramebuffer_resolver () at src/gl_generated_dispatch.c:76680
#12 epoxy_glBindFramebuffer_global_rewrite_ptr (target=36160, framebuffer=0) at src/gl_generated_dispatch.c:114585
#13 0xb2a643da in WebCore::PlatformDisplay::PlatformDisplay(std::unique_ptr<WebCore::GLDisplay, std::default_delete<WebCore::GLDisplay> >&&)::{lambda()#1}::_FUN() [clone .lto_priv.0] ()
    at ../git/Source/WebCore/platform/graphics/egl/GLContext.cpp:381
#14 0xb0de13c2 in __run_exit_handlers (status=0, listp=0xb0ebf384 <__exit_funcs>, run_list_atexit=run_list_atexit@entry=true, run_dtors=run_dtors@entry=true) at exit.c:113
#15 0xb0de14ce in __GI_exit (status=<optimized out>) at exit.c:143
#16 0xb0dd17ca in __libc_start_call_main (main=0x104f1, main@entry=0xb0ebee5c, argc=4, argc@entry=4212720, argv=0xbbfd5684, argv@entry=0xb0ec0770 <__exit_funcs_lock>) at ../sysdeps/nptl/libc_start_call_main.h:74
#17 0xb0dd1870 in __libc_start_main_impl (main=0xb0ebee5c, argc=4212720, argv=0xb0ec0770 <__exit_funcs_lock>, init=<optimized out>, fini=0x0, rtld_fini=0xb3f23891 <_dl_fini>, stack_end=0xbbfd5684) at libc-start.c:389
#18 0x0001051c in ?? ()
```

The exact place of the crash is ~GLContext() destructor of m_sharingGLContext. At the time of calling glBindFramebuffer(), current EGL context is empty (eglGetCurrentContext() results with nullptr).
In case of non-composited webgl the context was cleard from webgl ANGLE context destructor.
In case of regular configuration, egl context is cleared from compositor GL context destruction<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/f5a5ded4887d7cb08cf11f08668c3684f93e18cc

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [❌ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/116 "Failed to checkout and rebase branch from PR 1502") | [❌ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/116 "Failed to checkout and rebase branch from PR 1502") 
| [❌ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/117 "Failed to checkout and rebase branch from PR 1502") | [❌ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/117 "Failed to checkout and rebase branch from PR 1502") 
<!--EWS-Status-Bubble-End-->