### PR TITLE
Synthesize bold/italic when not available in fonts

### DIFF
--- a/Source/WebCore/platform/graphics/skia/FontCacheSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontCacheSkia.cpp
@@ -154,7 +154,10 @@ Ref<Font> FontCache::lastResortFallbackFont(const FontDescription& fontDescripti
         typeface = SkTypeface::MakeEmpty();
     }
 
-    FontPlatformData platformData(WTFMove(typeface), fontDescription.computedSize(), false /* syntheticBold */, false /* syntheticOblique */,
+    bool needsSyntheticBold = fontDescription.hasAutoFontSynthesisWeight() && isFontWeightBold(fontDescription.weight());
+    bool needsSyntheticOblique = fontDescription.hasAutoFontSynthesisStyle() && isItalic(fontDescription.italic());
+
+    FontPlatformData platformData(WTFMove(typeface), fontDescription.computedSize(), needsSyntheticBold, needsSyntheticOblique,
         fontDescription.orientation(), fontDescription.widthVariant(), fontDescription.textRenderingMode(), computeFeatures(fontDescription, { }));
     return fontForPlatformData(platformData);
 }


### PR DESCRIPTION
When default system fonts are used and these don't include bold and italic variants, the text was being rendered as regular without any bold/italic styling. This enables the synthesis of relevant styles.

This fixes issue https://github.com/WebPlatformForEmbedded/WPEWebKit/issues/1522 
<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/50acb6c29f94e7aea3a7bdde98fd90504e36efe5

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/138 "Built successfully") | [✅ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/46 "Passed tests") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/139 "Built successfully") | [✅ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/10/builds/50 "Passed tests") 
<!--EWS-Status-Bubble-End-->