### PR TITLE
RDKDEV-1148: Release CDM resources when not used

### DIFF
--- a/Source/WebCore/Modules/encryptedmedia/MediaKeys.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeys.cpp
@@ -161,6 +161,9 @@ void MediaKeys::detachCDMClient(CDMClient& client)
 {
     ASSERT(m_cdmClients.contains(client));
     m_cdmClients.remove(client);
+    if (m_cdmClients.computesEmpty()) {
+        m_instance->releaseCDM();
+    }
 }
 
 void MediaKeys::attemptToResumePlaybackOnClients()

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -6097,6 +6097,12 @@ void HTMLMediaElement::stop()
 
     if (m_mediaSession)
         m_mediaSession->stopSession();
+
+    if (m_mediaKeys) {
+        m_mediaKeys->detachCDMClient(*this);
+        if (m_player)
+            m_player->cdmInstanceDetached(m_mediaKeys->cdmInstance());
+    }
 }
 
 void HTMLMediaElement::suspend(ReasonForSuspension reason)

--- a/Source/WebCore/platform/encryptedmedia/CDMInstance.h
+++ b/Source/WebCore/platform/encryptedmedia/CDMInstance.h
@@ -107,6 +107,7 @@ public:
     virtual void setStorageDirectory(const String&) = 0;
     virtual const String& keySystem() const = 0;
     virtual RefPtr<CDMInstanceSession> createSession() = 0;
+    virtual void releaseCDM() { };
 
     enum class HDCPStatus : uint8_t {
         Unknown,

--- a/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp
@@ -141,7 +141,6 @@ bool CDMFactoryThunder::supportsKeySystem(const String& keySystem)
 
 CDMPrivateThunder::CDMPrivateThunder(const String& keySystem)
     : m_keySystem(keySystem)
-    , m_thunderSystem(opencdm_create_system(keySystem.utf8().data()))
 {
 };
 
@@ -204,7 +203,9 @@ void CDMPrivateThunder::loadAndInitialize()
 
 bool CDMPrivateThunder::supportsServerCertificates() const
 {
-    bool isSupported = opencdm_system_supports_server_certificate(m_thunderSystem.get());
+    OpenCDMSystem *ocdmSystem = opencdm_create_system(m_keySystem.utf8().data());
+    bool isSupported = opencdm_system_supports_server_certificate(ocdmSystem);
+    opencdm_destruct_system(ocdmSystem);
     GST_DEBUG("server certificate supported %s", boolForPrinting(isSupported));
     return isSupported;
 }
@@ -258,6 +259,9 @@ void CDMInstanceThunder::initializeWithConfiguration(const CDMKeySystemConfigura
 void CDMInstanceThunder::setServerCertificate(Ref<SharedBuffer>&& certificate,  SuccessCallback&& callback)
 {
     auto data = certificate->extractData();
+    if (m_thunderSystem.get() == nullptr) {
+        m_thunderSystem.reset(opencdm_create_system(m_keySystem.utf8().data()));
+    }
     OpenCDMError error = opencdm_system_set_server_certificate(m_thunderSystem.get(), const_cast<uint8_t*>(data.data()), data.size());
     callback(!error ? Succeeded : Failed);
 }
@@ -265,6 +269,12 @@ void CDMInstanceThunder::setServerCertificate(Ref<SharedBuffer>&& certificate,  
 void CDMInstanceThunder::setStorageDirectory(const String& storageDirectory)
 {
     FileSystem::makeAllDirectories(storageDirectory);
+}
+
+void CDMInstanceThunder::releaseCDM()
+{
+    GST_DEBUG("release CDM resources");
+    m_thunderSystem.reset();
 }
 
 CDMInstanceSessionThunder::CDMInstanceSessionThunder(CDMInstanceThunder& instance)

--- a/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.h
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.h
@@ -99,7 +99,6 @@ public:
 
 private:
     String m_keySystem;
-    Thunder::UniqueThunderSystem m_thunderSystem;
 };
 
 class CDMInstanceThunder final : public CDMInstanceProxy {
@@ -114,6 +113,7 @@ public:
     void setStorageDirectory(const String&) final;
     const String& keySystem() const final { return m_keySystem; }
     RefPtr<CDMInstanceSession> createSession() final;
+    void releaseCDM() final;
 
     OpenCDMSystem& thunderSystem() const { return *m_thunderSystem.get(); };
 


### PR DESCRIPTION
When HTMLMediaElement has been created in WPE and HTMLMediaElement::setMediaKeys() method was called to set DRM keys, CDMThunder implementation already allocates CDM resources and they're not released until HTMLMediaElement object is destructed.
HTMLMediaElement destruction is non-deterministic and it's relying on Garbage Collector.
In this case very often we observe that after WPE exit (WPE process is not closed, but some #boot address is being loaded), CDM resources are not released immediately and CDM can't be used by other applications like IP Player or Netflix.

Proposed solution introduces following changes:

1) CDMPrivateThunder implementation doesn't occupy CDM resources permanently, as it only needs CDM resources to check if server certificate is supported so CDM resources can be acquired before check and released afterwards

2) CDMInstanceThunder object's CDM resources are released on HTMLMediaElement::stop() to not wait for Garbage Collector<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/2c36c43da756f466651a3a1677655494d11a6ce1

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| [✅ 🛠 wpe-238-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/1/builds/166 "Built successfully") | [✅ 🧪 wpe-238-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/5/builds/57 "Passed tests") 
| [✅ 🛠 wpe-238-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/8/builds/165 "Built successfully") | [✅ 🧪 wpe-238-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/6/builds/67 "Passed tests") 
| | 
| | 
<!--EWS-Status-Bubble-End-->