### PR TITLE
[2.38][GST] Ensure GST initialized before playing with GST Quirks

### DIFF
--- a/Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp
@@ -55,6 +55,7 @@ GStreamerQuirksManager::GStreamerQuirksManager(bool isForTesting, bool loadQuirk
 {
     static std::once_flag debugRegisteredFlag;
     std::call_once(debugRegisteredFlag, [] {
+        ensureGStreamerInitialized();
         GST_DEBUG_CATEGORY_INIT(webkit_quirks_debug, "webkitquirks", 0, "WebKit Quirks");
     });
 


### PR DESCRIPTION
GStreamerQuirksManager verifies each quirk with isPlatformSupported() that usually relies on gst elements presense in the registry. Calling this without gst_init called fails for every gst element and rejects all quirks.

The problem exists for apps that don't use any of canPlayType() or isTypeSupported() that handle gst_init 

In the case I was analyzing, with audio only live stream playback, the gst_init was called in MediaPlayerPrivateGStreamer constructor, just after isHolePunchRenderingEnabled() that initialized gst quirks singleton:
```
#if USE(TEXTURE_MAPPER_GL) && USE(NICOSIA)
    m_nicosiaLayer = Nicosia::ContentLayer::create(Nicosia::ContentLayerTextureMapperImpl::createFactory(*this,
        [&]() -> Ref<TextureMapperPlatformLayerProxy> {
            if (isHolePunchRenderingEnabled())
                return adoptRef(*new TextureMapperPlatformLayerProxyGL);

#if USE(TEXTURE_MAPPER_DMABUF)
            if (webKitDMABufVideoSinkIsEnabled() && webKitDMABufVideoSinkProbePlatform())
                return adoptRef(*new TextureMapperPlatformLayerProxyDMABuf);
#endif
            return adoptRef(*new TextureMapperPlatformLayerProxyGL);
        }()));
#endif

    ensureGStreamerInitialized();
    m_audioSink = createAudioSink();
```

internally<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/60d9e167a0ac7c9ae6812f78f8a5e20ea180c422

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| [✅ 🛠 wpe-238-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/1/builds/168 "Built successfully") | [✅ 🧪 wpe-238-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/5/builds/58 "Passed tests") 
| [✅ 🛠 wpe-238-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/8/builds/167 "Built successfully") | [✅ 🧪 wpe-238-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/6/builds/68 "Passed tests") 
| | 
| | 
<!--EWS-Status-Bubble-End-->