### PR TITLE
[WebGL] avoid 'forceContextLost' notifications during destruction

### DIFF
--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -700,9 +700,9 @@ void WebGLRenderingContextBase::destroyGraphicsContextGL()
     removeActivityStateChangeObserver();
 
     if (m_context) {
-        // first release the big textures allocated for the FBOs
-        m_context->reshape(0,0);
         m_context->setClient(nullptr);
+        // release the big textures allocated for the FBOs
+        m_context->reshape(0,0);
         m_context = nullptr;
         removeActiveContext(*this);
     }


### PR DESCRIPTION
GraphicsContextGLANGLE::reshape(0, 0) may trigger `forceContextLost` if it fails to reshape FBOs. If it happens during HTMLCanvasElement destruction, it will capture a reference to an HTMLCanvasElement that is being destroyed, and lead to a double destruction of HTMLCanvasElement and random crashes.

Here is callstack showing how forceLostContext captures a reference to HTMLCanvasElement during destruction:

```
(gdb) bt                                                                                                                                                                                         12:45:09 [99/1811#0  WebCore::HTMLCanvasElement::queueTaskKeepingObjectAlive (this=0xf2f8bd80, source=WebCore::TaskSource::WebGL, task=...) at ../git/Source/WebCore/html/HTMLCanvasElement.cpp:1001
#1  0xf66bd716 in WebCore::WebGLRenderingContextBase::scheduleTaskToDispatchContextLostEvent (this=this@entry=0xe06cce50) at ../lib32-recipe-sysroot/usr/include/c++/11.3.0/bits/unique_ptr.h:172
#2  0xf66cb5fc in WebCore::WebGLRenderingContextBase::forceLostContext (this=0xe06cce50, mode=mode@entry=WebCore::WebGLRenderingContextBase::RealLostContext)
    at ../git/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:4664
#3  0xf66cb61e in WebCore::WebGLRenderingContextBase::forceContextLost (this=<optimized out>) at ../git/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:5559
#4  0xf6a4c360 in WebCore::GraphicsContextGL::forceContextLost (this=<optimized out>) at ../git/Source/WebCore/platform/graphics/GraphicsContextGL.cpp:625
#5  0xf57168a2 in WebCore::GraphicsContextGLANGLE::reshape (this=0xc3033368, width=<optimized out>, height=<optimized out>) at ../git/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:755
#6  0xf66cc36c in WebCore::WebGLRenderingContextBase::destroyGraphicsContextGL (this=this@entry=0xe06cce50) at ../git/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:704
#7  0xf66cc99a in WebCore::WebGLRenderingContextBase::~WebGLRenderingContextBase (this=this@entry=0xe06cce50, __in_chrg=<optimized out>) at ../git/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:684
#8  0xf66cd4e4 in WebCore::WebGLRenderingContext::~WebGLRenderingContext (this=0xe06cce50, __in_chrg=<optimized out>) at ../git/Source/WebCore/html/canvas/WebGLRenderingContext.cpp:120
#9  0xf66d0a40 in non-virtual thunk to WebCore::WebGLRenderingContext::~WebGLRenderingContext() () from ./usr/lib/libWPEWebKit-1.1.so.0
#10 0xf65b157e in std::default_delete<WebCore::CanvasRenderingContext>::operator() (__ptr=<optimized out>, this=<optimized out>) at ../lib32-recipe-sysroot/usr/include/c++/11.3.0/bits/unique_ptr.h:79
#11 std::__uniq_ptr_impl<WebCore::CanvasRenderingContext, std::default_delete<WebCore::CanvasRenderingContext> >::reset (__p=0x0, this=0xf2f8be38)
    at ../lib32-recipe-sysroot/usr/include/c++/11.3.0/bits/unique_ptr.h:182
#12 std::unique_ptr<WebCore::CanvasRenderingContext, std::default_delete<WebCore::CanvasRenderingContext> >::reset (__p=0x0, this=0xf2f8be38)
    at ../lib32-recipe-sysroot/usr/include/c++/11.3.0/bits/unique_ptr.h:456
#13 std::unique_ptr<WebCore::CanvasRenderingContext, std::default_delete<WebCore::CanvasRenderingContext> >::operator=(decltype(nullptr)) (this=0xf2f8be38)
    at ../lib32-recipe-sysroot/usr/include/c++/11.3.0/bits/unique_ptr.h:397
#14 WebCore::HTMLCanvasElement::~HTMLCanvasElement (this=0xf2f8bd80, __in_chrg=<optimized out>) at ../git/Source/WebCore/html/HTMLCanvasElement.cpp:153
#15 0xf65b4c6e in WebCore::HTMLCanvasElement::operator delete (size=200, object=0xf2f8bd80) at ../git/Source/WebCore/html/HTMLCanvasElement.h:66
#16 WebCore::HTMLCanvasElement::~HTMLCanvasElement (this=0xf2f8bd80, __in_chrg=<optimized out>) at ../git/Source/WebCore/html/HTMLCanvasElement.cpp:155
#17 0xf6480d90 in WebCore::Node::removedLastRef (this=0xf2f8bd80) at ../git/Source/WebCore/dom/Node.cpp:2856
#18 0xf599b7ae in WebCore::Node::derefAllowingPartiallyDestroyed (this=<optimized out>) at ../git/Source/WebCore/dom/Node.h:883
#19 WebCore::Node::deref (this=<optimized out>) at ../git/Source/WebCore/dom/Node.h:863
#20 WebCore::EventTarget::deref (this=<optimized out>) at ../git/Source/WebCore/dom/Node.h:979
#21 WTF::DefaultRefDerefTraits<WebCore::EventTarget>::derefIfNotNull (ptr=<optimized out>) at WTF/Headers/wtf/Ref.h:62
#22 WTF::Ref<WebCore::EventTarget, WTF::RawPtrTraits<WebCore::EventTarget>, WTF::DefaultRefDerefTraits<WebCore::EventTarget> >::~Ref (this=<optimized out>, __in_chrg=<optimized out>) at WTF/Headers/wtf/Ref.h:82
#23 WebCore::JSDOMWrapper<WebCore::EventTarget, WTF::RawPtrTraits<WebCore::EventTarget> >::~JSDOMWrapper (this=<optimized out>, __in_chrg=<optimized out>) at ../git/Source/WebCore/bindings/js/JSDOMWrapper.h:74
#24 WebCore::JSEventTarget::~JSEventTarget (this=<optimized out>, __in_chrg=<optimized out>) at WebCore/DerivedSources/JSEventTarget.h:29
#25 WebCore::JSEventTarget::destroy (cell=<optimized out>) at WebCore/DerivedSources/JSEventTarget.cpp:198
#26 0xf53a972c in JSC::JSDestructibleObjectDestroyFunc::operator() (cell=<optimized out>, this=<optimized out>) at ../git/Source/JavaScriptCore/runtime/JSDestructibleObjectHeapCellType.cpp:43
#27 JSC::JSDestructibleObjectHeapCellType::destroy (this=<optimized out>, vm=..., cell=<optimized out>) at ../git/Source/JavaScriptCore/runtime/JSDestructibleObjectHeapCellType.cpp:61
#28 0xf50984f8 in JSC::Subspace::destroy (this=<optimized out>, vm=..., cell=cell@entry=0xdc6527c8) at ../git/Source/JavaScriptCore/heap/Subspace.cpp:66
#29 0xf5094f1e in JSC::PreciseAllocation::sweep (this=0xdc652788) at ../git/Source/JavaScriptCore/heap/PreciseAllocation.h:65
#30 JSC::PreciseAllocation::sweep (this=this@entry=0xdc652788) at ../git/Source/JavaScriptCore/heap/PreciseAllocation.cpp:270
#31 0xf5093fa0 in JSC::MarkedSpace::sweepPreciseAllocations (this=this@entry=0xdf9000e8) at ../git/Source/JavaScriptCore/heap/MarkedSpace.cpp:237
#32 0xf5069ae8 in JSC::Heap::sweepInFinalize (this=0xdf900088) at ../git/Source/JavaScriptCore/heap/Heap.cpp:2305
#33 JSC::Heap::finalize (this=this@entry=0xdf900088) at ../git/Source/JavaScriptCore/heap/Heap.cpp:2239
#34 0xf5069de2 in JSC::Heap::handleNeedFinalize (this=this@entry=0xdf900088, oldState=<optimized out>) at ../git/Source/JavaScriptCore/heap/Heap.cpp:2177
#35 0xf506d918 in JSC::Heap::handleNeedFinalize (this=<optimized out>) at ../git/Source/JavaScriptCore/heap/Heap.cpp:2188
#36 JSC::Heap::finishChangingPhase (this=this@entry=0xdf900088, conn=conn@entry=JSC::GCConductor::Mutator) at ../git/Source/JavaScriptCore/heap/Heap.cpp:1789
#37 0xf506e452 in JSC::Heap::changePhase (nextPhase=JSC::CollectorPhase::NotRunning, conn=JSC::GCConductor::Mutator, this=0xdf900088) at ../git/Source/JavaScriptCore/heap/Heap.cpp:1764
#38 JSC::Heap::runEndPhase (this=this@entry=0xdf900088, conn=conn@entry=JSC::GCConductor::Mutator) at ../git/Source/JavaScriptCore/heap/Heap.cpp:1754
#39 0xf5078e88 in JSC::Heap::runCurrentPhase (currentThreadState=0xff860e2c, conn=JSC::GCConductor::Mutator, this=0xdf900088) at ../git/Source/JavaScriptCore/heap/Heap.cpp:1397
#40 JSC::Heap::runCurrentPhase (this=0xdf900088, conn=<optimized out>, currentThreadState=0xff860e2c) at ../git/Source/JavaScriptCore/heap/Heap.cpp:1354
#41 0xf507a564 in operator() (state=..., __closure=0xff860e7c) at ../git/Source/JavaScriptCore/heap/Heap.cpp:2016
#42 WTF::ScopedLambdaFunctor<void(JSC::CurrentThreadState&), JSC::Heap::collectInMutatorThread()::<lambda(JSC::CurrentThreadState&)> >::implFunction(void *, JSC::CurrentThreadState &) (argument=0xff860e74,
    arguments#0=...) at WTF/Headers/wtf/ScopedLambda.h:106
#43 0xf508f182 in WTF::ScopedLambda<void(JSC::CurrentThreadState&)>::operator()<JSC::CurrentThreadState&> (this=<optimized out>) at WTF/Headers/wtf/ScopedLambda.h:56
#44 JSC::callWithCurrentThreadState (lambda=...) at ../git/Source/JavaScriptCore/heap/MachineStackMarker.cpp:227
#45 0xf5078ece in JSC::Heap::collectInMutatorThread (this=this@entry=0xdf900088) at ../lib32-recipe-sysroot/usr/include/c++/11.3.0/bits/move.h:77
#46 0xf5078f06 in JSC::Heap::stopIfNecessarySlow (oldState=5, this=0xdf900088) at ../git/Source/JavaScriptCore/heap/Heap.cpp:1997
#47 JSC::Heap::stopIfNecessarySlow (this=0xdf900088, oldState=5) at ../git/Source/JavaScriptCore/heap/Heap.cpp:1978
#48 0xf50793e2 in JSC::Heap::stopIfNecessarySlow (this=this@entry=0xdf900088) at ../git/Source/JavaScriptCore/heap/Heap.cpp:1969
#49 0xf5079968 in JSC::Heap::stopIfNecessary (this=0xdf900088) at ../git/Source/JavaScriptCore/heap/HeapInlines.h:264
#50 JSC::Heap::collectIfNecessaryOrDefer (this=0xdf900088, deferralContext=deferralContext@entry=0x0) at ../git/Source/JavaScriptCore/heap/Heap.cpp:2844
```

