### PR TITLE
[MSE][GStreamer] don't push samples while seeking

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -269,6 +269,7 @@ bool MediaPlayerPrivateGStreamerMSE::doSeek(const SeekTarget& target, float rate
     // This will also add support for fastSeek once done (see webkit.org/b/260607)
     if (!m_mediaSourcePrivate)
         return false;
+    m_mediaSourcePrivate->willSeek();
     m_mediaSourcePrivate->waitForTarget(target)->whenSettled(RunLoop::current(), [this, weakThis = ThreadSafeWeakPtr { *this }](auto&& result) {
         RefPtr self = weakThis.get();
         if (!self || !result)

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp
@@ -205,6 +205,12 @@ TrackID MediaSourcePrivateGStreamer::registerTrackId(TrackID preferredId)
     return assignedId;
 }
 
+void MediaSourcePrivateGStreamer::willSeek()
+{
+    for (auto* sourceBuffer : m_activeSourceBuffers)
+        downcast<SourceBufferPrivateGStreamer>(sourceBuffer)->willSeek();
+}
+
 bool MediaSourcePrivateGStreamer::unregisterTrackId(TrackID trackId)
 {
     ASSERT(isMainThread());

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h
@@ -77,6 +77,8 @@ public:
     TrackID registerTrackId(TrackID);
     bool unregisterTrackId(TrackID);
 
+    void willSeek();
+
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger; }
     ASCIILiteral logClassName() const override { return "MediaSourcePrivateGStreamer"_s; }

--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
@@ -403,6 +403,23 @@ size_t SourceBufferPrivateGStreamer::platformEvictionThreshold() const
     return evictionThreshold;
 }
 
+void SourceBufferPrivateGStreamer::willSeek()
+{
+    ALWAYS_LOG(LOGIDENTIFIER);
+    m_seeking = true;
+}
+
+bool SourceBufferPrivateGStreamer::isSeeking() const
+{
+    return m_seeking;
+}
+
+void SourceBufferPrivateGStreamer::seekToTime(const MediaTime& time)
+{
+    m_seeking = false;
+    SourceBufferPrivate::seekToTime(time);
+}
+
 #undef GST_CAT_DEFAULT
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h
@@ -96,6 +96,10 @@ public:
     size_t platformMaximumBufferSize() const override;
     size_t platformEvictionThreshold() const final;
 
+    void willSeek();
+    bool isSeeking() const final;
+    void seekToTime(const MediaTime&) final;
+
 private:
     friend class AppendPipeline;
 
@@ -109,6 +113,7 @@ private:
     std::unique_ptr<AppendPipeline> m_appendPipeline;
     StdUnorderedMap<TrackID, RefPtr<MediaSourceTrackGStreamer>> m_tracks;
     std::optional<MediaPromise::Producer> m_appendPromise;
+    bool m_seeking { false };
 
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;


### PR DESCRIPTION
MediaSource::waitForTarget completes asynchronously. Even when the target time is already buffered, it still enqueues a task to compute seek time on next event loop cycle. This can lead to SourceBuffer providing media data for incorrect time, after GStreamer seek already flushed the source. For example this happens if
TrackQueue::LowLevelHandler callback was posted just before the seek.

The proposed change implements SourceBufferPrivate::isSeeking() that returns true until MSE seek is completed, effectivly blocking SourceBufferPrivate::provideMediaData during the seek.

