### PR TITLE
[EME] Check support for full content type string (including codecs)

### DIFF
--- a/Source/WebCore/platform/encryptedmedia/CDMPrivate.cpp
+++ b/Source/WebCore/platform/encryptedmedia/CDMPrivate.cpp
@@ -420,7 +420,7 @@ std::optional<Vector<CDMMediaCapability>> CDMPrivate::getSupportedCapabilitiesFo
         //       combination of container, media types, robustness and local accumulated configuration in combination
         //       with restrictions:
         MediaEngineSupportParameters parameters;
-        parameters.type = ContentType(contentType->mimeType());
+        parameters.type = ContentType(requestedCapability.contentType);
         if (MediaPlayer::supportsType(parameters) == MediaPlayer::SupportsType::IsNotSupported) {
 
             // Try with Media Source:


### PR DESCRIPTION
When evaluating media capability support in EME::requestMediaKeySystemAccess(), MediaPlayer::supportsType() was called with only the container MIME type (e.g. 'video/mp4'), stripping codecs and other parameters.

Pass the full content type string (e.g. 'video/mp4; codecs="avc1.42E01E"') so the media engine can properly validate codec support, not just the container.<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/391b3c3591f6dbe4758cc9081599a918eb3285b4

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/203 "Built successfully") | [✅ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/94 "Passed tests") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/204 "Built successfully") | [✅ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/10/builds/96 "Passed tests") 
<!--EWS-Status-Bubble-End-->