### PR TITLE
[MSE][GStreamer] update maximum buffer size after receiving first init segment

### DIFF
--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -1035,7 +1035,9 @@ Ref<MediaPromise> SourceBuffer::sourceBufferPrivateDidReceiveInitializationSegme
         // 5.6 Set first initialization segment flag to true.
         m_receivedFirstInitializationSegment = true;
 
+#if !PLATFORM(WPE)
         if (hasVideo())
+#endif
             m_private->setMaximumBufferSize(maximumBufferSize());
     }
 


### PR DESCRIPTION
This fixes the configuration of the maximum buffer size of audio source buffers via 'MSE_MAX_BUFFER_SIZE' env variable.
<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/05c7c2286c2e2b69a657ff8e33674753013c19ae

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/147 "Built successfully") | [✅ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/55 "Passed tests") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/148 "Built successfully") | [✅ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/10/builds/57 "Passed tests") 
<!--EWS-Status-Bubble-End-->