### PR TITLE
Keep PageLifecycleAPIEnabled disabled by default

### DIFF
--- a/Source/WTF/Scripts/Preferences/WebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferences.yaml
@@ -1722,9 +1722,9 @@ PageLifecycleAPIEnabled:
     WebKitLegacy:
       default: false
     WebKit:
-      default: true
+      default: false
     WebCore:
-      default: true
+      default: false
 
 PageVisibilityBasedProcessSuppressionEnabled:
   type: bool

--- a/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
@@ -1851,7 +1851,7 @@ static void webkit_settings_class_init(WebKitSettingsClass* klass)
         "enable-page-lifecycle",
         _("Enable Page Lifecycle"),
         _("Whether to enable the Page Lifecycle API."),
-        TRUE,
+        FALSE,
         readWriteConstructParamFlags);
 
     /**


### PR DESCRIPTION
to avoid regressions with current deployments