### PR TITLE
Fix content type frame rate limit

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
@@ -822,13 +822,11 @@ MediaPlayerEnums::SupportsType GStreamerRegistryScanner::isContentTypeSupported(
     float height = contentType.parameter("height"_s).toFloat(&ok);
     if (!ok)
         height = 0;
-
-    if (videoDecodingLimits && (width > videoDecodingLimits->mediaMaxWidth || height > videoDecodingLimits->mediaMaxHeight))
-        return SupportsType::IsNotSupported;
-
     float frameRate = contentType.parameter("framerate"_s).toFloat(&ok);
-    // Limit frameRate only in case of highest supported resolution.
-    if (ok && videoDecodingLimits && width == videoDecodingLimits->mediaMaxWidth && height == videoDecodingLimits->mediaMaxHeight && frameRate > videoDecodingLimits->mediaMaxFrameRate)
+    if (!ok)
+        frameRate = 0;
+
+    if (videoDecodingLimits && (width > videoDecodingLimits->mediaMaxWidth || height > videoDecodingLimits->mediaMaxHeight || frameRate > videoDecodingLimits->mediaMaxFrameRate))
         return SupportsType::IsNotSupported;
 
     const auto& codecs = contentType.codecs();


### PR DESCRIPTION
Decoder limits are set by a build configuration in the form of widthxheight@framerate. However, framerate limit is only considered when the width and height are the ones in the build config. If the actual requested resolution is different, no framerate limit is ever considered.
This change brings back 2.38 behavior where limits where considered for each variable independently. While not ideal, as lower resolutions might support higher frame rates, and the way the build config ties semantically the framerate to the resolution specified, an alternative fix would require either an absolute max rate to be specified, or possibly different sets of resolution + framerate limits, which might be overkill to this purpose.<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/87f9ef77fc1ee31a82e8a85d19115462b50f2460

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/155 "Built successfully") | [✅ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/63 "Passed tests") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/156 "Built successfully") | [✅ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/10/builds/65 "Passed tests") 
<!--EWS-Status-Bubble-End-->