### PR TITLE
[2.46][GST][MSE] Skip playback state update while EOS

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -477,6 +477,15 @@ void MediaPlayerPrivateGStreamerMSE::updateStates()
         }
     }
 
+    if (m_isEndReached) {
+        // m_isEndReached always makes HTMLMediaElement think playback is paused,
+        // despite the actual pipeline state. Notifying playback state change
+        // here would sync HTMLMediaElement state to paused while the pipeline
+        // could be in PLAYING state. That could effectively pause the pipeline
+        // without any pause request from the user.
+        shouldUpdatePlaybackState = false;
+    }
+
     if (!shouldUpdatePlaybackState)
         return;
 


### PR DESCRIPTION
Playback state change notification syncs Media Client (HTMLMediaElement) state with current player state:
    commit fb0730ec3038fd990d002dba3550838819daa035:

    The platform backend may change state, for example as a result
    of an external plugin controlling the backend, so we need to
    react to this situation by syncing up the WebCore state with the
    platform backend.

    We call playInternal()/pauseInternal() depending on the backend
    state, to trigger the corresponding DOM events to match the state.

Sending that notification on EOS condition may effectively pause the pipeline without user request becasue the GST player reports it is paused m_isEndReached is set.


PS. We already had a bunch of problems with that playback state change notification and the way of how HTMLMediaElement handles mediaPlayerPlaybackStateChanged(). In 2.46 that part was added because of sleep disable while it was completely missing in 2.38. Maybe we should handle sleep disable separately and skip that mediaPlayerPlaybackStateChanged() at all<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/46455f00d154622b1bce9ef79db93f12f7cb1ec3

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/174 "Built successfully") | [✅ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/81 "Passed tests") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/175 "Built successfully") | [✅ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/10/builds/83 "Passed tests") 
<!--EWS-Status-Bubble-End-->