### PR TITLE
[GLIB] Fix decoding of GTlsCertificate

### DIFF
--- a/Source/WebKit/Shared/glib/ArgumentCodersGLib.cpp
+++ b/Source/WebKit/Shared/glib/ArgumentCodersGLib.cpp
@@ -166,6 +166,7 @@ std::optional<GRefPtr<GTlsCertificate>> ArgumentCoder<GRefPtr<GTlsCertificate>>:
 #endif
             nullptr)));
         issuer = certificate.get();
+        ++i;
     }
 
     return certificate;


### PR DESCRIPTION
Mutual authentication is broken in wpe-2.46. The problem can be observed on https://server.cryptomix.com/secure, given that the browser launcher implements 'WebKitWebView::authenticate' callback and provides a client cert with a "private-key". 

wpe-2.46's GTlsCertificate argument decoder wasn't setting the private key causing an authentication failure.
<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/b58347dd5191ebf1f69fdeb6b77b15046ff143e7

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/122 "Built successfully") | [✅ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/35 "Passed tests") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/123 "Built successfully") | [⏳ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/WPE-246-ARM-32-bit-LayoutTests-EWS "Waiting to run tests") 
<!--EWS-Status-Bubble-End-->