### PR TITLE
[wpe-2.46] Write Breakpad minidump to a file descriptor instead of persistent st…

### DIFF
--- a/Source/WebKit/Shared/unix/BreakpadExceptionHandler.cpp
+++ b/Source/WebKit/Shared/unix/BreakpadExceptionHandler.cpp
@@ -40,6 +40,21 @@ void installBreakpadExceptionHandler()
 {
     static std::once_flag onceFlag;
     static MainThreadLazyNeverDestroyed<google_breakpad::ExceptionHandler> exceptionHandler;
+
+    // Use BREAKPAD_FD environment variable to pass the file descriptor where the minidump should be written.
+    // This is useful for environments where the filesystem is not available or not writable
+    // such as in some containerized environments.
+    const char* breakpadFd = getenv("BREAKPAD_FD");
+    if (breakpadFd) {
+        std::call_once(onceFlag, [breakpadFd]() {
+            exceptionHandler.construct(google_breakpad::MinidumpDescriptor(atoi(breakpadFd)), nullptr,
+                [](const google_breakpad::MinidumpDescriptor&, void*, bool succeeded) -> bool {
+                    return succeeded;
+                }, nullptr, true, -1);
+        });
+        return;
+    }
+
     static String breakpadMinidumpDir = String::fromUTF8(getenv("BREAKPAD_MINIDUMP_DIR"));
 
 #ifdef BREAKPAD_MINIDUMP_DIR


### PR DESCRIPTION
…orage

This change allows Breakpad minidumps to be written directly to a specified file descriptor, as defined by the BREAKPAD_FD environment variable. This is particularly useful in containerized environments where access to the file system is restricted or unavailable. By using a file descriptor, we avoid the need for persistent storage, ensuring better compatibility and reliability in such scenarios.<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/8a9fe3631c08c278d15aa1e6094630b99933222c

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [❌ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/123 "Failed to checkout and rebase branch from PR 1514") | [❌ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/123 "Failed to checkout and rebase branch from PR 1514") 
| [❌ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/124 "Failed to checkout and rebase branch from PR 1514") | [❌ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/124 "Failed to checkout and rebase branch from PR 1514") 
<!--EWS-Status-Bubble-End-->