### PR TITLE
Fix BitmapTexturePool size and improve mem usage

### DIFF
--- a/Source/WTF/wtf/MemoryPressureHandler.cpp
+++ b/Source/WTF/wtf/MemoryPressureHandler.cpp
@@ -309,7 +309,19 @@ void MemoryPressureHandler::setMemoryUsagePolicyBasedOnFootprints(size_t footpri
 
     RELEASE_LOG(MemoryPressure, "Memory usage policy changed (PID=%d): %s -> %s", getpid(), toString(m_memoryUsagePolicy).characters(), toString(newPolicy).characters());
     m_memoryUsagePolicy = newPolicy;
-    memoryPressureStatusChanged();
+
+    switch (m_memoryUsagePolicy) {
+    case MemoryUsagePolicy::Unrestricted:
+        setMemoryPressureStatus(SystemMemoryPressureStatus::Normal);
+        break;
+    case MemoryUsagePolicy::Conservative:
+        setMemoryPressureStatus(SystemMemoryPressureStatus::Warning);
+        break;
+    case MemoryUsagePolicy::Strict:
+    case MemoryUsagePolicy::StrictSynchronous:
+        setMemoryPressureStatus(SystemMemoryPressureStatus::Critical);
+        break;
+    }
 }
 
 void MemoryPressureHandler::setMemoryFootprintNotificationThresholds(Vector<size_t>&& thresholds, WTF::Function<void(size_t)>&& handler)

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexturePool.cpp
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexturePool.cpp
@@ -33,7 +33,7 @@
 namespace WebCore {
 
 #if defined(BITMAP_TEXTURE_POOL_MAX_SIZE_IN_MB) && BITMAP_TEXTURE_POOL_MAX_SIZE_IN_MB > 0
-static constexpr size_t poolSizeLimit = BITMAP_TEXTURE_POOL_MAX_SIZE_IN_MB * MB;
+static constexpr size_t poolSizeLimit = BITMAP_TEXTURE_POOL_MAX_SIZE_IN_MB * MB / 4; // size limit in pixels
 #else
 static constexpr size_t poolSizeLimit = std::numeric_limits<size_t>::max();
 #endif

--- a/Source/WebCore/platform/graphics/texmap/coordinated/TiledBackingStore.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/TiledBackingStore.cpp
@@ -57,7 +57,7 @@ void TiledBackingStore::createTilesIfNeeded(const IntRect& unscaledVisibleRect, 
 {
     IntRect scaledContentsRect = mapFromContents(contentsRect);
     IntRect visibleRect = mapFromContents(unscaledVisibleRect);
-    float coverAreaMultiplier = MemoryPressureHandler::singleton().isUnderMemoryPressure() ? 1.0f : 2.0f;
+    float coverAreaMultiplier = (MemoryPressureHandler::singleton().isUnderMemoryPressure() || MemoryPressureHandler::singleton().isUnderMemoryWarning()) ? 1.0f : 2.0f;
 
     bool didChange = m_trajectoryVector != m_pendingTrajectoryVector || m_visibleRect != visibleRect || m_rect != scaledContentsRect || m_coverAreaMultiplier != coverAreaMultiplier;
     if (didChange || m_pendingTileCreation)


### PR DESCRIPTION
Occasional GPU mem spikes observed. This fixes a wrong pool size and adds a few tweeks to reduce those GPU mem spikes.

Author: Eugene Mutavchi <ievgen_mutavchi@comcast.com>