### PR TITLE
Add support for AC4 audio codec and filter usac codec support

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
@@ -565,7 +565,7 @@ void GStreamerRegistryScanner::initializeDecoders(const GStreamerRegistryScanner
     Vector<GstCapsWebKitMapping> mseCompatibleMapping = {
         { ElementFactories::Type::AudioDecoder, "audio/x-ac3"_s, { }, { "x-ac3"_s, "ac-3"_s, "ac3"_s } },
         { ElementFactories::Type::AudioDecoder, "audio/x-eac3"_s, { "audio/x-ac3"_s }, { "x-eac3"_s, "ec3"_s, "ec-3"_s, "eac3"_s } },
-        { ElementFactories::Type::AudioDecoder, "audio/x-ac4"_s, { }, { "x-ac4"_s, "ac-4*"_s, "ac4*"_s } },
+        { ElementFactories::Type::AudioDecoder, "audio/x-ac4"_s, { }, { "x-ac4"_s, "ac-4*"_s, "ac4"_s } },
         { ElementFactories::Type::AudioDecoder, "audio/x-flac"_s, { "audio/x-flac"_s, "audio/flac"_s }, { "x-flac"_s, "flac"_s, "fLaC"_s } },
     };
     fillMimeTypeSetFromCapsMapping(factories, mseCompatibleMapping);
@@ -798,6 +798,8 @@ GStreamerRegistryScanner::CodecLookupResult GStreamerRegistryScanner::isCodecSup
         result = isAVC1CodecSupported(configuration, codecName, shouldCheckForHardwareUse);
     else if (codecName.startsWith("hev1"_s) || codecName.startsWith("hvc1"_s))
         result = isHEVCCodecSupported(configuration, codecName, shouldCheckForHardwareUse);
+    else if (codecName.startsWith("ac-4"_s) && !parseAc4LevelAndProfile(codecName))
+        result = { false, nullptr };
 #if PLATFORM(WPE)
     else if ((codecName.startsWith("dvhe"_s) || codecName.startsWith("dvh1"_s)) && !supportsDVHCodec)
         result = { false, nullptr };
@@ -1017,6 +1019,35 @@ ASCIILiteral GStreamerRegistryScanner::configurationNameForLogging(Configuration
         return "decoding"_s;
     }
     return ""_s;
+}
+
+bool GStreamerRegistryScanner::parseAc4LevelAndProfile(const String& codec) const
+{
+    auto parts = codec.split('.');
+    // sanity check
+    if (parts.isEmpty())
+        return false;
+    // "ac-4" with no dots is valid (generic, unconstrained).
+    if (parts.size() == 1 && equalIgnoringASCIICase(parts[0], "ac-4"_s))
+        return true;
+    // Full format requires exactly 4 components: ["ac-4", bitstream_version, presentation_version, mdcompat]
+    if (parts.size() != 4) {
+        GST_DEBUG("AC-4 codec string has wrong number of components: %s", codec.utf8().data());
+        return false;
+    }
+    // presentation_version must be 1 (stereo/5.1); value 2 denotes IMS which is not supported.
+    auto presentationVersion = parseInteger<unsigned>(parts[2]);
+    if (!presentationVersion || *presentationVersion != 1) {
+        GST_DEBUG("AC-4 codec string has unsupported presentation_version: %s", codec.utf8().data());
+        return false;
+    }
+    // mdcompat (level): only levels 0-3 are supported.
+    auto mdcompat = parseInteger<unsigned>(parts[3]);
+    if (!mdcompat || *mdcompat > 3) {
+        GST_DEBUG("AC-4 codec string has unsupported mdcompat level: %s", codec.utf8().data());
+        return false;
+    }
+    return true;
 }
 
 GStreamerRegistryScanner::RegistryLookupResult GStreamerRegistryScanner::isConfigurationSupported(Configuration configuration, const MediaConfiguration& mediaConfiguration) const

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
@@ -565,6 +565,7 @@ void GStreamerRegistryScanner::initializeDecoders(const GStreamerRegistryScanner
     Vector<GstCapsWebKitMapping> mseCompatibleMapping = {
         { ElementFactories::Type::AudioDecoder, "audio/x-ac3"_s, { }, { "x-ac3"_s, "ac-3"_s, "ac3"_s } },
         { ElementFactories::Type::AudioDecoder, "audio/x-eac3"_s, { "audio/x-ac3"_s }, { "x-eac3"_s, "ec3"_s, "ec-3"_s, "eac3"_s } },
+        { ElementFactories::Type::AudioDecoder, "audio/x-ac4"_s, { }, { "x-ac4"_s, "ac-4*"_s, "ac4*"_s } },
         { ElementFactories::Type::AudioDecoder, "audio/x-flac"_s, { "audio/x-flac"_s, "audio/flac"_s }, { "x-flac"_s, "flac"_s, "fLaC"_s } },
     };
     fillMimeTypeSetFromCapsMapping(factories, mseCompatibleMapping);

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
@@ -138,6 +138,17 @@ static VideoDecodingLimits* resolveVideoDecodingLimits()
     return limits ? &*limits : nullptr;
 }
 
+// Returns true if the given mp4a codec string refers to USAC (xHE-AAC, AudioObjectType=42).
+// Format: mp4a.<hex-object-type>.<decimal-audio-object-type>  e.g. "mp4a.40.42"
+static bool isUsacMp4aCodec(const String& codec)
+{
+    auto parts = codec.split('.');
+    if (parts.size() != 3)
+        return false;
+    auto aot = parseInteger<unsigned>(parts[2]);
+    return aot && *aot == 42;
+}
+
 // We shouldn't accept media that the player can't actually play.
 // AAC supports up to 96 channels.
 #define MEDIA_MAX_AAC_CHANNELS 96
@@ -798,6 +809,8 @@ GStreamerRegistryScanner::CodecLookupResult GStreamerRegistryScanner::isCodecSup
         result = isAVC1CodecSupported(configuration, codecName, shouldCheckForHardwareUse);
     else if (codecName.startsWith("hev1"_s) || codecName.startsWith("hvc1"_s))
         result = isHEVCCodecSupported(configuration, codecName, shouldCheckForHardwareUse);
+    else if (codecName.startsWith("mp4a"_s) && isUsacMp4aCodec(codecName))
+        result = isUSACCodecSupported(configuration, shouldCheckForHardwareUse);
     else if (codecName.startsWith("ac-4"_s) && !parseAc4LevelAndProfile(codecName))
         result = { false, nullptr };
 #if PLATFORM(WPE)
@@ -949,21 +962,19 @@ bool GStreamerRegistryScanner::areAllCodecsSupported(Configuration configuration
     return true;
 }
 
-GStreamerRegistryScanner::CodecLookupResult GStreamerRegistryScanner::areCapsSupported(Configuration configuration, const GRefPtr<GstCaps>& caps, bool shouldCheckForHardwareUse) const
+GStreamerRegistryScanner::CodecLookupResult GStreamerRegistryScanner::areCapsSupported(ElementFactories::Type factoryType, const GRefPtr<GstCaps>& caps, bool shouldCheckForHardwareUse) const
 {
-    OptionSet<ElementFactories::Type> factoryTypes;
-    switch (configuration) {
-    case Configuration::Decoding:
-        factoryTypes.add(ElementFactories::Type::VideoDecoder);
-        break;
-    case Configuration::Encoding:
-        factoryTypes.add(ElementFactories::Type::VideoEncoder);
-        break;
-    }
+    OptionSet<ElementFactories::Type> factoryTypes = { factoryType };
     auto lookupResult = ElementFactories(factoryTypes).hasElementForCaps(factoryTypes.toSingleValue().value(), caps, ElementFactories::CheckHardwareClassifier::Yes);
     bool supported = lookupResult && (shouldCheckForHardwareUse ? lookupResult.isUsingHardware : true);
     GST_DEBUG("%s decoding supported for caps %" GST_PTR_FORMAT ": %s", shouldCheckForHardwareUse ? "Hardware" : "Software", caps.get(), boolForPrinting(supported));
     return { supported, supported ? lookupResult.factory : nullptr };
+}
+
+GStreamerRegistryScanner::CodecLookupResult GStreamerRegistryScanner::areCapsSupported(Configuration configuration, const GRefPtr<GstCaps>& caps, bool shouldCheckForHardwareUse) const
+{
+    auto factoryType = configuration == Configuration::Decoding ? ElementFactories::Type::VideoDecoder : ElementFactories::Type::VideoEncoder;
+    return areCapsSupported(factoryType, caps, shouldCheckForHardwareUse);
 }
 
 GStreamerRegistryScanner::CodecLookupResult GStreamerRegistryScanner::isAVC1CodecSupported(Configuration configuration, const String& codec, bool shouldCheckForHardwareUse) const
@@ -1019,6 +1030,17 @@ ASCIILiteral GStreamerRegistryScanner::configurationNameForLogging(Configuration
         return "decoding"_s;
     }
     return ""_s;
+}
+
+GStreamerRegistryScanner::CodecLookupResult GStreamerRegistryScanner::isUSACCodecSupported(Configuration configuration, bool shouldCheckForHardwareUse) const
+{
+    // USAC (Unified Speech and Audio Coding / xHE-AAC) requires a decoder that explicitly
+    // supports xHE-AAC/USAC. Check stream-format=usac: used by platform decoders/sinks
+    auto factoryType = configuration == Configuration::Decoding ? ElementFactories::Type::AudioDecoder : ElementFactories::Type::AudioEncoder;
+    auto usacStreamFormatCaps = adoptGRef(gst_caps_from_string("audio/mpeg, mpegversion=(int)4, stream-format=(string)usac"));
+    auto result = areCapsSupported(factoryType, usacStreamFormatCaps, shouldCheckForHardwareUse);
+    GST_DEBUG("USAC (xHE-AAC) audio %s supported: %s", shouldCheckForHardwareUse ? "hardware" : "software", boolForPrinting(result.isSupported));
+    return result;
 }
 
 bool GStreamerRegistryScanner::parseAc4LevelAndProfile(const String& codec) const

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h
@@ -161,6 +161,7 @@ protected:
     void initializeEncoders(const ElementFactories&);
 
     RegistryLookupResult isConfigurationSupported(Configuration, const MediaConfiguration&) const;
+    CodecLookupResult areCapsSupported(ElementFactories::Type, const GRefPtr<GstCaps>&, bool shouldCheckForHardwareUse) const;
 
     struct GstCapsWebKitMapping {
         ElementFactories::Type elementType;
@@ -175,6 +176,7 @@ private:
     CodecLookupResult isHEVCCodecSupported(Configuration, const String& codec, bool shouldCheckForHardwareUse) const;
 
     bool parseAc4LevelAndProfile(const String& codec) const;
+    CodecLookupResult isUSACCodecSupported(Configuration, bool shouldCheckForHardwareUse) const;
 
     ASCIILiteral configurationNameForLogging(Configuration) const;
     bool supportsFeatures(const String& features) const;

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h
@@ -174,6 +174,8 @@ private:
     CodecLookupResult isAVC1CodecSupported(Configuration, const String& codec, bool shouldCheckForHardwareUse) const;
     CodecLookupResult isHEVCCodecSupported(Configuration, const String& codec, bool shouldCheckForHardwareUse) const;
 
+    bool parseAc4LevelAndProfile(const String& codec) const;
+
     ASCIILiteral configurationNameForLogging(Configuration) const;
     bool supportsFeatures(const String& features) const;
 

--- a/Source/WebCore/platform/graphics/gstreamer/eme/GStreamerEMEUtilities.h
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/GStreamerEMEUtilities.h
@@ -114,8 +114,8 @@ public:
     static constexpr auto s_unspecifiedUUID = GST_PROTECTION_UNSPECIFIED_SYSTEM_ID ""_s;
     static constexpr auto s_unspecifiedKeySystem = GST_PROTECTION_UNSPECIFIED_SYSTEM_ID ""_s;
 
-    static constexpr std::array<ASCIILiteral, 11> s_cencEncryptionMediaTypes = { "video/mp4"_s, "audio/mp4"_s, "video/x-h264"_s, "video/x-h265"_s, "audio/mpeg"_s,
-        "audio/x-eac3"_s, "audio/x-ac3"_s, "audio/x-flac"_s, "audio/x-opus"_s, "video/x-vp9"_s, "video/x-av1"_s };
+    static constexpr std::array<ASCIILiteral, 12> s_cencEncryptionMediaTypes = { "video/mp4"_s, "audio/mp4"_s, "video/x-h264"_s, "video/x-h265"_s, "audio/mpeg"_s,
+        "audio/x-eac3"_s, "audio/x-ac3"_s, "audio/x-ac4"_s, "audio/x-flac"_s, "audio/x-opus"_s, "video/x-vp9"_s, "video/x-av1"_s };
     static constexpr std::array<ASCIILiteral, 7> s_webmEncryptionMediaTypes = { "video/webm"_s, "audio/webm"_s, "video/x-vp9"_s, "video/x-av1"_s, "audio/x-opus"_s, "audio/x-vorbis"_s, "video/x-vp8"_s };
 
     static bool isClearKeyKeySystem(const String& keySystem)

--- a/Source/WebCore/platform/graphics/gstreamer/eme/WebKitThunderDecryptorGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/WebKitThunderDecryptorGStreamer.cpp
@@ -59,6 +59,7 @@ static GstStaticPadTemplate srcTemplate = GST_STATIC_PAD_TEMPLATE("src",
         "audio/x-flac; "
         "audio/x-eac3; "
         "audio/x-ac3; "
+        "audio/x-ac4; "
         "video/x-h264; "
         "video/x-h265; "
         "video/x-vp9; video/x-vp8; "

--- a/Source/WebCore/platform/graphics/gstreamer/eme/WebKitThunderParser.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/WebKitThunderParser.cpp
@@ -64,6 +64,7 @@ static GstStaticPadTemplate thunderParseSrcTemplate = GST_STATIC_PAD_TEMPLATE("s
         "audio/x-flac; "
         "audio/x-eac3; "
         "audio/x-ac3; "
+        "audio/x-ac4; "
         "video/x-h264; "
         "video/x-h265; "
         "video/x-vp9; video/x-vp8; "


### PR DESCRIPTION
1) Report that audio codec ac-4 is supported when audio/x-ac4 decoder is available (MS.isTypeSupported, video.canPlayType(), MediaCapabilities). Validate ac-4 codec string to reject non-standard configurations.
2) Add AC4 to webkit thunder decrypter and parser so GST can use them to decrypt encrypted ac-4 stream

3) Filter support for USAC (Unified Speech and Audio Coding) audio codec also known xHE-AAC. It comes with codecs="mp4a.40.42" codec string. Webkit uses wildcard "mp4a* to announce support for all configurations possible.
Our audio sinks reports stream-format=usac to distinguish usac codec but I'm not sure if all audio sink does that. The same stream seems to play on x86 webkit GTK with pulsesink (that doens't list usac stream-format) and doesn't report usac stream at all:
```
0:00:04.127090216     2 0x7d4374001660 DEBUG               GST_CAPS gstpad.c:2749:gst_pad_has_current_caps:<aacparse0:src> check current pad caps audio/mpeg, mpegversion=(int)4, framed=(boolean)true, stream-format=(string)raw, level=(string)1, codec_data=(buffer)f94643623cc041f93cc00d3c0e0200000124785220082408082420027003000084e0020000462c8000, rate=(int)48000, channels=(int)2
```
On Amlogic STB the caps are:
```
'audio/mpeg, mpegversion=(int)4, framed=(boolean)true, stream-format=(string)usac, level=(string)1, codec_data=(buffer)f94643623cc041f93cc00d3c0e0200000124785220082408082420027003000084e0020000462c8000, rate=(int)48000, channels=(int)2'
```
Maybe that depends on qtdemux impl<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/d4dd4510d0ffd5434e23ae813b1139b19e958c88

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/201 "Built successfully") | [✅ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/92 "Passed tests") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/202 "Built successfully") | [✅ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/10/builds/94 "Passed tests") 
<!--EWS-Status-Bubble-End-->