### PR TITLE
[ARMv7] Disable caches to reduce memory footprint

### DIFF
--- a/Source/JavaScriptCore/assembler/AssemblerBuffer.h
+++ b/Source/JavaScriptCore/assembler/AssemblerBuffer.h
@@ -119,6 +119,8 @@ namespace JSC {
             // from initialization
             poisonInlineBuffer();
 #endif
+            if constexpr (is32Bit())
+                return;
             if constexpr (type == AssemblerDataType::Code)
                 takeBufferIfLarger(*threadSpecificAssemblerData());
 #if ENABLE(JIT_SIGN_ASSEMBLER_BUFFER)
@@ -181,14 +183,16 @@ namespace JSC {
 
         ~AssemblerDataImpl()
         {
-            if constexpr (type == AssemblerDataType::Code)
-                threadSpecificAssemblerData()->takeBufferIfLarger(*this);
+            if constexpr (!is32Bit()) {
+                if constexpr (type == AssemblerDataType::Code)
+                    threadSpecificAssemblerData()->takeBufferIfLarger(*this);
 #if ENABLE(JIT_SIGN_ASSEMBLER_BUFFER)
-            if constexpr (type == AssemblerDataType::Hashes)
-                threadSpecificAssemblerHashes()->takeBufferIfLarger(*this);
+                if constexpr (type == AssemblerDataType::Hashes)
+                    threadSpecificAssemblerHashes()->takeBufferIfLarger(*this);
 #else
-            static_assert(type != AssemblerDataType::Hashes);
+                static_assert(type != AssemblerDataType::Hashes);
 #endif
+            }
             clear();
         }
 

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -499,8 +499,8 @@ bool hasCapacityToUseLargeGigacage();
     \
     v(Bool, useSuperSampler, false, Normal, nullptr) \
     \
-    v(Bool, useSourceProviderCache, true, Normal, "If false, the parser will not use the source provider cache. It's good to verify everything works when this is false. Because the cache is so successful, it can mask bugs."_s) \
-    v(Bool, useCodeCache, true, Normal, "If false, the unlinked byte code cache will not be used."_s) \
+    v(Bool, useSourceProviderCache, is64Bit(), Normal, "If false, the parser will not use the source provider cache. It's good to verify everything works when this is false. Because the cache is so successful, it can mask bugs."_s) \
+    v(Bool, useCodeCache, is64Bit(), Normal, "If false, the unlinked byte code cache will not be used."_s) \
     \
     v(Bool, useWasm, true, Normal, "Expose the Wasm global object."_s) \
     \


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=307206

Reviewed by NOBODY (OOPS!).

These caches don't make sense on devices where we are almost always hitting memory pressure anyway.
