### PR TITLE
[wpe-2.46] Fix build errors with malloc_heap_breakdown enabled

### DIFF
--- a/Source/WTF/wtf/text/StringImpl.cpp
+++ b/Source/WTF/wtf/text/StringImpl.cpp
@@ -37,6 +37,7 @@
 #include <wtf/text/SymbolRegistry.h>
 #include <wtf/unicode/CharacterNames.h>
 #include <wtf/unicode/UTF8Conversion.h>
+#include <wtf/NeverDestroyed.h>
 
 #if STRING_STATS
 #include <unistd.h>

--- a/Source/WebCore/animation/FrameRateAligner.cpp
+++ b/Source/WebCore/animation/FrameRateAligner.cpp
@@ -27,7 +27,6 @@
 #include "FrameRateAligner.h"
 
 namespace WebCore {
-DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(FrameRateAligner);
 
 FrameRateAligner::FrameRateAligner() = default;
 

--- a/Source/WebCore/loader/cache/CachedSVGDocumentReference.h
+++ b/Source/WebCore/loader/cache/CachedSVGDocumentReference.h
@@ -27,6 +27,7 @@
 
 #include "CachedResourceHandle.h"
 #include "CachedSVGDocumentClient.h"
+#include "LoaderMalloc.h"
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {

--- a/Source/WebCore/platform/graphics/Region.cpp
+++ b/Source/WebCore/platform/graphics/Region.cpp
@@ -27,6 +27,7 @@
 #include "Region.h"
 
 #include <stdio.h>
+#include <wtf/NeverDestroyed.h>
 #include <wtf/text/TextStream.h>
 
 // A region class based on the paper "Scanline Coherent Shape Algebra"

--- a/Source/WebCore/rendering/style/StyleSurroundData.cpp
+++ b/Source/WebCore/rendering/style/StyleSurroundData.cpp
@@ -21,6 +21,7 @@
 
 #include "config.h"
 #include "StyleSurroundData.h"
+#include <wtf/NeverDestroyed.h>
 
 namespace WebCore {
 


### PR DESCRIPTION
<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/f6f6f8e52a9a9be400d7ae68468fa301a2decf3b

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/179 "Built successfully") | [✅ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/84 "Passed tests") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/180 "Built successfully") | [✅ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/10/builds/86 "Passed tests") 
<!--EWS-Status-Bubble-End-->