### PR TITLE
Fix nullptr dereference in font typeface handling

### DIFF
--- a/Source/WebCore/platform/graphics/skia/FontCacheSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontCacheSkia.cpp
@@ -120,6 +120,9 @@ RefPtr<Font> FontCache::systemFallbackForCharacterCluster(const FontDescription&
     auto features = computeFeatures(description, { });
     auto skFontStyle = skiaFontStyle(description);
     auto typeface = fontManager().matchFamilyStyleCharacter(nullptr, skFontStyle, bcp47.data(), bcp47.size(), baseCharacter);
+    if (!typeface) {
+        typeface = SkTypeface::MakeEmpty();
+    }
     auto syntheticBold = description.hasAutoFontSynthesisWeight() && skFontStyle.weight() >= SkFontStyle::kSemiBold_Weight && !typeface->isBold();
     auto syntheticOblique = description.hasAutoFontSynthesisStyle() && skFontStyle.slant() != SkFontStyle::kUpright_Slant && !typeface->isItalic();
     FontPlatformData alternateFontData(WTFMove(typeface), description.computedSize(), syntheticBold, syntheticOblique, description.orientation(), description.widthVariant(), description.textRenderingMode(), WTFMove(features));


### PR DESCRIPTION
<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/a9b48fbb0c6b294781fa0319f32f2f695dea057d

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/157 "Built successfully") | [✅ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/65 "Passed tests") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/158 "Built successfully") | [✅ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/10/builds/67 "Passed tests") 
<!--EWS-Status-Bubble-End-->