### PR TITLE
Turn on testing class-static-block feature in test262

### DIFF
--- a/JSTests/test262/config.yaml
+++ b/JSTests/test262/config.yaml
@@ -19,7 +19,6 @@ skip:
     - resizable-arraybuffer
     - import-assertions
     - json-modules
-    - class-static-block
     - callable-boundary-realms
     - FinalizationRegistry.prototype.cleanupSome
     - Intl.DurationFormat


### PR DESCRIPTION
class-static-block feature was implemented and added in: https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1615<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/7c0b293996bb53815925d5f3f601f5bf23b660a6

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| [✅ 🛠 wpe-238-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/1/builds/183 "Built successfully") | [✅ 🧪 wpe-238-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/5/builds/67 "Passed tests") 
| [✅ 🛠 wpe-238-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/8/builds/181 "Built successfully") | [✅ 🧪 wpe-238-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/6/builds/77 "Passed tests") 
| | 
| | 
<!--EWS-Status-Bubble-End-->