### PR TITLE
ARRISEOS-48107: Remove API Implementation

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp
@@ -553,6 +553,13 @@ void CDMInstanceSessionThunder::sessionFailure()
     m_sessionChangedCallbacks.clear();
 }
 
+void CDMInstanceSessionThunder::sessionSuccess()
+{
+    for (auto& sessionChangedCallback : m_sessionChangedCallbacks)
+        sessionChangedCallback(true, nullptr);
+    m_sessionChangedCallbacks.clear();
+}
+
 void CDMInstanceSessionThunder::updateLicense(const String& sessionID, LicenseType, Ref<SharedBuffer>&& response, LicenseUpdateCallback&& callback)
 {
     ASSERT_UNUSED(sessionID, sessionID == m_sessionID);
@@ -683,8 +690,17 @@ void CDMInstanceSessionThunder::removeSessionData(const String& sessionID, Licen
             callback(m_keyStore.allKeysAs(MediaKeyStatus::InternalError), nullptr, SuccessValue::Failed);
         }
     });
-    if (!m_session || m_sessionID.isEmpty() || opencdm_session_remove(m_session->get()))
+    if (!m_session || m_sessionID.isEmpty() || opencdm_session_remove(m_session->get())) {
         sessionFailure();
+    } else {
+        GST_DEBUG("opencdm_session_remove success");
+        sessionSuccess();
+    }
+    m_session = BoxPtr<OpenCDMSession>();
+    auto instance = cdmInstanceThunder();
+    if (instance)
+        instance->unrefAllKeysFrom(m_keyStore);
+    m_keyStore.clear();
 }
 
 void CDMInstanceSessionThunder::storeRecordOfKeyUsage(const String&)

--- a/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.h
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.h
@@ -151,6 +151,7 @@ private:
     void errorCallback(RefPtr<SharedBuffer>&&);
     CDMInstanceSession::KeyStatus status(const KeyIDType&) const;
     void sessionFailure();
+    void sessionSuccess();
 
     // FIXME: Check all original uses of these attributes.
     String m_sessionID;


### PR DESCRIPTION
**Description:**
Previously AppleTV+ App was calling Remove() API on playback exit, but there was issue observed after multiple playback and exits. There was "DRM decrypt error" observed in this scenario. 
Later there was workaround from App side to use MediaKeySession::close() instead, which resolved the issue.

But implementation of remove() API was resumed to support if any OTT Apps might use MediaKeySession::remove(). 

**Change Summary**
This change is added as part of implementing remove() functionality. Following is implemented as part of this PR:
1. After successful cleaning of persistent license at OCDM server side, session keys are cleared from key store.
2. Media key status is set to released.
3. Handling of session success was missing previously, hence even though OCDM successfully returned after license removal, media key status was set as InternalError. Now this is fixed by handling success case.

Details of separate PR related to actual implementation of remove() functionality at OCDM server side will be added here once PR is ready.

Sample Test HTML App (attached) is used to test the functionality
[Playready-4.0-Updated.html](https://github.com/user-attachments/files/23896525/Playready-4.0-Updated.html)

**Dependencies/Gaps:**
1. Currently, there are no OTT Apps available supporting persistent license sessions. 
2. Hence, only cleaning of persistent license at CPE side is implemented in OCDM server side.
5. License Release message notification to license server after license deletion at CPE side is not implemented due to above dependencies.


