### PR TITLE
[GStreamer] Fix various mediastream and pad probe buffer leaks report…

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -1898,4 +1898,14 @@ GstBuffer* gst_buffer_new_memdup(gconstpointer data, gsize size)
 }
 #endif
 
+#if !GST_CHECK_VERSION(1, 27, 0)
+void gst_pad_probe_info_set_buffer(GstPadProbeInfo* info, GstBuffer* buffer)
+{
+    g_return_if_fail(info->type & GST_PAD_PROBE_TYPE_BUFFER);
+
+    gst_clear_mini_object(&info->data);
+    info->data = buffer;
+}
+#endif
+
 #endif // USE(GSTREAMER)

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -461,4 +461,8 @@ private:
 GstBuffer* gst_buffer_new_memdup(gconstpointer data, gsize size);
 #endif
 
+#if !GST_CHECK_VERSION(1, 27, 0)
+void gst_pad_probe_info_set_buffer(GstPadProbeInfo*, GstBuffer*);
+#endif
+
 #endif // USE(GSTREAMER)

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameMetadataGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameMetadataGStreamer.cpp
@@ -61,14 +61,17 @@ GType videoFrameMetadataAPIGetType()
 
 const GstMetaInfo* videoFrameMetadataGetInfo();
 
-std::pair<GstBuffer*, VideoFrameMetadataGStreamer*> ensureVideoFrameMetadata(GstBuffer* buffer)
+static std::pair<GRefPtr<GstBuffer>, VideoFrameMetadataGStreamer*> ensureVideoFrameMetadata(GRefPtr<GstBuffer>&& buffer)
 {
-    auto* meta = getInternalVideoFrameMetadata(buffer);
+    auto* meta = getInternalVideoFrameMetadata(buffer.get());
     if (meta)
-        return { buffer, meta };
+        return { WTFMove(buffer), meta };
 
-    buffer = gst_buffer_make_writable(buffer);
-    return { buffer, VIDEO_FRAME_METADATA_CAST(gst_buffer_add_meta(buffer, videoFrameMetadataGetInfo(), nullptr)) };
+    IGNORE_WARNINGS_BEGIN("cast-align");
+    auto modifiedBuffer = adoptGRef(gst_buffer_make_writable(buffer.leakRef()));
+    IGNORE_WARNINGS_END;
+    meta = VIDEO_FRAME_METADATA_CAST(gst_buffer_add_meta(modifiedBuffer.get(), videoFrameMetadataGetInfo(), nullptr));
+    return { WTFMove(modifiedBuffer), meta };
 }
 
 const GstMetaInfo* videoFrameMetadataGetInfo()
@@ -90,8 +93,8 @@ const GstMetaInfo* videoFrameMetadataGetInfo()
                 if (!GST_META_TRANSFORM_IS_COPY(type))
                     return FALSE;
 
-                auto* frameMeta = VIDEO_FRAME_METADATA_CAST(meta);
-                auto [buf, copyMeta] = ensureVideoFrameMetadata(buffer);
+                auto frameMeta = VIDEO_FRAME_METADATA_CAST(meta);
+                auto copyMeta = VIDEO_FRAME_METADATA_CAST(gst_buffer_add_meta(buffer, videoFrameMetadataGetInfo(), nullptr));
                 copyMeta->priv->videoSampleMetadata = frameMeta->priv->videoSampleMetadata;
 
                 Locker frameMetaLocker { frameMeta->priv->lock };
@@ -137,8 +140,8 @@ void webkitGstTraceProcessingTimeForElement(GstElement* element)
     static auto probeType = static_cast<GstPadProbeType>(GST_PAD_PROBE_TYPE_PUSH | GST_PAD_PROBE_TYPE_BUFFER);
 
     gst_pad_add_probe(sinkPad.get(), probeType, [](GstPad*, GstPadProbeInfo* info, gpointer userData) -> GstPadProbeReturn {
-        auto [modifiedBuffer, meta] = ensureVideoFrameMetadata(GST_PAD_PROBE_INFO_BUFFER(info));
-        GST_PAD_PROBE_INFO_DATA(info) = modifiedBuffer;
+        auto [modifiedBuffer, meta] = ensureVideoFrameMetadata(GRefPtr(GST_PAD_PROBE_INFO_BUFFER(info)));
+        gst_pad_probe_info_set_buffer(info, modifiedBuffer.leakRef());
         Locker locker { meta->priv->lock };
         meta->priv->processingTimes.set(GST_ELEMENT_CAST(userData), std::make_pair(gst_util_get_timestamp(), GST_CLOCK_TIME_NONE));
         return GST_PAD_PROBE_OK;

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.h
@@ -57,7 +57,7 @@ public:
     void unregisterCapturer(const GStreamerCapturer&);
     void stopCapturing(const String& persistentId);
 
-    void teardown();
+    virtual void teardown();
 
 private:
     void addDevice(GRefPtr<GstDevice>&&);
@@ -83,6 +83,7 @@ class GStreamerVideoCaptureDeviceManager final : public GStreamerCaptureDeviceMa
     friend class NeverDestroyed<GStreamerVideoCaptureDeviceManager>;
 public:
     static GStreamerVideoCaptureDeviceManager& singleton();
+
     CaptureDevice::DeviceType deviceType() final { return CaptureDevice::DeviceType::Camera; }
 };
 

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp
@@ -69,7 +69,7 @@ GStreamerCapturer::GStreamerCapturer(const char* sourceFactory, GRefPtr<GstCaps>
 
 GStreamerCapturer::~GStreamerCapturer()
 {
-    tearDown();
+    tearDown(true);
 }
 
 void GStreamerCapturer::tearDown(bool disconnectSignals)
@@ -93,7 +93,9 @@ void GStreamerCapturer::tearDown(bool disconnectSignals)
     m_valve = nullptr;
     m_src = nullptr;
     m_capsfilter = nullptr;
+    m_sink = nullptr;
     m_pipeline = nullptr;
+    m_caps = nullptr;
 }
 
 GStreamerCapturerObserver::~GStreamerCapturerObserver()
@@ -163,8 +165,9 @@ GstElement* GStreamerCapturer::createSource()
         gst_pad_add_probe(srcPad.get(), static_cast<GstPadProbeType>(GST_PAD_PROBE_TYPE_PUSH | GST_PAD_PROBE_TYPE_BUFFER), [](GstPad*, GstPadProbeInfo* info, gpointer) -> GstPadProbeReturn {
             VideoFrameTimeMetadata metadata;
             metadata.captureTime = MonotonicTime::now().secondsSinceEpoch();
-            auto modifiedBuffer = webkitGstBufferSetVideoFrameTimeMetadata(GRefPtr(GST_PAD_PROBE_INFO_BUFFER(info)), metadata);
-            GST_PAD_PROBE_INFO_DATA(info) = modifiedBuffer.leakRef();
+            auto buffer = GST_PAD_PROBE_INFO_BUFFER(info);
+            auto modifiedBuffer = webkitGstBufferSetVideoFrameTimeMetadata(GRefPtr(buffer), metadata);
+            gst_pad_probe_info_set_buffer(info, modifiedBuffer.leakRef());
             return GST_PAD_PROBE_OK;
         }, nullptr, nullptr);
     }

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.h
@@ -55,7 +55,7 @@ public:
     GStreamerCapturer(const char* sourceFactory, GRefPtr<GstCaps>&&, CaptureDevice::DeviceType);
     virtual ~GStreamerCapturer();
 
-    void tearDown(bool disconnectSignals = true);
+    virtual void tearDown(bool disconnectSignals);
 
     void addObserver(GStreamerCapturerObserver&);
     void removeObserver(GStreamerCapturerObserver&);

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp
@@ -316,7 +316,8 @@ void GStreamerIncomingTrackProcessor::installRtpBufferPadProbe(const GRefPtr<Gst
         }
 
         auto modifiedBuffer = webkitGstBufferSetVideoFrameTimeMetadata(GRefPtr(buffer), WTFMove(videoFrameTimeMetadata));
-        GST_PAD_PROBE_INFO_DATA(info) = modifiedBuffer.leakRef();
+        gst_pad_probe_info_set_buffer(info, modifiedBuffer.leakRef());
+
         return GST_PAD_PROBE_OK;
     }, gst_caps_new_empty_simple("timestamp/x-ntp"), reinterpret_cast<GDestroyNotify>(gst_caps_unref));
 }

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp
@@ -90,6 +90,13 @@ GstElement* GStreamerVideoCapturer::createSource()
     return src;
 }
 
+void GStreamerVideoCapturer::tearDown(bool disconnectSignals)
+{
+    GStreamerCapturer::tearDown(disconnectSignals);
+    if (disconnectSignals)
+        m_videoSrcMIMETypeFilter = nullptr;
+}
+
 GstElement* GStreamerVideoCapturer::createConverter()
 {
     if (isCapturingDisplay()) {
@@ -159,8 +166,9 @@ bool GStreamerVideoCapturer::setSize(const IntSize& size)
 
     GST_INFO_OBJECT(m_pipeline.get(), "Setting size to %dx%d", width, height);
     m_size = size;
-    m_caps = adoptGRef(gst_caps_copy(m_caps.get()));
-    gst_caps_set_simple(m_caps.get(), "width", G_TYPE_INT, width, "height", G_TYPE_INT, height, nullptr);
+    auto modifiedCaps = adoptGRef(gst_caps_make_writable(m_caps.leakRef()));
+    gst_caps_set_simple(modifiedCaps.get(), "width", G_TYPE_INT, width, "height", G_TYPE_INT, height, nullptr);
+    gst_caps_take(&m_caps.outPtr(), modifiedCaps.leakRef());
 
     g_object_set(m_capsfilter.get(), "caps", m_caps.get(), nullptr);
     return true;
@@ -190,8 +198,9 @@ bool GStreamerVideoCapturer::setFrameRate(double frameRate)
     if (UNLIKELY(!m_capsfilter))
         return false;
 
-    m_caps = adoptGRef(gst_caps_copy(m_caps.get()));
-    gst_caps_set_simple(m_caps.get(), "framerate", GST_TYPE_FRACTION, numerator, denominator, nullptr);
+    auto modifiedCaps = adoptGRef(gst_caps_make_writable(m_caps.leakRef()));
+    gst_caps_set_simple(modifiedCaps.get(), "framerate", GST_TYPE_FRACTION, numerator, denominator, nullptr);
+    gst_caps_take(&m_caps.outPtr(), modifiedCaps.leakRef());
 
     GST_INFO_OBJECT(m_pipeline.get(), "Setting framerate to %f fps", frameRate);
     g_object_set(m_capsfilter.get(), "caps", m_caps.get(), nullptr);

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.h
@@ -38,7 +38,11 @@ public:
     GStreamerVideoCapturer(const char* sourceFactory, CaptureDevice::DeviceType);
     ~GStreamerVideoCapturer() = default;
 
+
     GstElement* createSource() final;
+
+    void tearDown(bool disconnectSignals) final;
+
     GstElement* createConverter() final;
     const char* name() final { return "Video"; }
 


### PR DESCRIPTION
…ed by the GStreamer leak tracer

https://bugs.webkit.org/show_bug.cgi?id=298834

Reviewed by Xabier Rodriguez-Calvar.

The most important leaks were in the buffer pad probes that modify buffers, the previous ones were not un-reffed. The other leaks were about the pipewire device manager and several other GStreamer objects not cleared before gst_deinit() was called.

Driving-by in the video capturer modify existing caps instead of doing copies.

* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp: (gst_pad_probe_info_set_buffer):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h:
* Source/WebCore/platform/graphics/gstreamer/VideoFrameMetadataGStreamer.cpp: (videoFrameMetadataGetInfo):
(webkitGstTraceProcessingTimeForElement):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp: (WebCore::GStreamerCapturer::~GStreamerCapturer):
(WebCore::GStreamerCapturer::tearDown):
(WebCore::GStreamerCapturer::createSource):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp: (WebCore::GStreamerIncomingTrackProcessor::installRtpBufferPadProbe):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp: (WebCore::GStreamerVideoCapturer::tearDown):
(WebCore::GStreamerVideoCapturer::setSize):
(WebCore::GStreamerVideoCapturer::setFrameRate):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.h:

Canonical link: https://commits.webkit.org/299959@main

# Pull Request Template

## File a Bug

All changes should be associated with a bug. The WebKit project is currently using [Bugzilla](https://bugs.webkit.org) as our bug tracker. Note that multiple changes may be associated with a single bug.

## Provided Tooling

The WebKit Project strongly recommends contributors use [`Tools/Scripts/git-webkit`](https://github.com/WebKit/WebKit/tree/main/Tools/Scripts/git-webkit) to generate pull requests. See [Setup](https://github.com/WebKit/WebKit/wiki/Contributing#setup) and [Contributing Code](https://github.com/WebKit/WebKit/wiki/Contributing#contributing-code) for how to do this.

## Template

If a contributor wishes to file a pull request manually, the template is below. Manually-filed pull requests should contain their commit message as the pull request description, and their commit message should be formatted like the template below.

Additionally, the pull request should be mentioned on [Bugzilla](https://bugs.webkit.org), labels applied to the pull request matching the component and version of the [Bugzilla](https://bugs.webkit.org) associated with the pull request and the pull request assigned to its author.

<pre>
< bug title >
<a href="https://bugs.webkit.org/enter_bug.cgi">https://bugs.webkit.org/show_bug.cgi?id=#####</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* path/changed.ext:
(function):
(class.function):

</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/9a8729f31561fd54c59a0bf88db60f8f9e346f5c

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/173 "Built successfully") | [✅ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/80 "Passed tests") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/174 "Built successfully") | [✅ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/10/builds/82 "Passed tests") 
<!--EWS-Status-Bubble-End-->