### PR TITLE
[GStreamer][Broadcom] fix incorrect casting of GstGhostPad to GstElement

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -2166,7 +2166,7 @@ void MediaPlayerPrivateGStreamer::handleMessage(GstMessage* message)
             }
         }
 
-        if (quirksManager.isEnabled() && quirksManager.needsBufferingPercentageCorrection())
+        if (quirksManager.isEnabled() && quirksManager.needsBufferingPercentageCorrection() && !(isMediaSource() || isMediaStreamPlayer()))
             quirksManager.setupBufferingPercentageCorrection(this, currentState, newState, GRefPtr<GstElement>(GST_ELEMENT(GST_MESSAGE_SRC(message))));
 
         if (!messageSourceIsPlaybin || m_isDelayingLoad)

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcomBase.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcomBase.cpp
@@ -141,7 +141,7 @@ void GStreamerQuirkBroadcomBase::setupBufferingPercentageCorrection(MediaPlayerP
                 GRefPtr<GstPad> peerSrcPad = adoptGRef(gst_pad_get_peer(sinkPad));
                 if (!peerSrcPad)
                     continue; // And end the loop, because there's only one srcpad.
-                GRefPtr<GstElement> peerElement = adoptGRef(GST_ELEMENT(gst_pad_get_parent(peerSrcPad.get())));
+                GRefPtr<GstElement> peerElement = adoptGRef(gst_pad_get_parent_element(peerSrcPad.get()));
 
                 // If it's NOT a multiqueue, it's probably a parser like aacparse. We try to traverse before it.
                 if (peerElement && g_strcmp0(G_OBJECT_TYPE_NAME(element.get()), "GstMultiQueue")) {
@@ -150,7 +150,7 @@ void GStreamerQuirkBroadcomBase::setupBufferingPercentageCorrection(MediaPlayerP
                         if (!peerSrcPad)
                             continue; // And end the loop.
                         // Now we hopefully have peerElement pointing to the multiqueue.
-                        peerElement = adoptGRef(GST_ELEMENT(gst_pad_get_parent(peerSrcPad.get())));
+                        peerElement = adoptGRef(gst_pad_get_parent_element(peerSrcPad.get()));
                         break;
                     }
                 }


### PR DESCRIPTION
The problem is observed when brcm audio/video filters are plugged into the "inner-parser" in WebKitThunderParser. The
setupBufferingPercentageCorrection tries and fails to cast GstGhostPad to GstElement. The gst_pad_get_parent_element fits better for the use case.

Also, this change disables the correction of buffering percentage for MSE and MediaStream playbacks.