### PR TITLE
[wpe-2.46] Avoid premature atspi interactions during initialization

### DIFF
--- a/Source/WebCore/accessibility/atspi/AccessibilityAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityAtspi.cpp
@@ -75,14 +75,14 @@ void AccessibilityAtspi::connect(const String& busAddress, const String& busName
 
 void AccessibilityAtspi::didConnect(GRefPtr<GDBusConnection>&& connection)
 {
-    m_connection = WTFMove(connection);
-    if (!m_connection) {
+    m_pendingConnection = WTFMove(connection);
+    if (!m_pendingConnection) {
         m_isConnecting = false;
         return;
     }
 
     RELEASE_ASSERT(g_dbus_is_name(m_busName.utf8().data()));
-    g_bus_own_name_on_connection(m_connection.get(), m_busName.utf8().data(), G_BUS_NAME_OWNER_FLAGS_DO_NOT_QUEUE,
+    g_bus_own_name_on_connection(m_pendingConnection.get(), m_busName.utf8().data(), G_BUS_NAME_OWNER_FLAGS_DO_NOT_QUEUE,
         [](GDBusConnection*, const char*, gpointer userData) {
             auto& atspi = *static_cast<AccessibilityAtspi*>(userData);
             atspi.didOwnName();
@@ -93,6 +93,7 @@ void AccessibilityAtspi::didConnect(GRefPtr<GDBusConnection>&& connection)
 void AccessibilityAtspi::didOwnName()
 {
     m_isConnecting = false;
+    m_connection = WTFMove(m_pendingConnection);
 
     for (auto& pendingRegistration : m_pendingRootRegistrations)
         registerRoot(pendingRegistration.root, WTFMove(pendingRegistration.interfaces), WTFMove(pendingRegistration.completionHandler));

--- a/Source/WebCore/accessibility/atspi/AccessibilityAtspi.h
+++ b/Source/WebCore/accessibility/atspi/AccessibilityAtspi.h
@@ -132,6 +132,7 @@ private:
     String m_busName;
     bool m_isConnecting { false };
     GRefPtr<GDBusConnection> m_connection;
+    GRefPtr<GDBusConnection> m_pendingConnection;
     GRefPtr<GDBusProxy> m_registry;
     Vector<PendingRootRegistration> m_pendingRootRegistrations;
     HashMap<CString, Vector<GUniquePtr<char*>>> m_eventListeners;


### PR DESCRIPTION
Currently, when the system is starting up, it will perform the atspi related initializations to allow clients to connect. When a client connects, the accessibility object cache is enabled via a call to AXObjectCache::enableAccessibility(). On certain platforms, a client may connect only if accesibility support is enabled via a user configurable menu option (e.g. to enable/disable voice guidance) to minimize unnecessary D-Bus traffic. Consequently, the accessibility object cache may not be enabled when the page loads and no accessibility related information will be gathered.

If the user enables accessibility without effectively leaving the browser (e.g. remote control shortcut), accessibility will not be operational on the currently loaded page. A page reload would be required or changes to the DOM tree, which may not happen depending on the app design (at least while on the page the user is navigating on).

To overcome this, the accessibility cache may be enabled by default (via custom patch). This leads to a race condition between the atspi init sequence waiting to take ownership of the bus name, and the page load causing state changes that lead to attempts to register objects:

AccessibilityAtspi::stateChanged() ->
    AccessibilityObjectAtspi::path () ->
        AccessibilityObjectAtspi::registerObject() ->
            AccessibilityAtspi::registerObject() ->
                RELEASE_ASSERT(!m_isConnecting);

To overcome this, we'll consider the connection as established to allow method calls to complete only after acquiring the bus name.