### PR TITLE
[GStreamer] Fix thunderparser autoplugging for Westeros VP9 and AV1

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -2656,6 +2656,8 @@ void MediaPlayerPrivateGStreamer::configureElementPlatformQuirks(GstElement* ele
         characteristics.add({ ElementRuntimeCharacteristics::HasAudio });
     if (m_isLiveStream.value_or(false))
         characteristics.add({ ElementRuntimeCharacteristics::IsLiveStream });
+    if (isMediaSource())
+        characteristics.add({ ElementRuntimeCharacteristics::IsMediaSource });
 
     GStreamerQuirksManager::singleton().configureElement(element, WTFMove(characteristics));
 }

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.cpp
@@ -76,7 +76,7 @@ bool GStreamerQuirkRialto::isPlatformSupported() const
     return gst_plugin_feature_get_rank(GST_PLUGIN_FEATURE(sinkFactory.get())) > GST_RANK_MARGINAL;
 }
 
-void GStreamerQuirkRialto::configureElement(GstElement* element, const OptionSet<ElementRuntimeCharacteristics>&)
+void GStreamerQuirkRialto::configureElement(GstElement* element, const OptionSet<ElementRuntimeCharacteristics>& characteristics)
 {
     if (!g_strcmp0(G_OBJECT_TYPE_NAME(G_OBJECT(element)), "GstURIDecodeBin3")) {
         GRefPtr<GstCaps> defaultCaps;
@@ -84,6 +84,13 @@ void GStreamerQuirkRialto::configureElement(GstElement* element, const OptionSet
         defaultCaps = adoptGRef(gst_caps_merge(gst_caps_ref(m_sinkCaps.get()), defaultCaps.leakRef()));
         GST_INFO("Setting stop caps to %" GST_PTR_FORMAT, defaultCaps.get());
         g_object_set(element, "caps", defaultCaps.get(), nullptr);
+    }
+    if (!g_strcmp0(G_OBJECT_TYPE_NAME(G_OBJECT(element)), "GstParseBin") &&
+        characteristics.contains(ElementRuntimeCharacteristics::IsMediaSource)) {
+        auto autoplugId = g_signal_lookup("autoplug-continue", G_OBJECT_TYPE (element));
+        g_signal_handlers_disconnect_matched(
+            element, static_cast<GSignalMatchType>(G_SIGNAL_MATCH_ID | G_SIGNAL_MATCH_DATA),
+            autoplugId, 0, nullptr, nullptr, GST_OBJECT_PARENT(element));
     }
 }
 

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.cpp
@@ -59,13 +59,27 @@ bool GStreamerQuirkWesteros::isPlatformSupported() const
 
 void GStreamerQuirkWesteros::configureElement(GstElement* element, const OptionSet<ElementRuntimeCharacteristics>& characteristics)
 {
+    // Decodebin3 will try to autoplug available elements until it reaches a raw video format.
+    // Set stop caps on decodebin3 to prevent it from decoding the stream.
+    // Instead, it should expose a pad with encoded caps that platform sink can handle directly as a sink element.
+    // That brings unwanted side effects for parsebin element.
+    // Decodebin3 installs "autoplug-continue" signal handler on parsebin to stop its autoplugging process
+    // when it reaches decodebin stop caps. We still may want to use some parsers elements,
+    // like webkithunderparser, so we need to disconnect the "autoplug-continue" signal handler
+    // and let parsebin to control the autoplugging process. (Default handler will stop on decoder element)
     if (equalIgnoringASCIICase(G_OBJECT_TYPE_NAME(G_OBJECT(element)), "GstURIDecodeBin3")) {
         GRefPtr<GstCaps> defaultCaps;
         g_object_get(element, "caps", &defaultCaps.outPtr(), nullptr);
         defaultCaps = adoptGRef(gst_caps_merge(gst_caps_ref(m_sinkCaps.get()), defaultCaps.leakRef()));
         GST_INFO("Setting stop caps to %" GST_PTR_FORMAT, defaultCaps.get());
         g_object_set(element, "caps", defaultCaps.get(), nullptr);
-        return;
+    }
+    if (equalIgnoringASCIICase(G_OBJECT_TYPE_NAME(G_OBJECT(element)), "GstParseBin") &&
+        characteristics.contains(ElementRuntimeCharacteristics::IsMediaSource)) {
+        auto autoplugId = g_signal_lookup("autoplug-continue", G_OBJECT_TYPE (element));
+        g_signal_handlers_disconnect_matched(
+            element, static_cast<GSignalMatchType>(G_SIGNAL_MATCH_ID | G_SIGNAL_MATCH_DATA),
+            autoplugId, 0, nullptr, nullptr, GST_OBJECT_PARENT(element));
     }
 
     if (!characteristics.contains(ElementRuntimeCharacteristics::IsMediaStream))

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirks.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirks.h
@@ -39,6 +39,7 @@ enum class ElementRuntimeCharacteristics : uint8_t {
     HasVideo = 1 << 1,
     HasAudio = 1 << 2,
     IsLiveStream = 1 << 3,
+    IsMediaSource = 1 << 4,
 };
 
 class GStreamerQuirkBase {


### PR DESCRIPTION
Disconnect autoplug-continue signal that decodebin3 sets on a parsebin to make parsebin continue autoplugging proces even if caps already matches sink capabilities.

The problem here is that setting stop caps on decodebin disables thunderparser autoplugging for formats that doesn't need a parser, like VP9 and AV1 (that caps matches sink caps without any elements needed). But we still want to inject thunderparser in such cases

<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/5f1da13eab0ee348cc07d7c05d06fb7548b260c0

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/168 "Built successfully") | [✅ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/75 "Passed tests") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/169 "Built successfully") | [✅ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/10/builds/77 "Passed tests") 
<!--EWS-Status-Bubble-End-->