### PR TITLE
Support whitelisting URLs for security origin universal access

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -7295,6 +7295,17 @@ UpgradeMixedContentEnabled:
     WebCore:
       default: true
 
+UrlsWithUniversalAccess:
+  type: String
+  status: embedder
+  defaultValue:
+    WebKitLegacy:
+      default: '""_str'
+    WebKit:
+      default: '""_str'
+    WebCore:
+      default: '""_str'
+
 UseARKitForModel:
   type: bool
   status: internal

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -7532,6 +7532,8 @@ void Document::initSecurityContext()
         // Web security is turned off. We should let this document access every other document. This is used primary by testing
         // harnesses for web sites.
         securityOrigin().grantUniversalAccess();
+    } else if (settings().urlsWithUniversalAccess().contains(m_url.url().string())) {
+        securityOrigin().grantUniversalAccess();
     } else if (securityOrigin().isLocal()) {
         if (settings().allowUniversalAccessFromFileURLs() || m_frame->loader().client().shouldForceUniversalAccessFromLocalURL(m_url)) {
             // Some clients want local URLs to have universal access, but that setting is dangerous for other clients.

--- a/Source/WebKit/Shared/WebPageCreationParameters.h
+++ b/Source/WebKit/Shared/WebPageCreationParameters.h
@@ -273,6 +273,7 @@ struct WebPageCreationParameters {
 
     String overriddenMediaType;
     Vector<String> corsDisablingPatterns;
+    Vector<String> localUniversalAccessAllowList;
     HashSet<String> maskedURLSchemes;
     bool userScriptsShouldWaitUntilNotification { true };
     bool loadsSubresources { true };

--- a/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
@@ -197,6 +197,7 @@ enum class WebCore::UserInterfaceLayoutDirection : bool;
 
     String overriddenMediaType;
     Vector<String> corsDisablingPatterns;
+    Vector<String> localUniversalAccessAllowList;
     HashSet<String> maskedURLSchemes;
     bool userScriptsShouldWaitUntilNotification;
     bool loadsSubresources;

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.h
@@ -533,6 +533,7 @@ private:
 
         HashMap<WTF::String, Ref<WebKit::WebURLSchemeHandler>> urlSchemeHandlers;
         Vector<WTF::String> corsDisablingPatterns;
+        Vector<WTF::String> localUniversalAccessAllowList;
         HashSet<WTF::String> maskedURLSchemes;
         bool maskedURLSchemesWasSet { false };
         bool userScriptsShouldWaitUntilNotification { true };

--- a/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
@@ -74,6 +74,7 @@ struct _WebKitSettingsPrivate {
 #if ENABLE(WEB_RTC)
         webrtcUDPPortsRange = preferences->webRTCUDPPortRange().utf8();
 #endif
+        urlsWithUniversalAccess = preferences->urlsWithUniversalAccess().utf8();
     }
 
     RefPtr<WebPreferences> preferences;
@@ -90,6 +91,7 @@ struct _WebKitSettingsPrivate {
 #if ENABLE(WEB_RTC)
     CString webrtcUDPPortsRange;
 #endif
+    CString urlsWithUniversalAccess;
     bool allowModalDialogs { false };
     bool zoomTextOnly { false };
 #if PLATFORM(GTK)
@@ -198,6 +200,7 @@ enum {
     PROP_WEBRTC_UDP_PORTS_RANGE,
     PROP_ENABLE_NON_COMPOSITED_WEBGL,
     PROP_SCREEN_SUPPORTS_HDR,
+    PROP_URLS_WITH_UNIVERSAL_ACCESS,
     N_PROPERTIES,
 };
 
@@ -402,6 +405,9 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         break;
     case PROP_ALLOW_UNIVERSAL_ACCESS_FROM_FILE_URLS:
         webkit_settings_set_allow_universal_access_from_file_urls(settings, g_value_get_boolean(value));
+        break;
+    case PROP_URLS_WITH_UNIVERSAL_ACCESS:
+        webkit_settings_set_urls_with_universal_access(settings, g_value_get_string(value));
         break;
     case PROP_ALLOW_TOP_NAVIGATION_TO_DATA_URLS:
         webkit_settings_set_allow_top_navigation_to_data_urls(settings, g_value_get_boolean(value));
@@ -643,6 +649,9 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         break;
     case PROP_ALLOW_UNIVERSAL_ACCESS_FROM_FILE_URLS:
         g_value_set_boolean(value, webkit_settings_get_allow_universal_access_from_file_urls(settings));
+        break;
+    case PROP_URLS_WITH_UNIVERSAL_ACCESS:
+        g_value_set_string(value, webkit_settings_get_urls_with_universal_access(settings));
         break;
     case PROP_ALLOW_TOP_NAVIGATION_TO_DATA_URLS:
         g_value_set_boolean(value, webkit_settings_get_allow_top_navigation_to_data_urls(settings));
@@ -1603,6 +1612,21 @@ static void webkit_settings_class_init(WebKitSettingsClass* klass)
             _("Allow universal access from the context of file scheme URLs"),
             _("Whether or not universal access is allowed from the context of file scheme URLs"),
             FEATURE_DEFAULT(AllowUniversalAccessFromFileURLs),
+            readWriteConstructParamFlags);
+
+    /**
+     * WebKitSettings:urls-with-universal-access:
+     *
+     * Comma-separated string with URLs that have universal access
+     *
+     * Since: 2.46
+     */
+    sObjProperties[PROP_URLS_WITH_UNIVERSAL_ACCESS] =
+        g_param_spec_string(
+            "urls-with-universal-access",
+            _("Allow universal access from the context of the URLs in the provided list"),
+            _("Whether or not universal access is allowed from the context of the URL in the provided list"),
+            nullptr,
             readWriteConstructParamFlags);
 
     /**
@@ -3972,6 +3996,45 @@ void webkit_settings_set_allow_universal_access_from_file_urls(WebKitSettings* s
 
     priv->preferences->setAllowUniversalAccessFromFileURLs(allowed);
     g_object_notify_by_pspec(G_OBJECT(settings), sObjProperties[PROP_ALLOW_UNIVERSAL_ACCESS_FROM_FILE_URLS]);
+}
+
+/**
+ * webkit_settings_get_urls_with_universal_access:
+ * @settings: a #WebKitSettings
+ * @url: Comma separated list with URLs that shall have universal access
+ *
+ * Get the #WebKitSettings:urls-with-universal-access property.
+ *
+ * Returns: String with comma-separated URLs that shall have universal access
+ *
+ * Since: 2.46
+ */
+const gchar* webkit_settings_get_urls_with_universal_access(WebKitSettings *settings)
+{
+    g_return_val_if_fail(WEBKIT_IS_SETTINGS(settings), nullptr);
+
+    return settings->priv->urlsWithUniversalAccess.data();
+}
+
+/**
+ * webkit_settings_set_urls_with_universal_access:
+ * @settings: a #WebKitSettings
+ * @urls: String with comma-separated URLs that shall have universal access. E.g.
+ *        "file:///var/www/index.html,file:///var/www/error.html"
+ *
+ * Set the #WebKitSettings:urls-with-universal-access property.
+ *
+ * Since: 2.46
+ */
+void webkit_settings_set_urls_with_universal_access(WebKitSettings *settings, const gchar *urls)
+{
+    g_return_if_fail(WEBKIT_IS_SETTINGS(settings));
+
+    auto url_list = String::fromUTF8(urls);
+    settings->priv->urlsWithUniversalAccess = url_list.utf8();
+    settings->priv->preferences->setUrlsWithUniversalAccess(url_list);
+
+    g_object_notify_by_pspec(G_OBJECT(settings), sObjProperties[PROP_URLS_WITH_UNIVERSAL_ACCESS]);
 }
 
 /**

--- a/Source/WebKit/UIProcess/API/glib/WebKitSettings.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitSettings.h.in
@@ -484,6 +484,13 @@ WEBKIT_API void
 webkit_settings_set_allow_universal_access_from_file_urls      (WebKitSettings *settings,
                                                                 gboolean        allowed);
 
+WEBKIT_API const gchar *
+webkit_settings_get_urls_with_universal_access                 (WebKitSettings *settings);
+
+WEBKIT_API void
+webkit_settings_set_urls_with_universal_access                 (WebKitSettings *settings,
+                                                                const gchar    *urls);
+
 WEBKIT_API gboolean
 webkit_settings_get_allow_top_navigation_to_data_urls          (WebKitSettings *settings);
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -5495,6 +5495,33 @@ void webkit_web_view_set_cors_allowlist(WebKitWebView* webView, const gchar* con
     getPage(webView).setCORSDisablingPatterns(WTFMove(allowListVector));
 }
 
+
+/**
+ * webkit_web_view_set_local_universal_access_allowlist:
+ * @web_view: a #WebKitWebView
+ * @allowlist: (array zero-terminated=1) (element-type utf8) (transfer none) (nullable): an allowlist of URIs, or %NULL
+ *
+ * Sets the @allowlist for which local universal access is granted.
+ *
+ * If this function is called multiple times, only the allowlist set by
+ * the most recent call will be effective.
+ *
+ * Since: 2.46
+ */
+void webkit_web_view_set_local_universal_access_allowlist(WebKitWebView* webView, const gchar* const* allowList)
+{
+    g_return_if_fail(WEBKIT_IS_WEB_VIEW(webView));
+
+    Vector<String> allowListVector;
+    if (allowList) {
+        for (auto str = allowList; *str; ++str)
+            allowListVector.append(String::fromUTF8(*str));
+    }
+
+    getPage(webView).setLocalUniversalAccessAllowList(WTFMove(allowListVector));
+}
+
+
 static void webkitWebViewConfigureMediaCapture(WebKitWebView* webView, WebCore::MediaProducerMediaCaptureKind captureKind, WebKitMediaCaptureState captureState)
 {
     Ref page = getPage(webView);

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
@@ -872,6 +872,10 @@ WEBKIT_API void
 webkit_web_view_set_cors_allowlist                   (WebKitWebView             *web_view,
                                                       const gchar * const       *allowlist);
 
+WEBKIT_API void
+webkit_web_view_set_local_universal_access_allowlist (WebKitWebView             *web_view,
+                                                      const gchar * const       *allowlist);
+
 WEBKIT_API WebKitWebsitePolicies *
 webkit_web_view_get_website_policies                 (WebKitWebView             *web_view);
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -10636,6 +10636,7 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
 
     parameters.overriddenMediaType = m_overriddenMediaType;
     parameters.corsDisablingPatterns = corsDisablingPatterns();
+    parameters.localUniversalAccessAllowList = localUniversalAccessAllowList();
     parameters.maskedURLSchemes = m_configuration->maskedURLSchemes();
     parameters.userScriptsShouldWaitUntilNotification = m_configuration->userScriptsShouldWaitUntilNotification();
     parameters.allowedNetworkHosts = m_configuration->allowedNetworkHosts();
@@ -13450,6 +13451,12 @@ void WebPageProxy::setCORSDisablingPatterns(Vector<String>&& patterns)
 {
     m_corsDisablingPatterns = WTFMove(patterns);
     send(Messages::WebPage::UpdateCORSDisablingPatterns(m_corsDisablingPatterns));
+}
+
+void WebPageProxy::setLocalUniversalAccessAllowList(Vector<String>&& allowList)
+{
+    m_localUniversalAccessAllowList = WTFMove(allowList);
+    send(Messages::WebPage::SetLocalUniversalAccessAllowList(m_localUniversalAccessAllowList));
 }
 
 void WebPageProxy::setOverriddenMediaType(const String& mediaType)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2104,6 +2104,9 @@ public:
     void setCORSDisablingPatterns(Vector<String>&&);
     const Vector<String>& corsDisablingPatterns() const { return m_corsDisablingPatterns; }
 
+    void setLocalUniversalAccessAllowList(Vector<String>&&);
+    const Vector<String>& localUniversalAccessAllowList() const { return m_localUniversalAccessAllowList; }
+
     void getProcessDisplayName(CompletionHandler<void(String&&)>&&);
 
     void setOrientationForMediaCapture(WebCore::IntDegrees);
@@ -3545,6 +3548,7 @@ private:
     String m_overriddenMediaType;
 
     Vector<String> m_corsDisablingPatterns;
+    Vector<String> m_localUniversalAccessAllowList;
 
     struct InjectedBundleMessage {
         String messageName;

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPage.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPage.cpp
@@ -283,6 +283,11 @@ private:
     {
     }
 
+    bool shouldForceUniversalAccessFromLocalURL(WebKit::WebPage& webPage, const WTF::String& url)
+    {
+        return webPage.localUniversalAccessAllowList().contains(url);
+    }
+
     WebKitWebPage* m_webPage;
 };
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -772,6 +772,8 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
     pageConfiguration.httpsUpgradeEnabled = parameters.httpsUpgradeEnabled;
     pageConfiguration.portsForUpgradingInsecureSchemeForTesting = parameters.portsForUpgradingInsecureSchemeForTesting;
 
+    m_localUniversalAccessAllowList = WTFMove(parameters.localUniversalAccessAllowList);
+
     if (!parameters.crossOriginAccessControlCheckEnabled)
         CrossOriginAccessControlCheckDisabler::singleton().setCrossOriginAccessControlCheckEnabled(false);
 
@@ -8918,6 +8920,11 @@ void WebPage::updateCORSDisablingPatterns(Vector<String>&& patterns)
     m_corsDisablingPatterns = WTFMove(patterns);
     synchronizeCORSDisablingPatternsWithNetworkProcess();
     m_page->setCORSDisablingPatterns(parseAndAllowAccessToCORSDisablingPatterns(m_corsDisablingPatterns));
+}
+
+void WebPage::setLocalUniversalAccessAllowList(Vector<String>&& allowList)
+{
+    m_localUniversalAccessAllowList = WTFMove(allowList);
 }
 
 void WebPage::synchronizeCORSDisablingPatternsWithNetworkProcess()

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1592,6 +1592,7 @@ public:
     void setOverriddenMediaType(const String&);
 
     void updateCORSDisablingPatterns(Vector<String>&&);
+    void setLocalUniversalAccessAllowList(Vector<String>&&);
 
 #if ENABLE(IPC_TESTING_API)
     bool ipcTestingAPIEnabled() const { return m_ipcTestingAPIEnabled; }
@@ -1813,6 +1814,8 @@ public:
     void loadRequest(LoadParameters&&);
 
     void setTopContentInset(float);
+
+    const Vector<String>& localUniversalAccessAllowList() const { return m_localUniversalAccessAllowList; };
 
 private:
     WebPage(WebCore::PageIdentifier, WebPageCreationParameters&&);
@@ -2829,6 +2832,7 @@ private:
     std::optional<Vector<WebCore::TextManipulationController::ExclusionRule>> m_textManipulationExclusionRules;
 
     Vector<String> m_corsDisablingPatterns;
+    Vector<String> m_localUniversalAccessAllowList;
 
     std::unique_ptr<WebCore::CachedPage> m_cachedPage;
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -703,6 +703,8 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
 
     UpdateCORSDisablingPatterns(Vector<String> patterns)
 
+    SetLocalUniversalAccessAllowList(Vector<String> patterns)
+
     SetIsTakingSnapshotsForApplicationSuspension(bool isTakingSnapshotsForApplicationSuspension)
     SetNeedsDOMWindowResizeEvent()
 


### PR DESCRIPTION
When launching the browser with a local (file) URL, the page may need to load scripts that reside on a different volume. The commit 448487f4e635fac0719e05793ab6fba164ae361a introduced a change to use the posix version of FileSystem::getFileDeviceId() instead of the glib one. This affected the return value which is now non-zero, fixing a bug, but changing the behavior of FileSystem::filesHaveSameVolume() compared to older versions and consequently the behavior of SecurityOrigin::canDisplay() when a page loads a script that resides on a different volume. While this can be overcome by enabling the setting to allow universal access from file urls using the API
webkit_settings_set_allow_universal_access_from_file_urls(), that will allow a wider access that needed, as the access is only required from a limited number of trusted local files. This new API introduces a way to overcome this issue and allow only the access that is required.
<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/373add5103ae013242773bad9f639cd8cdee5d4f

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/119 "Built successfully") | [✅ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/32 "Passed tests") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/120 "Built successfully") | [❌ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/10/builds/36 "Found 1 new test failure: imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/srcdoc-inherit.meta/unset/sharedworker-module.https.html (failure)") 
<!--EWS-Status-Bubble-End-->