### PR TITLE
[ANGLE] Support EGL_PLATFORM_WAYLAND_EXT extension

### DIFF
--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/gl/egl/FunctionsEGL.cpp
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/gl/egl/FunctionsEGL.cpp
@@ -43,6 +43,7 @@ bool IsValidPlatformTypeForPlatformDisplayConnection(EGLAttrib platformType)
     switch (platformType)
     {
         case EGL_PLATFORM_SURFACELESS_MESA:
+        case EGL_PLATFORM_WAYLAND_EXT:
             return true;
         default:
             break;
@@ -418,6 +419,10 @@ EGLDisplay FunctionsEGL::getPlatformDisplay(EGLAttrib platformType,
     {
         case EGL_PLATFORM_SURFACELESS_MESA:
             if (!hasExtension("EGL_MESA_platform_surfaceless"))
+                return EGL_NO_DISPLAY;
+            break;
+        case EGL_PLATFORM_WAYLAND_EXT:
+            if (!hasExtension("EGL_EXT_platform_wayland"))
                 return EGL_NO_DISPLAY;
             break;
         default:


### PR DESCRIPTION
WebGL fails to initialize EGL display with followingn error:
```
ERR: Display.cpp:1083 (initialize): ANGLE Display::initialize error 12289: Failed to get system egl display
```<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/5550d947d27896984530654dff6fdd748da2f248

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/158 "Built successfully") | [✅ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/66 "Passed tests") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/159 "Built successfully") | [✅ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/10/builds/68 "Passed tests") 
<!--EWS-Status-Bubble-End-->