### PR TITLE
[WPE][MSE][GStreamer] Fix QuotaExceededError for init segment when no…

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
@@ -339,7 +339,7 @@ size_t SourceBufferPrivateGStreamer::platformMaximumBufferSize() const
     });
 
     // If any track type size isn't specified, we consider that it has no limit and the values from the
-    // element have to be used. Otherwise, the track limits are accumulative. If everything is specified
+    // element have to be used. Otherwise, the track limits are accumulative. If at least video and audio is specified
     // but there's no track (eg: because we're processing an init segment that we don't know yet which
     // kind of track(s) is going to generate) we assume that the 3 kind of tracks might appear (audio,
     // video, text) and use all the accumulated limits at once to make room for any possible outcome.
@@ -380,7 +380,7 @@ size_t SourceBufferPrivateGStreamer::platformMaximumBufferSize() const
         if (hasText || m_tracks.empty()) {
             if (maxBufferSizeText)
                 bufferSize += maxBufferSizeText;
-            else
+            else if (hasText)
                 break;
         }
         if (bufferSize)


### PR DESCRIPTION
… text limit specified

Ignore missing "Text" limit in MSE_MAX_BUFFER_SIZE env when calculating max buffer size for init segment.
With current impl, missing any of track type A/V/T from MSE_MAX_BUFFER_SIZE causes WebKit to fallback to default value from HTMLMediaElement/settings that is ~15MB for WPE. Providing higher video and audio limits in the env we can still end up in QuotaExceededError because of that.

Assume video and audio limits are enough to calculate accumulative max buffer size for any type of track.<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/c9318f661394bce2b0535147d7169398268f96d0

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/178 "Built successfully") | [✅ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/83 "Passed tests") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/179 "Built successfully") | [✅ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/10/builds/85 "Passed tests") 
<!--EWS-Status-Bubble-End-->