### PR TITLE
[GStreamer] use WebCore application runtime checks

### DIFF
--- a/Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp
@@ -36,9 +36,9 @@
 #include "GStreamerQuirkRealtek.h"
 #include "GStreamerQuirkRialto.h"
 #include "GStreamerQuirkWesteros.h"
+#include "RuntimeApplicationChecks.h"
 #include <wtf/NeverDestroyed.h>
 #include <wtf/OptionSet.h>
-#include <wtf/RuntimeApplicationChecks.h>
 #include <wtf/text/StringView.h>
 
 namespace WebCore {


### PR DESCRIPTION
wpe-2.46 branch has WTF and WebCore runtime application checks. Using WTF ones results in crashes due to false assertions.
