### PR TITLE
[GST][MSE] RDKEMW-9777 Make sure to extend very first sample when DTS = 0 and PTS > 0.

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -449,7 +449,7 @@ static MediaTime bufferTimeToStreamTime(const GstSegment* segment, GstClockTime 
     return MediaTime(sign * streamTime, GST_SECOND);
 }
 
-void AppendPipeline::appsinkNewSample(const Track& track, GRefPtr<GstSample>&& sample)
+void AppendPipeline::appsinkNewSample(Track& track, GRefPtr<GstSample>&& sample)
 {
     ASSERT(isMainThread());
 
@@ -476,7 +476,8 @@ void AppendPipeline::appsinkNewSample(const Track& track, GRefPtr<GstSample>&& s
         GST_TRACE_OBJECT(track.appsinkPad.get(), "Mapped buffer to segment, PTS %" GST_TIME_FORMAT " -> %s DTS %" GST_TIME_FORMAT " -> %s",
             GST_TIME_ARGS(GST_BUFFER_PTS(buffer)), pts.toString().utf8().data(), GST_TIME_ARGS(GST_BUFFER_DTS(buffer)), dts.toString().utf8().data());
         mediaSample->setTimestamps(pts, dts);
-    } else if (!GST_BUFFER_DTS(buffer) && GST_BUFFER_PTS(buffer) > 0 && GST_BUFFER_PTS(buffer) <= 100'000'000) {
+    } else if (!GST_BUFFER_DTS(buffer) && GST_BUFFER_PTS(buffer) > 0 && GST_BUFFER_PTS(buffer) <= 100'000'000 &&
+               !track.hasExtendedFirstSample) {
         // Because a track presentation time starting at some close to zero, but not exactly zero time can cause unexpected
         // results for applications, we extend the duration of this first sample to the left so that it starts at zero.
         // This is relevant for files that should have an edit list but don't, or when using GStreamer < 1.16, where
@@ -484,6 +485,7 @@ void AppendPipeline::appsinkNewSample(const Track& track, GRefPtr<GstSample>&& s
 
         GST_DEBUG("Extending first sample of track '%s' to make it start at PTS=0 %" GST_PTR_FORMAT, track.trackId.string().utf8().data(), buffer);
         mediaSample->extendToTheBeginning();
+        track.hasExtendedFirstSample = true;
     }
 
     GST_TRACE_OBJECT(pipeline(), "append: trackId=%s PTS=%s DTS=%s DUR=%s presentationSize=%.0fx%.0f",
@@ -680,6 +682,10 @@ void AppendPipeline::resetParserState()
     // All processing related to the previous append has been aborted and the pipeline is idle.
     // We can listen again to new requests coming from the streaming thread.
     m_taskQueue.finishAborting();
+
+    // Reset the flag for extending the first sample, as we're starting fresh with new data.
+    for (std::unique_ptr<Track>& track : m_tracks)
+        track->hasExtendedFirstSample = false;
 
 #if (!(LOG_DISABLED || defined(GST_DISABLE_GST_DEBUG)))
     {

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.h
@@ -75,12 +75,14 @@ private:
             , streamType(streamType)
             , caps(caps)
             , presentationSize(presentationSize)
+            , hasExtendedFirstSample(false)
         { }
 
         AtomString trackId;
         StreamType streamType;
         GRefPtr<GstCaps> caps;
         FloatSize presentationSize;
+        bool hasExtendedFirstSample;
 
         // Needed by some formats. To simplify the code, parser can be a GstIdentity when not needed.
         GRefPtr<GstElement> parser;
@@ -116,7 +118,7 @@ private:
     static std::tuple<GRefPtr<GstCaps>, AppendPipeline::StreamType, FloatSize> parseDemuxerSrcPadCaps(GstCaps*);
     Ref<WebCore::TrackPrivateBase> makeWebKitTrack(int trackIndex);
     void appsinkCapsChanged(Track&);
-    void appsinkNewSample(const Track&, GRefPtr<GstSample>&&);
+    void appsinkNewSample(Track&, GRefPtr<GstSample>&&);
     void handleEndOfAppend();
     void didReceiveInitializationSegment();
 


### PR DESCRIPTION


This is backport of upstream wpe-2.46 commit
https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1601

This fixes the handling of invalid streams with multiple DTS = 0 samples. Modifying PTS values for all of them results in unexpected behavior, playback issues, PTS reordering, etc.

The problem was spotted in a video web application that uses TS -> MSE transmuxing, when starting video playback on some streams there was microblocks.

