### PR TITLE
[Linux] Fixes to the memory pressure monitor logging

### DIFF
--- a/Source/WebKit/UIProcess/linux/MemoryPressureMonitor.cpp
+++ b/Source/WebKit/UIProcess/linux/MemoryPressureMonitor.cpp
@@ -287,7 +287,7 @@ static int systemMemoryUsedAsPercentage(FILE* memInfoFile, FILE* zoneInfoFile)
         return -1;
 
     int memoryUsagePercentage = ((memoryTotal - memoryAvailable) * 100) / memoryTotal;
-    LOG_VERBOSE(MemoryPressure, "MemoryPressureMonitor: memory real (memory total=%zu MB) (memory available=%zu MB) (memory usage percentage=%d MB)", memoryTotal, memoryAvailable, memoryUsagePercentage);
+    LOG(MemoryPressure, "MemoryPressureMonitor::memory: real (total: %zu kB) (available: %zu kB) (usage: %d%%)", memoryTotal, memoryAvailable, memoryUsagePercentage);
 
     return memoryUsagePercentage;
 }
@@ -304,7 +304,7 @@ static int containerMemoryUsedAsPercentage(CGroupMemoryController* memoryControl
         return -1;
 
     int memoryUsagePercentageWithCgroup = 100 * ((float) memoryUsage / (float) memoryTotal);
-    LOG_VERBOSE(MemoryPressure, "MemoryPressureMonitor: memory cgroup (memory total=%zu bytes) (memory usage=%zu bytes) (memory usage percentage=%d bytes)", memoryTotal, memoryUsage, memoryUsagePercentageWithCgroup);
+    LOG(MemoryPressure, "MemoryPressureMonitor::memory: cgroup (total: %zu bytes) (in use: %zu bytes) (usage: %d%%)", memoryTotal, memoryUsage, memoryUsagePercentageWithCgroup);
 
     return memoryUsagePercentageWithCgroup;
 }


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=282441

Reviewed by Alicia Boya Garcia.

The logging for the memory pressure monitor was completely broken: memory reported in /mem/info is in kB, not MB, percentages had the wrong units, and it was not very readable, so fix it and make it a bit less verbose while we are at it.

* Source/WebKit/UIProcess/linux/MemoryPressureMonitor.cpp: (WebKit::systemMemoryUsedAsPercentage):

Canonical link: https://commits.webkit.org/286009@main<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/5daf96d608f2853a6f5e3e437f9d68b7e3f2a790

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| [✅ 🛠 wpe-238-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/1/builds/184 "Built successfully") | [✅ 🧪 wpe-238-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/5/builds/68 "Passed tests") 
| [✅ 🛠 wpe-238-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/8/builds/182 "Built successfully") | [✅ 🧪 wpe-238-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/6/builds/78 "Passed tests") 
| | 
| | 
<!--EWS-Status-Bubble-End-->