### PR TITLE
LayerTreeHost construction race condition fix

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
@@ -84,6 +84,8 @@ LayerTreeHost::LayerTreeHost(WebPage& webPage)
     m_layerTreeContext.contextID = m_surface->surfaceID();
 
     didChangeViewport();
+
+    initialized.store(true);
 }
 
 LayerTreeHost::~LayerTreeHost()
@@ -394,7 +396,9 @@ void LayerTreeHost::updateScene()
 
 void LayerTreeHost::frameComplete()
 {
-    m_compositor->frameComplete();
+    if (initialized.load()) {
+        m_compositor->frameComplete();
+    }
 }
 
 uint64_t LayerTreeHost::nativeSurfaceHandleForCompositing()

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
@@ -37,6 +37,7 @@
 #include <wtf/Forward.h>
 #include <wtf/OptionSet.h>
 #include <wtf/RunLoop.h>
+#include <atomic>
 
 #if USE(GRAPHICS_LAYER_TEXTURE_MAPPER)
 
@@ -220,6 +221,7 @@ private:
     double m_transientZoomScale { 1 };
     WebCore::FloatPoint m_transientZoomOrigin;
 #endif
+    std::atomic_bool initialized { false };
 };
 
 #if !USE(COORDINATED_GRAPHICS)


### PR DESCRIPTION
This fixes race condition happening during LayerTreeHost construction The problem is seen with Process Swap On Cross-Site Navigation enabled.

The race condition happens during LayerTreeHost construction. The scenario is:

- on THREAD_A (main thread) LayerTreeHost constructor starts; it first creates AcceleratedSurfaceLibWPE, then ThreadedCompositor

- ThreadedCompositor constructor creates run loop (m_compositingRunLoop), executes & synchronously waits for initialization task on the run loop. This task calls m_client.nativeSurfaceHandleForCompositing() on THREAD_B (compositing thread) and this ends up calling AcceleratedSurfaceLibWPE::initialize() Note: at this point, LayerTreeHost constructor hasn't set LayerTreeHost::m_compositor value yet

- still on THREAD_B, AcceleratedSurfaceLibWPE::initialize connects backend events (wpe_renderer_backend_egl_target_set_client). And sometimes we get first frame_complete event quickly (I've only seen that with PSON enabled). The handler for frame_complete is already registered, and it calls surface.m_client.frameComplete(). And LayerTreeHost::frameComplete() calls 'm_compositor->frameComplete()', but this requires THREAD_A to already have set m_compositor value in ThreadedCompositor constructor, and some memory barrier between threads A & B. So m_compositor can be null here, which causes SIGSEGV.

The proposed fix introduces additional 'LayerTreeHost::initialized' atomic bool which enables to prevent this case and adds memory barrier (via atomic_bool load/store) between threads.
<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/ca3045da5e2ca8f51da4a873dd0f9d85bf077982

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| [✅ 🛠 wpe-238-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/1/builds/110 "Built successfully") | [✅ 🧪 wpe-238-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/5/builds/51 "Passed tests") 
| [✅ 🛠 wpe-238-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/8/builds/109 "Built successfully") | [✅ 🧪 wpe-238-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/6/builds/61 "Passed tests") 
| | 
| | 
<!--EWS-Status-Bubble-End-->