### PR TITLE
Avoid round-up of small volume capacities

### DIFF
--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -389,7 +389,10 @@ void NetworkStorageManager::spaceGrantedForOrigin(const WebCore::ClientOrigin& o
         if (m_volumeCapacityOverride)
             volumeCapacity = m_volumeCapacityOverride;
         else if (auto capacity = FileSystem::volumeCapacity(m_path))
-            volumeCapacity = WTF::roundUpToMultipleOf(defaultVolumeCapacityUnit, *capacity);
+            if (*capacity < defaultVolumeCapacityUnit)
+                volumeCapacity = *capacity;
+            else
+                volumeCapacity = WTF::roundUpToMultipleOf(defaultVolumeCapacityUnit, *capacity);
         if (volumeCapacity)
             m_totalQuota = *m_totalQuotaRatio * *volumeCapacity;
         else
@@ -551,7 +554,10 @@ OriginQuotaManager::Parameters NetworkStorageManager::originQuotaManagerParamete
         if (m_volumeCapacityOverride)
             volumeCapacity = m_volumeCapacityOverride;
         else if (auto capacity = FileSystem::volumeCapacity(m_path))
-            volumeCapacity = WTF::roundUpToMultipleOf(defaultVolumeCapacityUnit, *capacity);
+            if (*capacity < defaultVolumeCapacityUnit)
+                volumeCapacity = *capacity;
+            else
+                volumeCapacity = WTF::roundUpToMultipleOf(defaultVolumeCapacityUnit, *capacity);
         if (volumeCapacity) {
             quota = m_originQuotaRatio.value() * volumeCapacity.value();
             increaseQuotaFunction = { };


### PR DESCRIPTION
For use cases where the volume capacity override option cannot be used, if we round small capacities to the next 1GB, we might use inadequate values for proper origin and total storage quota control. This is more critical for smaller capacities.

Note: It is arguable if we should be rounding up at all, because that will lead to the use of wrong quotas. Rounding down would seem more sensible to ensure we won't attempt to use more space than the one available. For now, adjust for the small volume sizes
<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/950911bec3ed723ff001d334e85b14aad8fb165a

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/134 "Built successfully") | [⏳ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/WPE-246-x86-64-bit-LayoutTests-EWS "Waiting to run tests") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/135 "Built successfully") | [⏳ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/WPE-246-ARM-32-bit-LayoutTests-EWS "Waiting to run tests") 
<!--EWS-Status-Bubble-End-->