### PR TITLE
[WebKitSettings] Add API for OpportunisticSweepingAndGarbageCollectio…

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
@@ -198,6 +198,7 @@ enum {
     PROP_WEBRTC_UDP_PORTS_RANGE,
     PROP_ENABLE_NON_COMPOSITED_WEBGL,
     PROP_SCREEN_SUPPORTS_HDR,
+    PROP_OPPORTUNISTIC_SWEEPING_AND_GC,
     N_PROPERTIES,
 };
 
@@ -459,6 +460,9 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     case PROP_SCREEN_SUPPORTS_HDR:
         webkit_settings_set_screen_supports_hdr(settings, g_value_get_boolean(value));
         break;
+    case PROP_OPPORTUNISTIC_SWEEPING_AND_GC:
+        webkit_settings_set_opportunistic_sweeping_and_gc(settings, g_value_get_boolean(value));
+        break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propId, paramSpec);
         break;
@@ -699,6 +703,9 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         break;
     case PROP_SCREEN_SUPPORTS_HDR:
         g_value_set_boolean(value, webkit_settings_get_screen_supports_hdr(settings));
+        break;
+    case PROP_OPPORTUNISTIC_SWEEPING_AND_GC:
+        g_value_set_boolean(value, webkit_settings_get_opportunistic_sweeping_and_gc(settings));
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propId, paramSpec);
@@ -1893,6 +1900,20 @@ static void webkit_settings_class_init(WebKitSettingsClass* klass)
         _("Screen supports HDR"),
         _("Does screen support HDR."),
         FALSE,
+        readWriteConstructParamFlags);
+
+    /**
+     * WebKitSettings:opportunistic-sweeping-and-gc:
+     *
+     * Enable or disable opportunistic sweeping and garbage collection.
+     * GC timers will be postponed if any critical tasks are pending.
+     *
+     */
+    sObjProperties[PROP_OPPORTUNISTIC_SWEEPING_AND_GC] = g_param_spec_boolean(
+        "opportunistic-sweeping-and-gc",
+        _("Enable opportunistic sweeping and garbage collection"),
+        _("Whether opportunistic sweeping and garbage collection should be enabled"),
+        FEATURE_DEFAULT(OpportunisticSweepingAndGarbageCollectionEnabled),
         readWriteConstructParamFlags);
 
     g_object_class_install_properties(gObjectClass, N_PROPERTIES, sObjProperties);
@@ -4957,4 +4978,39 @@ webkit_settings_set_screen_supports_hdr(WebKitSettings* settings, gboolean scree
 
     priv->preferences->setScreenSupportsHDR(screenSupportsHDR);
     g_object_notify_by_pspec(G_OBJECT(settings), sObjProperties[PROP_SCREEN_SUPPORTS_HDR]);
+}
+
+/**
+ * webkit_settings_get_opportunistic_sweeping_and_gc:
+ * @settings: a #WebKitSettings
+ *
+ * Get the #WebKitSettings:opportunistic-sweeping-and-gc property.
+ *
+ * Returns: %TRUE if opportunistic sweeping and garbage collection is enabled or %FALSE otherwise.
+ */
+gboolean
+webkit_settings_get_opportunistic_sweeping_and_gc(WebKitSettings* settings)
+{
+    g_return_val_if_fail(WEBKIT_IS_SETTINGS(settings), FALSE);
+    return settings->priv->preferences->opportunisticSweepingAndGarbageCollectionEnabled();
+}
+
+/**
+ * webkit_settings_set_opportunistic_sweeping_and_gc:
+ * @settings: a #WebKitSettings
+ * @enabled: Value to be set
+ *
+ * Set the #WebKitSettings:opportunistic-sweeping-and-gc property.
+ */
+void
+webkit_settings_set_opportunistic_sweeping_and_gc(WebKitSettings* settings, gboolean enabled)
+{
+    g_return_if_fail(WEBKIT_IS_SETTINGS(settings));
+    WebKitSettingsPrivate* priv = settings->priv;
+    bool currentValue = priv->preferences->opportunisticSweepingAndGarbageCollectionEnabled();
+    if (currentValue == enabled)
+        return;
+
+    priv->preferences->setOpportunisticSweepingAndGarbageCollectionEnabled(enabled);
+    g_object_notify_by_pspec(G_OBJECT(settings), sObjProperties[PROP_OPPORTUNISTIC_SWEEPING_AND_GC]);
 }

--- a/Source/WebKit/UIProcess/API/glib/WebKitSettings.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitSettings.h.in
@@ -643,6 +643,12 @@ WEBKIT_API void
 webkit_settings_set_screen_supports_hdr                        (WebKitSettings* settings,
                                                                 gboolean        screenSupportsHDR);
 
+WEBKIT_API gboolean
+webkit_settings_get_opportunistic_sweeping_and_gc              (WebKitSettings* settings);
+WEBKIT_API void
+webkit_settings_set_opportunistic_sweeping_and_gc              (WebKitSettings* settings,
+                                                                gboolean        enabled);
+
 G_END_DECLS
 
 #endif /* WebKitSettings_h */


### PR DESCRIPTION
…nEnabled

We observe increased WebKit 2.46 average memory usage (vs 2.38) with OpportunisticSweepingAndGarbageCollectionEnabled. In case of LightningApps (webgl/non composited webgl) this option effectively disables GC timers in some cases (FullGCActivityCallback and EdenGCActivityCallback) and prevents them from running.
Initially reported as memory during video playback but I can observe it also with UI scrolling

The only source of GC is Heap.cpp:
```
2026-02-05 06:50:18 Requesting GC because bytes allocated this cycle: 855941 exceed bytes allowed: 817924 (critical) normal bytes: 715034 oversized bytes: 140907 last oversized: 66063
2026-02-05 06:50:18 [GC<0x8c014088>: START M 1020kb => FullCollection, v=0kb (C:0 M:0 P1:0 P2:0 P3:0) o=0 b=87 i#1:N<CsMsrShDMsm(0)> 21+0 v=140kb (C:28 M:0 P1:17 P2:27 P3:66) o=2 b=87 i#2:N<WsOJwJIT Worklists:
2026-02-05 06:50:18 Collector: [], Mutator: []> 0+0 v=140kb (C:28 M:0 P1:17 P2:27 P3:66) o=2 b=87 i#3:P<WsOJwJIT Worklists:
2026-02-05 06:50:18 Collector: [], Mutator: []MsrShCsMsm(0)DCbDomo> => 234kb, p=5.890000ms (max 173.480000), cycle 5.852000ms END]
2026-02-05 06:50:18 GC END!
2026-02-05 06:50:18 [GC<0x8c014088>: finalize 0.225000ms]
```

GC timers are blocked by OpportunisticTaskScheduler, where isBusyForTimerBasedGC() is always true because of requestAnimationFrame() callback that is set over and over for LightningApp and it considered as imminently scheduled task.
```
ScriptedAnimationController::CallbackId ScriptedAnimationController::registerCallback(Ref<RequestAnimationFrameCallback>&& callback)
{

    RefPtr<ImminentlyScheduledWorkScope> workScope;
    if (RefPtr page = this->page()) {
        workScope = page->opportunisticTaskScheduler().makeScheduledWorkScope();
```

Here is how WebProcess memory usage looks for hbomax app steady video playback with webkit 2.38:
marked moments are FullGCActivityCallback, beside that EdenGCActivityCallback triggers GC every 10sec
<img width="2474" height="788" alt="Screenshot From 2026-02-02 17-49-00" src="https://github.com/user-attachments/assets/a49a2654-1ce8-4dea-96c8-e7c09934c509" />
And here is how it looks with 2.46 where GC is invoked at spikes only, every ~1min. Full gc is marked with a red circle while other points are Eden GC
<img width="2474" height="788" alt="Screenshot From 2026-02-02 18-17-17" src="https://github.com/user-attachments/assets/280cead1-26e4-4f31-a5c2-8b65c5ba9e7e" />

Disabling OpportunisticSweepingAndGarbageCollectionEnabled brings back wpe-2.38 behavior.

https://github.com/WebKit/WebKit/commit/5c9eac47597dd0447d181e32ef2436cfce67791c
https://github.com/WebKit/WebKit/pull/20688