### PR TITLE
RDKEMW-9893: set option to enable new dtags.

### DIFF
--- a/Source/cmake/OptionsCommon.cmake
+++ b/Source/cmake/OptionsCommon.cmake
@@ -71,6 +71,15 @@ else ()
     set(LD_SUPPORTS_THIN_ARCHIVES FALSE)
     set(LD_SUPPORTS_DISABLE_NEW_DTAGS FALSE)
 endif ()
+
+if (LD_SUPPORTS_DISABLE_NEW_DTAGS)
+    set(DISABLE_NEW_DTAGS_DEFAULT ON)
+else ()
+    set(DISABLE_NEW_DTAGS_DEFAULT OFF)
+endif ()
+
+option(DISABLE_NEW_DTAGS "Disable new dtags" ${DISABLE_NEW_DTAGS_DEFAULT})
+
 unset(LD_VERSION)
 message(STATUS "Linker variant in use: ${LD_VARIANT} ")
 message(STATUS "  Linker supports thin archives - ${LD_SUPPORTS_THIN_ARCHIVES}")
@@ -112,10 +121,14 @@ message(STATUS "  Archiver supports thin archives - ${AR_SUPPORTS_THIN_ARCHIVES}
 # passing the option DT_RUNPATH is used, which can be overriden by the value
 # of LD_LIBRARY_PATH set in the environment, resulting in unexpected behaviour
 # for developers.
-if (LD_SUPPORTS_DISABLE_NEW_DTAGS)
+if (DISABLE_NEW_DTAGS)
     string(APPEND CMAKE_EXE_LINKER_FLAGS " -Wl,--disable-new-dtags")
     string(APPEND CMAKE_SHARED_LINKER_FLAGS " -Wl,--disable-new-dtags")
     string(APPEND CMAKE_MODULE_LINKER_FLAGS " -Wl,--disable-new-dtags")
+else ()
+    string(APPEND CMAKE_EXE_LINKER_FLAGS " -Wl,--enable-new-dtags")
+    string(APPEND CMAKE_SHARED_LINKER_FLAGS " -Wl,--enable-new-dtags")
+    string(APPEND CMAKE_MODULE_LINKER_FLAGS " -Wl,--enable-new-dtags")
 endif ()
 
 # Prefer thin archives by default if they can be both created by the


### PR DESCRIPTION
### Added option to enable new dtags.
**Explanation**:
This change introduces a Cmake option ENABLE_NEW_DTAGS to allow to use --enable-new-dtags for WPE Webkit build.
Primary goal is to force the linker to use DT_RUNPATH instead of legacy DT_RPATH. This change is important because:

1. DT_RUNPATH respects LD_LIBRARY_PATH unlike older DT_RPATH
2. This allows us to override system libraries or redirect library lookup at runtime without re-linkiing the entire Webkit.

**Changes:**

- Source/cmake/OptionsCommon.cmake