### PR TITLE
[GST Thunder] Limit webkitthunderparser element to MSE only

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -2553,7 +2553,10 @@ void MediaPlayerPrivateGStreamer::configureParsebin(GstElement* parsebin)
     // If no DRM is supported, we can skip the webkitthunderparser factory
     if (CDMFactoryThunder::singleton().supportedKeySystems().isEmpty())
         return;
-    if (m_url.protocolIsBlob())
+    // Enable for MSE only.
+    // Progressive playback doesn't use parsebin element so the below makes no effect there.
+    // Don't use thunder parser for MediaStream also.
+    if (!isMediaSource())
         return;
 
     // Otherwise we need to ensure that the webkitthunderparser factory is present


### PR DESCRIPTION
To not impact media stream use cases mainly.<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/3822de1bea659ae310f2b14d61b42fce877e8942

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/156 "Built successfully") | [✅ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/64 "Passed tests") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/157 "Built successfully") | [✅ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/10/builds/66 "Passed tests") 
<!--EWS-Status-Bubble-End-->