### PR TITLE
[BFCache][WebSocket] don't dispatch error if websocket is closed in p…

### DIFF
--- a/Source/WebCore/Modules/websockets/WebSocket.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocket.cpp
@@ -503,7 +503,7 @@ void WebSocket::contextDestroyed()
 
 void WebSocket::suspend(ReasonForSuspension reason)
 {
-    if (!m_channel)
+    if (!m_channel || m_state == CLOSING || m_state == CLOSED)
         return;
 
     if (reason == ReasonForSuspension::BackForwardCache) {


### PR DESCRIPTION
…agehide

https://bugs.webkit.org/show_bug.cgi?id=303619

Reviewed by Alexey Proskuryakov.

When the WebSocket is suspending and it was closed, or it is in the middle of closing, it does not need to be closed separately (and dispatch the error event).

There is already WPT test for that case. Now the test passes.

* LayoutTests/imported/w3c/web-platform-tests/websockets/back-forward-cache-with-open-websocket-connection-and-close-it-in-pagehide.window-expected.txt:
* Source/WebCore/Modules/websockets/WebSocket.cpp: (WebCore::WebSocket::suspend):

Canonical link: https://commits.webkit.org/304082@main