### PR TITLE
[wpe-2.46][RWI] fixes for RWI with chromium browser

### DIFF
--- a/Source/WebInspectorUI/Tools/Images/index.js
+++ b/Source/WebInspectorUI/Tools/Images/index.js
@@ -76,7 +76,7 @@ async function parseSVG(path) {
 
     let imgs = [];
     if (!path.includes("#")) {
-        let variants = dom.querySelectorAll(":root > :matches(svg, g)[id]");
+        let variants = dom.querySelectorAll(":root > :is(svg, g)[id]");
         if (variants.length) {
             for (let variant of variants) {
                 let target = variant.getAttribute("id");

--- a/Source/WebInspectorUI/UserInterface/Views/ButtonNavigationItem.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ButtonNavigationItem.css
@@ -91,11 +91,6 @@
     color: var(--glyph-color-disabled);
 }
 
-.navigation-bar .item.button > img {
-    width: 100%;
-    height: 100%;
-}
-
 .navigation-bar .item.button.disabled > img {
     opacity: 0.3;
 }

--- a/Source/WebInspectorUI/UserInterface/Views/ButtonNavigationItem.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ButtonNavigationItem.js
@@ -229,8 +229,11 @@ WI.ButtonNavigationItem = class ButtonNavigationItem extends WI.NavigationItem
 
             case WI.ButtonNavigationItem.ImageType.IMG: {
                 let img = this.element.appendChild(document.createElement("img"));
-                if (this._image)
+                if (this._image) {
+                    img.style.width = this._imageWidth + "px";
+                    img.style.height = this._imageHeight + "px";
                     img.src = this._image;
+		}
                 break;
             }
             }

--- a/Source/WebInspectorUI/UserInterface/Views/GradientSlider.css
+++ b/Source/WebInspectorUI/UserInterface/Views/GradientSlider.css
@@ -62,7 +62,7 @@
     width: 20px;
     height: 26px;
 
-    background-image: image-set(url(../Images/GradientStop.png) 1x, url(../Images/GradientStop@2x.png) 2x);
+    background-image: url(../Images/GradientStop.png);
 
     transition: opacity 350ms;
 }
@@ -73,7 +73,7 @@
 }
 
 .gradient-slider-knob.selected {
-    background-image: image-set(url(../Images/GradientStopSelected.png) 1x, url(../Images/GradientStopSelected@2x.png) 2x);
+    background-image: url(../Images/GradientStopSelected.png);
 }
 
 .gradient-slider-knob.detaching {

--- a/Source/WebInspectorUI/UserInterface/Views/HoverMenu.css
+++ b/Source/WebInspectorUI/UserInterface/Views/HoverMenu.css
@@ -58,7 +58,7 @@
     width: 15px;
     height: 13px;
 
-    content: image-set(url(../Images/HoverMenuButton.png) 1x, url(../Images/HoverMenuButton@2x.png) 2x);
+    content: url(../Images/HoverMenuButton.png);
     transform: translateY(-1px);
 }
 

--- a/Source/WebInspectorUI/UserInterface/Views/Slider.css
+++ b/Source/WebInspectorUI/UserInterface/Views/Slider.css
@@ -34,7 +34,7 @@
     top: -5px;
     width: 14px;
     height: 17px;
-    content: image-set(url(../Images/SliderThumb.png) 1x, url(../Images/SliderThumb@2x.png) 2x);
+    content: url(../Images/SliderThumb.png);
 }
 
 body[dir=ltr] .slider > img {
@@ -48,7 +48,7 @@ body[dir=rtl] .slider > img {
 }
 
 .slider > img.dragging {
-    content: image-set(url(../Images/SliderThumbPressed.png) 1x, url(../Images/SliderThumbPressed@2x.png) 2x);
+    content: url(../Images/SliderThumbPressed.png);
 }
 
 .slider:focus {

--- a/Source/WebInspectorUI/UserInterface/Views/SourceCodeTextEditor.css
+++ b/Source/WebInspectorUI/UserInterface/Views/SourceCodeTextEditor.css
@@ -183,7 +183,7 @@
 .hover-menu.color > img {
     width: 16px;
     height: 16px;
-    content: image-set(url(../Images/ColorIcon.png) 1x, url(../Images/ColorIcon@2x.png) 2x);
+    content: url(../Images/ColorIcon.png);
     transform: translateY(0.5px);
 }
 

--- a/Source/WebInspectorUI/UserInterface/Views/TextEditor.css
+++ b/Source/WebInspectorUI/UserInterface/Views/TextEditor.css
@@ -104,7 +104,7 @@
 
     z-index: -1;
 
-    background-image: image-set(url(../Images/InstructionPointer.png) 1x, url(../Images/InstructionPointer@2x.png) 2x);
+    background-image: url(../Images/InstructionPointer.png);
     background-size: 9px 100%;
     background-repeat: no-repeat;
 }


### PR DESCRIPTION
Fixes for RWI problem under chrome browser from wpe-2.38.

1. WebInspectorUI: Fix console warning/error icon for Chromium browser.-https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/645c968a25d44566bbd1b8601b58716eae786125
2. WebInspectorUI: Replace image-set() with simple url() as not supported by Chrome - https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/a331c827bf3aa423835789b30bd9ca66ec844a5d
3. [GTK][WPE] Remote Web Inspector: replace deprecated CSS method 'matches' with 'is'. => **one missing changes** - https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/b3f698fe804f78e70959b90917067d672315b36a



<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/4a57ee1a8f69fc41f780908e77242e14b82c22f2

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/159 "Built successfully") | [✅ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/67 "Passed tests") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/160 "Built successfully") | [✅ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/10/builds/69 "Passed tests") 
<!--EWS-Status-Bubble-End-->