### PR TITLE
[GST] Expose VIDEO_DECODING_LIMIT through env variable

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
@@ -61,20 +61,16 @@ struct VideoDecodingLimits {
     {
     }
 };
-}
 
-#ifdef VIDEO_DECODING_LIMIT
-static std::optional<VideoDecodingLimits> videoDecoderLimitsDefaults()
+// Parses a video decoding limit string in format WIDTHxHEIGHT@FRAMERATE.
+static std::optional<VideoDecodingLimits> parseVideoDecodingLimit(const String& videoDecodingLimit)
 {
-    // VIDEO_DECODING_LIMIT should be in format: WIDTHxHEIGHT@FRAMERATE.
-    String videoDecodingLimit(String::fromUTF8(VIDEO_DECODING_LIMIT));
-
     if (videoDecodingLimit.isEmpty())
         return { };
 
     Vector<String> entries;
 
-    // Extract frame rate part from the VIDEO_DECODING_LIMIT: WIDTHxHEIGHT@FRAMERATE.
+    // Extract frame rate part: WIDTHxHEIGHT@FRAMERATE.
     videoDecodingLimit.split('@', [&entries](StringView item) {
         entries.append(item.toString());
     });
@@ -104,7 +100,40 @@ static std::optional<VideoDecodingLimits> videoDecoderLimitsDefaults()
 
     return { VideoDecodingLimits(width.value(), height.value(), frameRate.value()) };
 }
+
+// Returns the active VideoDecodingLimits, resolved once at first call.
+// WEBKIT_GST_VIDEO_DECODING_LIMIT env var takes precedence over the compile-time VIDEO_DECODING_LIMIT.
+// Format for both: WIDTHxHEIGHT@FRAMERATE (e.g. "1920x1080@30").
+static VideoDecodingLimits* resolveVideoDecodingLimits()
+{
+    static std::optional<VideoDecodingLimits> limits;
+    static std::once_flag onceFlag;
+    std::call_once(onceFlag, [] {
+        if (const char* envLimit = g_getenv("WEBKIT_GST_VIDEO_DECODING_LIMIT")) {
+            GST_DEBUG("WEBKIT_GST_VIDEO_DECODING_LIMIT env var is set: %s", envLimit);
+            limits = parseVideoDecodingLimit(String::fromUTF8(envLimit));
+            if (!limits)
+                GST_WARNING("Parsing WEBKIT_GST_VIDEO_DECODING_LIMIT env var failed: %s", envLimit);
+        }
+#ifdef VIDEO_DECODING_LIMIT
+        if (!limits) {
+            GST_DEBUG("VIDEO_DECODING_LIMIT compile-time definition is set: %s", VIDEO_DECODING_LIMIT);
+            limits = parseVideoDecodingLimit(String::fromUTF8(VIDEO_DECODING_LIMIT));
+            if (!limits) {
+                GST_WARNING("Parsing VIDEO_DECODING_LIMIT failed: %s", VIDEO_DECODING_LIMIT);
+                ASSERT_NOT_REACHED();
+            }
+        }
 #endif
+        if (limits) {
+            GST_DEBUG("Video decoding limits: max width=%u, max height=%u, max frame rate=%u",
+                limits->mediaMaxWidth, limits->mediaMaxHeight, limits->mediaMaxFrameRate);
+        }
+    });
+    return limits ? &*limits : nullptr;
+}
+
+} // namespace
 
 namespace WebCore {
 
@@ -808,22 +837,8 @@ bool GStreamerRegistryScanner::supportsFeatures(const String& features) const
 MediaPlayerEnums::SupportsType GStreamerRegistryScanner::isContentTypeSupported(Configuration configuration, const ContentType& contentType, const Vector<ContentType>& contentTypesRequiringHardwareSupport, CaseSensitiveCodecName caseSensitive) const
 {
     VideoDecodingLimits* videoDecodingLimits = nullptr;
-#ifdef VIDEO_DECODING_LIMIT
-    static std::optional<VideoDecodingLimits> videoDecodingLimitsDefaults;
-    static std::once_flag onceFlag;
-    if (configuration == Configuration::Decoding) {
-        std::call_once(onceFlag, [] {
-            videoDecodingLimitsDefaults = videoDecoderLimitsDefaults();
-            if (!videoDecodingLimitsDefaults) {
-                GST_WARNING("Parsing VIDEO_DECODING_LIMIT failed");
-                ASSERT_NOT_REACHED();
-                return;
-            }
-        });
-        if (videoDecodingLimitsDefaults)
-            videoDecodingLimits = &*videoDecodingLimitsDefaults;
-    }
-#endif
+    if (configuration == Configuration::Decoding)
+        videoDecodingLimits = resolveVideoDecodingLimits();
 
     using SupportsType = MediaPlayerEnums::SupportsType;
 


### PR DESCRIPTION
WEBKIT_GST_VIDEO_DECODING_LIMIT can now be set in runtime and it takes precedence over compile time definition VIDEO_DECODING_LIMIT.