### PR TITLE
[GStreamer] change network state to idle when delaying the load

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -407,7 +407,7 @@ void MediaPlayerPrivateGStreamer::load(const String& urlString)
 
     // Reset network and ready states. Those will be set properly once
     // the pipeline pre-rolled.
-    m_networkState = MediaPlayer::NetworkState::Loading;
+    m_networkState = m_isDelayingLoad ? MediaPlayer::NetworkState::Idle : MediaPlayer::NetworkState::Loading;
     player->networkStateChanged();
     m_readyState = MediaPlayer::ReadyState::HaveNothing;
     player->readyStateChanged();


### PR DESCRIPTION
Sometimes applications create a `<video>` tag with `preload="none"` and then remove the element from the DOM without ever starting playback. This results in the video element being leaked, because HTMLMediaElement::virtualHasPendingActivity() retains the element while its network state is still "Loading".