### PR TITLE
[Cairo] Fix cairo pattern memory leak

### DIFF
--- a/Source/WebCore/platform/graphics/cairo/CairoUtilities.cpp
+++ b/Source/WebCore/platform/graphics/cairo/CairoUtilities.cpp
@@ -235,7 +235,7 @@ void drawPatternToCairoContext(cairo_t* cr, cairo_surface_t* image, const IntSiz
         scaledImageSurface = adoptRef(cairo_image_surface_create(CAIRO_FORMAT_ARGB32, scaledImageSurfaceSize.width(), scaledImageSurfaceSize.height()));
         RefPtr<cairo_t> scaledImageContext = adoptRef(cairo_create(scaledImageSurface.get()));
 
-        RefPtr<cairo_pattern_t> pattern = cairo_pattern_create_for_surface(image);
+        RefPtr<cairo_pattern_t> pattern = adoptRef(cairo_pattern_create_for_surface(image));
         switch (imageInterpolationQuality) {
         case InterpolationQuality::DoNotInterpolate:
         case InterpolationQuality::Low:


### PR DESCRIPTION
Adopt the created cairo pattern so that it is properly managed. 

I have tried to reproduce https://github.com/WebPlatformForEmbedded/WPEWebKit/issues/1509 building a _cog_ configuration and running it on a Raspberry Pi, using the Web Inspector to send navigation keys. 

I was logged out, and could not reproduce the original bug -- without any patch applied.

I will now attempt a wpe build and see if the different key handling has an impact, but it would be great if @pradeep-raveendranpillai-infosys could attempt to reproduce with my patch applied.<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/f622590df98cdbfa4081a4bbf7494a7c03c5a79e

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| [✅ 🛠 wpe-238-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/1/builds/111 "Built successfully") | [✅ 🧪 wpe-238-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/5/builds/52 "Passed tests") 
| [✅ 🛠 wpe-238-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/8/builds/110 "Built successfully") | [✅ 🧪 wpe-238-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/6/builds/62 "Passed tests") 
| | 
| | 
<!--EWS-Status-Bubble-End-->