### PR TITLE
RDKEMW-9893: Load libWPEWebInspectorResources from launcher.

### DIFF
--- a/Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorUtils.cpp
+++ b/Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorUtils.cpp
@@ -43,7 +43,14 @@ GRefPtr<GBytes> backendCommands()
     static bool moduleLoaded = false;
 
     if (!moduleLoaded) {
-        GModule* resourcesModule = g_module_open(PKGLIBDIR G_DIR_SEPARATOR_S "libWPEWebInspectorResources.so", G_MODULE_BIND_LAZY);
+        const char* libDir = PKGLIBDIR;
+        GUniquePtr<char> tmp;
+        if (const char* path = g_getenv("WEBKIT_INJECTED_BUNDLE_PATH"); path && g_file_test(path, G_FILE_TEST_IS_DIR)) {
+            tmp.reset(g_build_filename(path, "..", nullptr));
+            libDir = tmp.get();
+        }
+        GUniquePtr<char> bundleFilename(g_build_filename(libDir, "libWPEWebInspectorResources.so", nullptr));
+        GModule* resourcesModule = g_module_open(bundleFilename.get(), G_MODULE_BIND_LAZY);
         if (!resourcesModule) {
             WTFLogAlways("Error loading libWPEWebInspectorResources.so: %s", g_module_error());
             return nullptr;


### PR DESCRIPTION
### Added libWPEWebInspectorResources from launcher widget .
Explanation:
The primary goal of this change is to allow the Webkit to lookup and load libWPEWebInspectorResources.so directly from a widget’s internal bundle.

### Fallback Mechanism: 
**Check Internal:** Look for resources inside the widget’s bundle.
**Check External:** If not found, fall back to the standard library/system path.