### PR TITLE
[2.46] [BitmapTexture] Check EGL context before destruction

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp
@@ -288,6 +288,12 @@ void BitmapTexture::bindAsSurface()
 
 BitmapTexture::~BitmapTexture()
 {
+    GLContext* currentContext = GLContext::current();
+    if (!currentContext || !currentContext->platformContext()) {
+        // The context has been destroyed already, so we can't clean up.
+        return;
+    }
+
     glDeleteTextures(1, &m_id);
 
     if (m_fbo)


### PR DESCRIPTION
Destroying GL resources without EGL context bound is not safe and may lead to crash.

We have a crash reported for 2.38 inside ~BitmapTexutreGL() on browser shutdown. It's not particulary easy to reproduce the crash itself but analyzing scenario leads to the case where ~BitmapTexutre() is called without current EGL context that isn't safe to destroy GL resources and, potentially, may lead to crash - that probably depends on impl details.

Here is a test case
https://asurdej-comcast.github.io/tests/iPlayer_test.html
Problem seen on wpe-2.46 x86 build, open the page -> wait until its loaded and close it (Alt+F4).
I'm validating the problem by adding logs inside ~BitmapTexture() to confirm EGL context is missing. The EGL context that BitmapTexture was created with is already destroyed (with native window, etc). There is still sharing context available that we can probably also use but not sure if that's correct solution.

This may be related to https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1502 where destruction of the compositor GL context leaves the remaining shutdown without EGL contex bound<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/898eea2d5e682705d2b8da007786b4fb5e6de54c

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [❌ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/127 "Failed to checkout and rebase branch from PR 1519") | [❌ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/127 "Failed to checkout and rebase branch from PR 1519") 
| [❌ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/128 "Failed to checkout and rebase branch from PR 1519") | [❌ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/128 "Failed to checkout and rebase branch from PR 1519") 
<!--EWS-Status-Bubble-End-->