### PR TITLE
[GStreamer] Support Dolby Vision codecs

### DIFF
--- a/Source/WebCore/platform/PlatformScreen.cpp
+++ b/Source/WebCore/platform/PlatformScreen.cpp
@@ -26,7 +26,7 @@
 #include "config.h"
 #include "PlatformScreen.h"
 
-#if PLATFORM(COCOA) || PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(WPE_PLATFORM))
+#if PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)
 
 #include "ScreenProperties.h"
 #include <wtf/NeverDestroyed.h>

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
@@ -42,6 +42,11 @@
 #include "VideoEncoderPrivateGStreamer.h"
 #endif
 
+#if PLATFORM(WPE)
+#include "PlatformScreen.h"
+#include "ScreenProperties.h"
+#endif // PLATFORM(WPE)
+
 namespace {
 struct VideoDecodingLimits {
     unsigned mediaMaxWidth = 0;
@@ -510,6 +515,10 @@ void GStreamerRegistryScanner::initializeDecoders(const GStreamerRegistryScanner
         m_decoderCodecMap.add("x-h265"_s, h265DecoderAvailable);
         m_decoderCodecMap.add("hvc1*"_s, h265DecoderAvailable);
         m_decoderCodecMap.add("hev1*"_s, h265DecoderAvailable);
+#if PLATFORM(WPE)
+        m_decoderCodecMap.add("dvhe*"_s, h265DecoderAvailable);
+        m_decoderCodecMap.add("dvh1*"_s, h265DecoderAvailable);
+#endif // PLATFORM(WPE)
     }
 
     if (shouldAddMP4Container) {
@@ -747,11 +756,22 @@ GStreamerRegistryScanner::CodecLookupResult GStreamerRegistryScanner::isCodecSup
     String subType = slashIndex != notFound ? codec.substring(slashIndex + 1) : codec;
     auto codecName = caseSensitive == CaseSensitiveCodecName::Yes ? subType : subType.convertToASCIILowercase();
 
+#if PLATFORM(WPE)
+    bool supportsDVHCodec = false;
+    auto* scrData = screenData(primaryScreenDisplayID());
+    if (scrData && scrData->screenSupportsHighDynamicRange)
+        supportsDVHCodec = true;
+#endif // PLATFORM(WPE)
+
     CodecLookupResult result;
     if (codecName.startsWith("avc1"_s))
         result = isAVC1CodecSupported(configuration, codecName, shouldCheckForHardwareUse);
     else if (codecName.startsWith("hev1"_s) || codecName.startsWith("hvc1"_s))
         result = isHEVCCodecSupported(configuration, codecName, shouldCheckForHardwareUse);
+#if PLATFORM(WPE)
+    else if ((codecName.startsWith("dvhe"_s) || codecName.startsWith("dvh1"_s)) && !supportsDVHCodec)
+        result = { false, nullptr };
+#endif // PLATFORM(WPE)
     else {
         auto& codecMap = configuration == Configuration::Decoding ? m_decoderCodecMap : m_encoderCodecMap;
         for (const auto& [codecId, lookupResult] : codecMap) {

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -463,6 +463,11 @@
 #include <pal/cf/CoreTextSoftLink.h>
 #endif
 
+#if PLATFORM(WPE) && !ENABLE(WPE_PLATFORM)
+#include <WebCore/PlatformScreen.h>
+#include <WebCore/ScreenProperties.h>
+#endif // PLATFORM(WPE) && !ENABLE(WPE_PLATFORM)
+
 namespace WebKit {
 using namespace JSC;
 using namespace WebCore;
@@ -4813,6 +4818,20 @@ void WebPage::updatePreferences(const WebPreferencesStore& store)
 #endif
 
     m_page->settingsDidChange();
+
+#if PLATFORM(WPE) && !ENABLE(WPE_PLATFORM)
+    // On WPE, we don't have a way to get screen properties from the system, so
+    // we fake them here based on the settings.
+    auto* currentScreenData = WebCore::screenData(primaryScreenDisplayID());
+    if (!currentScreenData || currentScreenData->screenSupportsHighDynamicRange != settings.screenSupportsHDR()) {
+        WebCore::ScreenData data;
+        data.screenSupportsHighDynamicRange = settings.screenSupportsHDR();
+        WebCore::ScreenProperties props;
+        props.primaryDisplayID = 1; // Fake display ID
+        props.screenDataMap.add(props.primaryDisplayID, WTFMove(data));
+        WebCore::setScreenProperties(props);
+    }
+#endif // PLATFORM(WPE) && !ENABLE(WPE_PLATFORM
 }
 
 #if ENABLE(DATA_DETECTION)


### PR DESCRIPTION
Some applications (like AppleTV+) explicitly checks MSE for DV codecs support and select proper stream based on that. Browser needs to report that Dolby vision codecs are supported.

List 'dvhe' and 'dvh1' codecs in GStreamer registry scanner but make sure they are exposed only if platform screen supports HDR.

WPEPlatform provides screen properties throuhg ScreenManager. When disabled, use fake screen properties with HDR support based on page settings.

For WPE port only.<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/9b6a71a057b2f37e3241da414274ec39e3b50581

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/169 "Built successfully") | [✅ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/76 "Passed tests") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/170 "Built successfully") | [✅ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/10/builds/78 "Passed tests") 
<!--EWS-Status-Bubble-End-->