### PR TITLE
[WebRTC] Use WebCore::LibWebRTCProvider by default

### DIFF
--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.h
@@ -84,9 +84,12 @@ private:
     WeakRef<WebPage> m_webPage;
 };
 
-inline UniqueRef<LibWebRTCProvider> createLibWebRTCProvider(WebPage& page)
+inline UniqueRef<LibWebRTCProviderBase> createLibWebRTCProvider(WebPage& page)
 {
-    return makeUniqueRef<LibWebRTCProvider>(page);
+    // In downstream WPEWebKit WebProcess sandbox is disabled,
+    // so moving LibWebRTC networking out of it doesn't make much sense.
+    // For better performance keep it in WPEWebProcess
+    return makeUniqueRef<LibWebRTCProviderBase>();
 }
 
 #elif USE(GSTREAMER_WEBRTC)


### PR DESCRIPTION
Instead of Network LibWebRTCProvided to lower CPU usage.

Cherry-pick from wpe-2.38 https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1326<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/a467ce71046948b6a6319f911c2e0bd6465af2e4

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/154 "Built successfully") | [✅ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/62 "Passed tests") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/155 "Built successfully") | [✅ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/10/builds/64 "Passed tests") 
<!--EWS-Status-Bubble-End-->