### PR TITLE
[GStreamer][WebRTC] increase size of apps max-bytes for video tracks

### DIFF
--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
@@ -166,6 +166,8 @@ public:
 
         g_object_set(m_src.get(), "is-live", TRUE, "format", GST_FORMAT_TIME, "emit-signals", TRUE, "min-percent", 100,
             "do-timestamp", isCaptureTrack, "handle-segment-change", TRUE, nullptr);
+        if (track.isVideo())
+            g_object_set(m_src.get(), "max-bytes", static_cast<guint64>(2 * MB), nullptr);
         g_signal_connect(m_src.get(), "enough-data", G_CALLBACK(+[](GstElement*, InternalSource* data) {
             data->m_enoughData = true;
         }), this);

--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoDecoderFactory.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoDecoderFactory.cpp
@@ -86,7 +86,7 @@ public:
     bool Configure(const webrtc::VideoDecoder::Settings& codecSettings) override
     {
         m_src = makeElement("appsrc");
-        g_object_set(m_src, "is-live", TRUE, "do-timestamp", TRUE, "max-buffers", 2, "max-bytes", 0, nullptr);
+        g_object_set(m_src, "is-live", TRUE, "do-timestamp", TRUE, "max-buffers", static_cast<gint64>(2), "max-bytes", static_cast<guint64>(0), nullptr);
 
         GRefPtr<GstCaps> caps = nullptr;
         auto capsfilter = CreateFilter();


### PR DESCRIPTION
The default 200'000 is not enough and leads to frame drops during pipeline buildup.

Also, this PR adds an explicit type cast for max-buffers/max-bytes arguments set in GStreamerVideoDecoderFactory.cpp