### PR TITLE
[wpe-2.46] Reduce GPU mem usage / spikes

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/BitmapTexturePool.cpp
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexturePool.cpp
@@ -70,6 +70,9 @@ RefPtr<BitmapTexture> BitmapTexturePool::acquireTexture(const IntSize& size, Opt
         m_textures.append(Entry(BitmapTexture::create(size, flags)));
         selectedEntry = &m_textures.last();
         m_poolSize += size.unclampedArea();
+
+        if (flags.contains(BitmapTexture::Flags::DepthBuffer))
+            m_poolSize += size.unclampedArea();
     } else
         selectedEntry->m_texture->reset(size, flags);
 
@@ -100,6 +103,10 @@ void BitmapTexturePool::releaseUnusedTexturesTimerFired()
     m_textures.removeAllMatching([this, &minUsedTime](const Entry& entry) {
         if (entry.canBeReleased(minUsedTime)) {
             m_poolSize -= entry.m_texture->size().unclampedArea();
+
+            if (entry.m_texture->flags().contains(BitmapTexture::Flags::DepthBuffer))
+                m_poolSize -= entry.m_texture->size().unclampedArea();
+
             return true;
         }
         return false;

--- a/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
@@ -112,6 +112,12 @@ private:
         SharedGLData()
         {
             glGetIntegerv(GL_MAX_TEXTURE_SIZE, &m_maxTextureSize);
+
+#ifdef GL_TEXTURE_MAX_SIZE
+            // Limit the max texture size to allow textures reuse and reduce GPU mem spikes
+            if (m_maxTextureSize > GL_TEXTURE_MAX_SIZE)
+                m_maxTextureSize = GL_TEXTURE_MAX_SIZE;
+#endif
         }
 
         HashMap<unsigned, RefPtr<TextureMapperShaderProgram>> m_programs;

--- a/Source/cmake/OptionsWPE.cmake
+++ b/Source/cmake/OptionsWPE.cmake
@@ -382,6 +382,10 @@ if (USER_AGENT_BRANDING)
     add_definitions(-DUSER_AGENT_BRANDING=${USER_AGENT_BRANDING})
 endif ()
 
+if (GL_TEXTURE_MAX_SIZE)
+    add_definitions(-DGL_TEXTURE_MAX_SIZE=${GL_TEXTURE_MAX_SIZE})
+endif ()
+
 if (NOT EXISTS "${TOOLS_DIR}/glib/apply-build-revision-to-files.py")
     set(BUILD_REVISION "tarball")
 endif ()


### PR DESCRIPTION
Change creates a cap for the texture size to increase reuse of textures from the BitmapTexturePool.
A fix is also added to account for the depth buffer in the pool usage accounting algorithm.