### PR TITLE
Support whitelisting URLs for local universal access

### DIFF
--- a/Source/WebKit/Shared/WebPageCreationParameters.h
+++ b/Source/WebKit/Shared/WebPageCreationParameters.h
@@ -273,6 +273,7 @@ struct WebPageCreationParameters {
 
     String overriddenMediaType;
     Vector<String> corsDisablingPatterns;
+    Vector<String> localUniversalAccessAllowList;
     HashSet<String> maskedURLSchemes;
     bool userScriptsShouldWaitUntilNotification { true };
     bool loadsSubresources { true };

--- a/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
@@ -197,6 +197,7 @@ enum class WebCore::UserInterfaceLayoutDirection : bool;
 
     String overriddenMediaType;
     Vector<String> corsDisablingPatterns;
+    Vector<String> localUniversalAccessAllowList;
     HashSet<String> maskedURLSchemes;
     bool userScriptsShouldWaitUntilNotification;
     bool loadsSubresources;

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.h
@@ -533,6 +533,7 @@ private:
 
         HashMap<WTF::String, Ref<WebKit::WebURLSchemeHandler>> urlSchemeHandlers;
         Vector<WTF::String> corsDisablingPatterns;
+        Vector<WTF::String> localUniversalAccessAllowList;
         HashSet<WTF::String> maskedURLSchemes;
         bool maskedURLSchemesWasSet { false };
         bool userScriptsShouldWaitUntilNotification { true };

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -5495,6 +5495,33 @@ void webkit_web_view_set_cors_allowlist(WebKitWebView* webView, const gchar* con
     getPage(webView).setCORSDisablingPatterns(WTFMove(allowListVector));
 }
 
+
+/**
+ * webkit_web_view_set_local_universal_access_allowlist:
+ * @web_view: a #WebKitWebView
+ * @allowlist: (array zero-terminated=1) (element-type utf8) (transfer none) (nullable): an allowlist of URIs, or %NULL
+ *
+ * Sets the @allowlist for which local universal access is granted.
+ *
+ * If this function is called multiple times, only the allowlist set by
+ * the most recent call will be effective.
+ *
+ * Since: 2.46
+ */
+void webkit_web_view_set_local_universal_access_allowlist(WebKitWebView* webView, const gchar* const* allowList)
+{
+    g_return_if_fail(WEBKIT_IS_WEB_VIEW(webView));
+
+    Vector<String> allowListVector;
+    if (allowList) {
+        for (auto str = allowList; *str; ++str)
+            allowListVector.append(String::fromUTF8(*str));
+    }
+
+    getPage(webView).setLocalUniversalAccessAllowList(WTFMove(allowListVector));
+}
+
+
 static void webkitWebViewConfigureMediaCapture(WebKitWebView* webView, WebCore::MediaProducerMediaCaptureKind captureKind, WebKitMediaCaptureState captureState)
 {
     Ref page = getPage(webView);

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
@@ -872,6 +872,10 @@ WEBKIT_API void
 webkit_web_view_set_cors_allowlist                   (WebKitWebView             *web_view,
                                                       const gchar * const       *allowlist);
 
+WEBKIT_API void
+webkit_web_view_set_local_universal_access_allowlist (WebKitWebView             *web_view,
+                                                      const gchar * const       *allowlist);
+
 WEBKIT_API WebKitWebsitePolicies *
 webkit_web_view_get_website_policies                 (WebKitWebView             *web_view);
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -10636,6 +10636,7 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
 
     parameters.overriddenMediaType = m_overriddenMediaType;
     parameters.corsDisablingPatterns = corsDisablingPatterns();
+    parameters.localUniversalAccessAllowList = localUniversalAccessAllowList();
     parameters.maskedURLSchemes = m_configuration->maskedURLSchemes();
     parameters.userScriptsShouldWaitUntilNotification = m_configuration->userScriptsShouldWaitUntilNotification();
     parameters.allowedNetworkHosts = m_configuration->allowedNetworkHosts();
@@ -13450,6 +13451,12 @@ void WebPageProxy::setCORSDisablingPatterns(Vector<String>&& patterns)
 {
     m_corsDisablingPatterns = WTFMove(patterns);
     send(Messages::WebPage::UpdateCORSDisablingPatterns(m_corsDisablingPatterns));
+}
+
+void WebPageProxy::setLocalUniversalAccessAllowList(Vector<String>&& allowList)
+{
+    m_localUniversalAccessAllowList = WTFMove(allowList);
+    send(Messages::WebPage::SetLocalUniversalAccessAllowList(m_localUniversalAccessAllowList));
 }
 
 void WebPageProxy::setOverriddenMediaType(const String& mediaType)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2104,6 +2104,9 @@ public:
     void setCORSDisablingPatterns(Vector<String>&&);
     const Vector<String>& corsDisablingPatterns() const { return m_corsDisablingPatterns; }
 
+    void setLocalUniversalAccessAllowList(Vector<String>&&);
+    const Vector<String>& localUniversalAccessAllowList() const { return m_localUniversalAccessAllowList; }
+
     void getProcessDisplayName(CompletionHandler<void(String&&)>&&);
 
     void setOrientationForMediaCapture(WebCore::IntDegrees);
@@ -3545,6 +3548,7 @@ private:
     String m_overriddenMediaType;
 
     Vector<String> m_corsDisablingPatterns;
+    Vector<String> m_localUniversalAccessAllowList;
 
     struct InjectedBundleMessage {
         String messageName;

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPage.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPage.cpp
@@ -283,6 +283,11 @@ private:
     {
     }
 
+    bool shouldForceUniversalAccessFromLocalURL(WebKit::WebPage& webPage, const WTF::String& url) override
+    {
+        return webPage.localUniversalAccessAllowList().contains(url);
+    }
+
     WebKitWebPage* m_webPage;
 };
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -772,6 +772,8 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
     pageConfiguration.httpsUpgradeEnabled = parameters.httpsUpgradeEnabled;
     pageConfiguration.portsForUpgradingInsecureSchemeForTesting = parameters.portsForUpgradingInsecureSchemeForTesting;
 
+    m_localUniversalAccessAllowList = WTFMove(parameters.localUniversalAccessAllowList);
+
     if (!parameters.crossOriginAccessControlCheckEnabled)
         CrossOriginAccessControlCheckDisabler::singleton().setCrossOriginAccessControlCheckEnabled(false);
 
@@ -8918,6 +8920,11 @@ void WebPage::updateCORSDisablingPatterns(Vector<String>&& patterns)
     m_corsDisablingPatterns = WTFMove(patterns);
     synchronizeCORSDisablingPatternsWithNetworkProcess();
     m_page->setCORSDisablingPatterns(parseAndAllowAccessToCORSDisablingPatterns(m_corsDisablingPatterns));
+}
+
+void WebPage::setLocalUniversalAccessAllowList(Vector<String>&& allowList)
+{
+    m_localUniversalAccessAllowList = WTFMove(allowList);
 }
 
 void WebPage::synchronizeCORSDisablingPatternsWithNetworkProcess()

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1592,6 +1592,7 @@ public:
     void setOverriddenMediaType(const String&);
 
     void updateCORSDisablingPatterns(Vector<String>&&);
+    void setLocalUniversalAccessAllowList(Vector<String>&&);
 
 #if ENABLE(IPC_TESTING_API)
     bool ipcTestingAPIEnabled() const { return m_ipcTestingAPIEnabled; }
@@ -1813,6 +1814,8 @@ public:
     void loadRequest(LoadParameters&&);
 
     void setTopContentInset(float);
+
+    const Vector<String>& localUniversalAccessAllowList() const { return m_localUniversalAccessAllowList; };
 
 private:
     WebPage(WebCore::PageIdentifier, WebPageCreationParameters&&);
@@ -2829,6 +2832,7 @@ private:
     std::optional<Vector<WebCore::TextManipulationController::ExclusionRule>> m_textManipulationExclusionRules;
 
     Vector<String> m_corsDisablingPatterns;
+    Vector<String> m_localUniversalAccessAllowList;
 
     std::unique_ptr<WebCore::CachedPage> m_cachedPage;
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -703,6 +703,8 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
 
     UpdateCORSDisablingPatterns(Vector<String> patterns)
 
+    SetLocalUniversalAccessAllowList(Vector<String> patterns)
+
     SetIsTakingSnapshotsForApplicationSuspension(bool isTakingSnapshotsForApplicationSuspension)
     SetNeedsDOMWindowResizeEvent()
 


### PR DESCRIPTION
When launching the browser with a local (file) URL, the page may need to load scripts that reside on a different volume. The commit 448487f introduced a change to use the posix version of FileSystem::getFileDeviceId() instead of the glib one. This affected the return value which is now non-zero, fixing a bug, but changing the behavior of
FileSystem::filesHaveSameVolume() compared to older versions and consequently the behavior of
SecurityOrigin::canDisplay() when a page loads a script that resides on a different volume. While this can be overcome by enabling the setting to allow universal access from file urls using the API webkit_settings_set_allow_universal_access_from_file_urls(), that will allow a wider access that needed, as the access is only required from a limited number of trusted local files. This new API introduces a way to overcome this issue and allow only the access that is required.<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/599d021869d10d7722972c0250009622b85b40ec

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/121 "Built successfully") | [✅ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/34 "Passed tests") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/122 "Built successfully") | [⏳ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/WPE-246-ARM-32-bit-LayoutTests-EWS "Waiting to run tests") 
<!--EWS-Status-Bubble-End-->