### PR TITLE
[wpe-2.46] Don't upgrade mixed content when insecure content is allowed

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
@@ -4610,6 +4610,11 @@ void webkit_settings_set_allow_running_of_insecure_content(WebKitSettings* setti
         return;
 
     priv->preferences->setAllowRunningOfInsecureContent(allowed);
+
+    // If we are allowed to run insecure content, then upgrade mixed content should not be performed
+    if (allowed)
+        priv->preferences->setUpgradeMixedContentEnabled(false);
+
     g_object_notify_by_pspec(G_OBJECT(settings), sObjProperties[PROP_ALLOW_RUNNING_OF_INSECURE_CONTENT]);
 }
 
@@ -4645,6 +4650,11 @@ void webkit_settings_set_allow_display_of_insecure_content(WebKitSettings* setti
         return;
 
     priv->preferences->setAllowDisplayOfInsecureContent(allowed);
+
+    // If we are allowed to display insecure content, then upgrade mixed content should not be performed
+    if (allowed)
+        priv->preferences->setUpgradeMixedContentEnabled(false);
+
     g_object_notify_by_pspec(G_OBJECT(settings), sObjProperties[PROP_ALLOW_DISPLAY_OF_INSECURE_CONTENT]);
 }
 


### PR DESCRIPTION
When access to insecure content has been allowed via calls to "webkit_settings_set_allow_display_of_insecure_content" / "webkit_settings_set_allow_running_of_insecure_content", having the mixed content upgrade setting enabled causes a conflict and does not actually allow the access to insecure content. To avoid this, we need to either disable the upgrade when insecure content is allowed, or adjust all points where the upgrade of mixed content setting is checked to make it compatible with the insecure content allowed setting.
The critical sequence is: checkInsecureContent() -> shouldBlockRequestForDisplayableContent() -> shouldBlockInsecureContent()