### PR TITLE
Improve Quota Manager accuracy to mitigate "disk full" issues

### DIFF
--- a/Source/WebKit/NetworkProcess/storage/OriginQuotaManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/OriginQuotaManager.cpp
@@ -110,6 +110,15 @@ bool OriginQuotaManager::grantWithCurrentQuota(uint64_t spaceRequested)
     }
     m_quotaCountdown = *m_usage < m_quota ? m_quota - *m_usage : 0;
 
+    // As the overhead to store data by the underlying storage backend may be significant, the quota countdown may not
+    // be accurate enough. Depending on the data size persisted, we may run out of disk space on constraint devices even
+    // when quota is in theory available (when a lot of data is written without checking the real usage).
+    // To mitigate this, we force the read of the real usage after consuming 25% of the theoretically available space.
+    // If the remaining available space is too small that the overhead becomes insignificant (100 KB), we just take all
+    // remaining space is available from that point on
+    if (m_quotaCountdown > (100*1024))
+        m_quotaCountdown /= 4;
+
     return grantFastPath(spaceRequested);
 }
 


### PR DESCRIPTION
Depending on the backend used to store data controlled by the Quota Manager (e.g. SQLite), the amount of actual disk space used to store a given amount of data may be much greater than the size of the actual data.
Currently, the real disk usage is used only at start to determine the available quota, and after exhausting this quota, which ignores the overhead.

While the eviction algorithm will attempt to free data across different origins, depending on the origin and total ratios configured, as well as the amount of data written by the app without restarting the browser, we may end up running out of space on constrained devices.

To mitigate this, whenever the Quota Manager receives a space request, we force the read of the real usage after consuming 25% of the theoretically available space since the last time the real usage was evaluated. If the remaining available space is too small that the overhead becomes insignificant (100 KB), we just take all remaining space available from that point on.<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/1e8d68c9a5090b522340abe0a1622dd31d49089d

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/181 "Built successfully") | [❌ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/85 "Found 11 new test failures: http/tests/IndexedDB/storage-limit-1.https.html, http/tests/IndexedDB/storage-limit-2.https.html, http/tests/IndexedDB/storage-limit.https.html, http/wpt/cache-storage/cache-quota-add.any.html, imported/w3c/web-platform-tests/service-workers/cache-storage/cache-match.https.any.html, imported/w3c/web-platform-tests/service-workers/cache-storage/cache-match.https.any.serviceworker.html, imported/w3c/web-platform-tests/service-workers/cache-storage/cache-match.https.any.sharedworker.html, imported/w3c/web-platform-tests/service-workers/cache-storage/cache-match.https.any.worker.html, imported/w3c/web-platform-tests/service-workers/cache-storage/serviceworker/cache-match.https.html, imported/w3c/web-platform-tests/service-workers/cache-storage/window/cache-match.https.html ... (failure)") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/182 "Built successfully") | [❌ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/10/builds/87 "Found 11 new test failures: http/tests/IndexedDB/storage-limit-1.https.html, http/tests/IndexedDB/storage-limit-2.https.html, http/tests/IndexedDB/storage-limit.https.html, http/wpt/cache-storage/cache-quota-add.any.html, imported/w3c/web-platform-tests/service-workers/cache-storage/cache-match.https.any.html, imported/w3c/web-platform-tests/service-workers/cache-storage/cache-match.https.any.serviceworker.html, imported/w3c/web-platform-tests/service-workers/cache-storage/cache-match.https.any.sharedworker.html, imported/w3c/web-platform-tests/service-workers/cache-storage/cache-match.https.any.worker.html, imported/w3c/web-platform-tests/service-workers/cache-storage/serviceworker/cache-match.https.html, imported/w3c/web-platform-tests/service-workers/cache-storage/window/cache-match.https.html ... (failure)") 
<!--EWS-Status-Bubble-End-->