### PR TITLE
[GStreamer] Filter HDR content in MediaCapabilities querry

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
@@ -1005,7 +1005,6 @@ ASCIILiteral GStreamerRegistryScanner::configurationNameForLogging(Configuration
 
 GStreamerRegistryScanner::RegistryLookupResult GStreamerRegistryScanner::isConfigurationSupported(Configuration configuration, const MediaConfiguration& mediaConfiguration) const
 {
-    bool isSupported = false;
     bool isUsingHardware = false;
 #ifndef GST_DISABLE_GST_DEBUG
     ASCIILiteral configLogString = configurationNameForLogging(configuration);
@@ -1020,11 +1019,33 @@ GStreamerRegistryScanner::RegistryLookupResult GStreamerRegistryScanner::isConfi
             videoConfiguration.bitrate, videoConfiguration.framerate);
 #endif
 
+#if PLATFORM(WPE)
+        auto* scrData = screenData(primaryScreenDisplayID());
+        if (!scrData || !scrData->screenSupportsHighDynamicRange) {
+            // Check HDR metadata field
+            if (videoConfiguration.hdrMetadataType.has_value()) {
+                return { false, false, nullptr };
+            }
+            // Transfer function (EOTF)
+            if (videoConfiguration.transferFunction.has_value()) {
+                auto tf = videoConfiguration.transferFunction.value();
+                // compare to your enum values for PQ/HLG; adjust names if different
+                if (tf == TransferFunction::PQ || tf == TransferFunction::HLG) {
+                    return { false, false, nullptr };
+                }
+            }
+        }
+#endif // PLATFORM(WPE)
         auto contentType = ContentType(videoConfiguration.contentType);
-        isSupported = isContainerTypeSupported(configuration, contentType.containerType());
+        if (!isContainerTypeSupported(configuration, contentType.containerType()))
+            return { false, false, nullptr };
+
         auto codecs = contentType.codecs();
-        if (!codecs.isEmpty())
+        if (!codecs.isEmpty()) {
+            if (!areAllCodecsSupported(configuration, codecs, false))
+                return { false, false, nullptr };
             isUsingHardware = areAllCodecsSupported(configuration, codecs, true);
+        }
     }
 
     if (mediaConfiguration.audio) {
@@ -1035,10 +1056,11 @@ GStreamerRegistryScanner::RegistryLookupResult GStreamerRegistryScanner::isConfi
             audioConfiguration.bitrate.value_or(0), audioConfiguration.samplerate.value_or(0));
 #endif
         auto contentType = ContentType(audioConfiguration.contentType);
-        isSupported = isContainerTypeSupported(configuration, contentType.containerType());
+        if (!isContainerTypeSupported(configuration, contentType.containerType()))
+            return { false, false, nullptr };
     }
 
-    return { isSupported, isUsingHardware, nullptr };
+    return { true, isUsingHardware, nullptr };
 }
 
 #if USE(GSTREAMER_WEBRTC)


### PR DESCRIPTION
[GStreamer] Filter HDR content in MediaCapabilities querry

Improve MediaCapabilites decoding support:
    1) Filter HDR related fields if screen doesn't support HDR.
    2) Both video and audio needs to be supported
    3) Include codecs check into the supported result

This patch is based on HDR screen props setting from https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1562 but this change wasn't properly tested yet so pushing it separately

<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/d417ff3983b528cff9efd07787c32869a8331afe

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/171 "Built successfully") | [✅ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/78 "Passed tests") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/172 "Built successfully") | [✅ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/10/builds/80 "Passed tests") 
<!--EWS-Status-Bubble-End-->