### PR TITLE
watchOS arm64_32 build broken due to ThreadSafeRefCounted layout

### DIFF
--- a/Source/WTF/wtf/RefCounted.cpp
+++ b/Source/WTF/wtf/RefCounted.cpp
@@ -21,8 +21,12 @@
 #include "config.h"
 #include <wtf/RefCounted.h>
 
+#include <wtf/ThreadSafeRefCounted.h>
+
 namespace WTF {
 
 bool RefCountedBase::areThreadingChecksEnabledGlobally { false };
+
+static_assert(sizeof(RefCountedBase) == sizeof(ThreadSafeRefCountedBase));
 
 }

--- a/Source/WTF/wtf/ThreadSafeRefCounted.h
+++ b/Source/WTF/wtf/ThreadSafeRefCounted.h
@@ -107,6 +107,12 @@ protected:
 private:
     mutable std::atomic<unsigned> m_refCount { 1 };
 
+#if ASSERT_ENABLED
+    // Match the layout of RefCounted, which has flag bits for threading checks.
+    UNUSED_MEMBER_VARIABLE bool m_unused1;
+    UNUSED_MEMBER_VARIABLE bool m_unused2;
+#endif
+
 #if CHECK_THREAD_SAFE_REF_COUNTED_LIFECYCLE
     bool deletionHasEnded() const;
 
@@ -116,6 +122,8 @@ private:
         Yes = 0xFEEDB0BA
     };
     mutable std::atomic<IsAllocatedMemory> m_isAllocatedMemory { IsAllocatedMemory::Yes };
+    // Match the layout of RefCounted.
+    UNUSED_MEMBER_VARIABLE bool m_unused3;
 #endif
 };
 


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=279227
rdar://problem/135371304

Reviewed by Alex Christensen.

With assertions enabled, WTF::RefCounted has m_isOwnedByMainThread, m_areThreadingChecksEnabled, and m_adoptionIsRequired boolean fields which implement runtime assertion checks. On platforms with 8-byte pointers, these are packed in to the object without affecting the overall size of the class, but on arm64_32 they make it a byte larger. This causes a GeneratedSerializers.mm assertion which compares the sizes of WTF::ThreadSafeRefCounted and WTF::RefCounted to fail:

    error: static assertion failed due to requirement 'sizeof(ShouldBeSameSizeAsThreadSafeDataBufferImpl) == sizeof(WebCore::ThreadSafeDataBufferImpl)'
     31638 |     static_assert(sizeof(ShouldBeSameSizeAsThreadSafeDataBufferImpl) == sizeof(WebCore::ThreadSafeDataBufferImpl));
    GeneratedSerializers.mm:31638:70: note: expression evaluates to '28 == 24'
     31638 |     static_assert(sizeof(ShouldBeSameSizeAsThreadSafeDataBufferImpl) == sizeof(WebCore::ThreadSafeDataBufferImpl));

To fix this without teaching IPC serializers about the different implementations of refcounting, pad ThreadSafeRefCounted with the same bool fields to get the expected layout.

* Source/WTF/wtf/Compiler.h: Add UNUSED_MEMBER_VARIABLE (unlike WK_UNUSED_INSTANCE_VARIABLE, it it not disabled in some API/SPI headers)
* Source/WTF/wtf/RefCounted.cpp:
* Source/WTF/wtf/ThreadSafeRefCounted.h:

Canonical link: https://commits.webkit.org/283247@main

<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/4e8cc17d323d3bee780483419abc3566a8b10178

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/117 "Built successfully") | [✅ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/30 "Passed tests") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/118 "Built successfully") | [✅ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/10/builds/34 "Passed tests") 
<!--EWS-Status-Bubble-End-->