### PR TITLE
Fix buffering handling in progressive playback

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -2104,6 +2104,8 @@ void MediaPlayerPrivateGStreamer::handleMessage(GstMessage* message)
         if (!messageSourceIsPlaybin || m_isDelayingLoad)
             break;
 
+        updateBufferingStatus();
+
         // The MediaPlayerPrivateGStreamer superclass now processes what it needs by calling updateStates() in handleMessage() for
         // GST_MESSAGE_STATE_CHANGED. However, subclasses still need to override asyncStateChangeDone() to do their own stuff.
         didPreroll();
@@ -2402,6 +2404,17 @@ void MediaPlayerPrivateGStreamer::updateBufferingStatus(GstBufferingMode mode, d
         updateStates();
     GST_TRACE("[Buffering] Settled results: m_wasBuffering: %s, m_isBuffering: %s, m_previousBufferingPercentage: %d, m_bufferingPercentage: %d",
         boolForPrinting(m_wasBuffering), boolForPrinting(m_isBuffering), m_previousBufferingPercentage, m_bufferingPercentage);
+}
+
+void MediaPlayerPrivateGStreamer::updateBufferingStatus()
+{
+    std::optional<int> percentage = queryBufferingPercentage();
+
+    if (!percentage.has_value()) {
+        GST_DEBUG_OBJECT(pipeline(), "[Buffering] Unable to determine buffering status");
+        return;
+    }
+    updateBufferingStatus(GST_BUFFERING_DOWNLOAD, percentage.value(), false, false);
 }
 
 #if USE(GSTREAMER_MPEGTS)

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -2334,18 +2334,8 @@ void MediaPlayerPrivateGStreamer::updateMaxTimeLoaded(double percentage)
 
 void MediaPlayerPrivateGStreamer::updateBufferingStatus(GstBufferingMode mode, double percentage, bool resetHistory, bool shouldUpdateStates)
 {
-    GstStateChangeReturn getStateResult = gst_element_get_state(m_pipeline.get(), nullptr, nullptr, 0);
-
-    // If an async transition is in progress, we keep the previous buffering state and percentage so that the buffering
-    // state transition can be correctly detected once the state change completes, as updateBufferingStatus() might
-    // not get called again after reaching max level while we are still in the async transition state.
-    // This ensures consistency in case updateBufferingStatus() is called without calling updateStates(), as well as
-    // calls to updateStates() whithout prior calls to updateBufferingStatus().
-    if (getStateResult != GST_STATE_CHANGE_ASYNC)
-    {
-        m_wasBuffering = m_isBuffering;
-        m_previousBufferingPercentage = m_bufferingPercentage;
-    }
+    m_wasBuffering = m_isBuffering;
+    m_previousBufferingPercentage = m_bufferingPercentage;
 
 #ifndef GST_DISABLE_GST_DEBUG
     GUniquePtr<char> modeString(g_enum_to_string(GST_TYPE_BUFFERING_MODE, mode));
@@ -2892,6 +2882,15 @@ void MediaPlayerPrivateGStreamer::updateStates()
     case GST_STATE_CHANGE_ASYNC:
         GST_DEBUG_OBJECT(pipeline(), "Async: State: %s, pending: %s", gst_element_state_get_name(m_currentState), gst_element_state_get_name(pending));
         // Change in progress.
+
+        // Delay the m_isBuffering change by returning it to its previous value. Without this, the false --> true change
+        // would go unnoticed by the code that should trigger a pause.
+        if (m_wasBuffering != m_isBuffering && !m_isPaused && m_playbackRate) {
+            GST_TRACE_OBJECT(pipeline(), "[Buffering] Delaying m_isBuffering %s --> %s to force the proper change from not buffering to buffering when the async state change completes.", boolForPrinting(m_wasBuffering), boolForPrinting(m_isBuffering));
+            m_isBuffering = m_wasBuffering;
+            m_bufferingPercentage = m_previousBufferingPercentage;
+        }
+
         break;
     case GST_STATE_CHANGE_FAILURE:
         GST_DEBUG_OBJECT(pipeline(), "Failure: State: %s, pending: %s", gst_element_state_get_name(m_currentState), gst_element_state_get_name(pending));

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -2334,8 +2334,18 @@ void MediaPlayerPrivateGStreamer::updateMaxTimeLoaded(double percentage)
 
 void MediaPlayerPrivateGStreamer::updateBufferingStatus(GstBufferingMode mode, double percentage, bool resetHistory, bool shouldUpdateStates)
 {
-    m_wasBuffering = m_isBuffering;
-    m_previousBufferingPercentage = m_bufferingPercentage;
+    GstStateChangeReturn getStateResult = gst_element_get_state(m_pipeline.get(), nullptr, nullptr, 0);
+
+    // If an async transition is in progress, we keep the previous buffering state and percentage so that the buffering
+    // state transition can be correctly detected once the state change completes, as updateBufferingStatus() might
+    // not get called again after reaching max level while we are still in the async transition state.
+    // This ensures consistency in case updateBufferingStatus() is called without calling updateStates(), as well as
+    // calls to updateStates() whithout prior calls to updateBufferingStatus().
+    if (getStateResult != GST_STATE_CHANGE_ASYNC)
+    {
+        m_wasBuffering = m_isBuffering;
+        m_previousBufferingPercentage = m_bufferingPercentage;
+    }
 
 #ifndef GST_DISABLE_GST_DEBUG
     GUniquePtr<char> modeString(g_enum_to_string(GST_TYPE_BUFFERING_MODE, mode));
@@ -2882,15 +2892,6 @@ void MediaPlayerPrivateGStreamer::updateStates()
     case GST_STATE_CHANGE_ASYNC:
         GST_DEBUG_OBJECT(pipeline(), "Async: State: %s, pending: %s", gst_element_state_get_name(m_currentState), gst_element_state_get_name(pending));
         // Change in progress.
-
-        // Delay the m_isBuffering change by returning it to its previous value. Without this, the false --> true change
-        // would go unnoticed by the code that should trigger a pause.
-        if (m_wasBuffering != m_isBuffering && !m_isPaused && m_playbackRate) {
-            GST_TRACE_OBJECT(pipeline(), "[Buffering] Delaying m_isBuffering %s --> %s to force the proper change from not buffering to buffering when the async state change completes.", boolForPrinting(m_wasBuffering), boolForPrinting(m_isBuffering));
-            m_isBuffering = m_wasBuffering;
-            m_bufferingPercentage = m_previousBufferingPercentage;
-        }
-
         break;
     case GST_STATE_CHANGE_FAILURE:
         GST_DEBUG_OBJECT(pipeline(), "Failure: State: %s, pending: %s", gst_element_state_get_name(m_currentState), gst_element_state_get_name(pending));

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -558,6 +558,7 @@ private:
     virtual void updateDownloadBufferingFlag();
     void processBufferingStats(GstMessage*);
     void updateBufferingStatus(GstBufferingMode, double percentage, bool resetHistory = false, bool shouldUpdateStates = true);
+    void updateBufferingStatus();
     void updateMaxTimeLoaded(double percentage);
 
 #if USE(GSTREAMER_MPEGTS)


### PR DESCRIPTION
When performing a seek operation during playback, the pipeline switches to the PAUSED state and starts buffering data. As this transition is async, we may reach the 100% buffer level before the state change completes. This may cause updateBufferingStatus() to stop getting called while the async transition is still in progress. As m_isBuffering was getting set back to m_wasBuffering value in updateStates() async state handling, once the state change completed, the updateStates() might not detect that we are not buffering anymore, as m_isBuffering is holding the wrong value.
<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/4fcc021a4d3e473b02453e2076c8b5d63a46f09f

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/166 "Built successfully") | [❌ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/74 "Found 200 new test failures: compositing/geometry/clipped-video-controller.html, compositing/geometry/video-fixed-scrolling.html, compositing/geometry/video-opacity-overlay.html, compositing/shared-backing/clipping-and-shared-backing.html, compositing/video-page-visibility.html, compositing/video/video-reflection.html, compositing/visibility/visibility-simple-video-layer.html, imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-invalid-args.html, imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-serializable.html, imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-transfer.html ... (failure)") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/167 "Built successfully") | [❌ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/10/builds/76 "Found 157 new test failures: compositing/geometry/clipped-video-controller.html, compositing/geometry/video-fixed-scrolling.html, compositing/geometry/video-opacity-overlay.html, compositing/overflow/scroll-ancestor-update.html, compositing/shared-backing/clipping-and-shared-backing.html, compositing/video-page-visibility.html, compositing/video/video-reflection.html, compositing/visibility/visibility-simple-video-layer.html, fullscreen/full-screen-iframe-legacy.html, imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-invalid-args.html ... (failure)") 
<!--EWS-Status-Bubble-End-->