### PR TITLE
Enable dumpInfoAndCrashForInvalidHandleV2 on non-Cocoa

### DIFF
--- a/Source/JavaScriptCore/heap/MarkedBlock.cpp
+++ b/Source/JavaScriptCore/heap/MarkedBlock.cpp
@@ -573,16 +573,14 @@ NO_RETURN_DUE_TO_CRASH NEVER_INLINE void MarkedBlock::dumpInfoAndCrashForInvalid
     }
 
     auto updateCrashLogMsg = [&](int line) {
-#if PLATFORM(COCOA)
         StringPrintStream out;
         out.printf("INVALID HANDLE [%d]: markedBlock=%p; heapCell=%p; cellFirst8Bytes=%#llx; subspaceHash=%#x; contiguousZeros=%lu; totalZeros=%lu; blockVM=%p; actualVM=%p; isBlockVMValid=%d; isBlockInSet=%d; isBlockInDir=%d; foundInBlockVM=%d;",
-            line, this, heapCell, cellFirst8Bytes, subspaceHash, contiguousZeroBytesHeadOfBlock, totalZeroBytesInBlock, blockVM, actualVM, isBlockVMValid, isBlockInSet, isBlockInDirectory, foundInBlockVM);
+            line, this, heapCell, static_cast<long long>(cellFirst8Bytes), subspaceHash, contiguousZeroBytesHeadOfBlock, totalZeroBytesInBlock, blockVM, actualVM, isBlockVMValid, isBlockInSet, isBlockInDirectory, foundInBlockVM);
         auto message = out.toCString();
+#if PLATFORM(COCOA)
         WTF::setCrashLogMessage(message.data());
-        dataLogLn(message.data());
-#else
-        UNUSED_PARAM(line);
 #endif
+        dataLogLn(message.data());
     };
     updateCrashLogMsg(__LINE__);
 


### PR DESCRIPTION
See discussion in #1622.<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/d6ad5c82a8cc15d72adddf605fa0f3a3c4ec19e6

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/190 "Built successfully") | [✅ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/89 "Passed tests") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/191 "Built successfully") | [✅ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/10/builds/91 "Passed tests") 
<!--EWS-Status-Bubble-End-->