### PR TITLE
[2.46][GST]Ensure GST initialized before playing with GST Quirks

### DIFF
--- a/Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp
@@ -56,6 +56,7 @@ GStreamerQuirksManager::GStreamerQuirksManager(bool isForTesting, bool loadQuirk
 {
     static std::once_flag debugRegisteredFlag;
     std::call_once(debugRegisteredFlag, [] {
+        ensureGStreamerInitialized();
         GST_DEBUG_CATEGORY_INIT(webkit_quirks_debug, "webkitquirks", 0, "WebKit Quirks");
     });
 


### PR DESCRIPTION
GStreamerQuirksManager verifies each quirk with isPlatformSupported() that usually relies on gst elements presense in the registry. Calling this without gst_init called fails for every gst element and rejects all quirks.

The problem exists for apps that don't use any of canPlayType() or isTypeSupported() that handle gst_init internally

More details in #1583 <!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/cfa5698a73f0002d8de2a61ed1ebbf0b7cf4f958

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/183 "Built successfully") | [✅ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/86 "Passed tests") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/184 "Built successfully") | [✅ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/10/builds/88 "Passed tests") 
<!--EWS-Status-Bubble-End-->