### PR TITLE
Fix playback rate change

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -729,9 +729,9 @@ void MediaPlayerPrivateGStreamer::updatePlaybackRate()
         auto& quirksManager = GStreamerQuirksManager::singleton();
         const auto [processed, didInstantRateChange] = quirksManager.applyCustomInstantRateChange(
             m_isPipelinePlaying, isPipelineWaitingPreroll(), m_playbackRate, mute, pipeline());
-        if (processed) {
-            if (didInstantRateChange)
-                m_lastPlaybackRate = m_playbackRate;
+
+        if (processed && didInstantRateChange) {
+            m_lastPlaybackRate = m_playbackRate;
         } else if (doSeek(SeekTarget { playbackPosition() }, m_playbackRate)) {
             g_object_set(m_pipeline.get(), "mute", mute, nullptr);
             m_lastPlaybackRate = m_playbackRate;


### PR DESCRIPTION
When attempting to change playback rate while the pipeline is not playing and not prerolling (isPipelinePlaying = 0 and isPipelineWaitingPreroll = 0), if the quirk processes the request but doesn't change the playback rate, the rate won't get changed on platforms where instant playback rate change is supported.<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/83fe7f84e190b349cc7def91bbb3bfe77f509241

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/124 "Built successfully") | [✅ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/36 "Passed tests") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/125 "Built successfully") | [⏳ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/WPE-246-ARM-32-bit-LayoutTests-EWS "Waiting to run tests") 
<!--EWS-Status-Bubble-End-->