### PR TITLE
Revert "[Media] Avoid play() call during seek flow before the finishS…

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -3747,10 +3747,6 @@ void HTMLMediaElement::seekWithTolerance(const SeekTarget& target, bool fromDOM)
     refreshCachedTime();
     MediaTime now = currentMediaTime();
 
-    // Needed to detect a special case in updatePlayState().
-    if (now >= durationMediaTime())
-        m_seekAfterPlaybackEnded = true;
-
     // 3 - If the element's seeking IDL attribute is true, then another instance of this algorithm is
     // already running. Abort that other instance of the algorithm without waiting for the step that
     // it is running to complete.
@@ -3938,8 +3934,6 @@ void HTMLMediaElement::finishSeek()
 #endif
     if (wasPlayingBeforeSeeking)
         playInternal();
-
-    m_seekAfterPlaybackEnded = false;
 }
 
 HTMLMediaElement::ReadyState HTMLMediaElement::readyState() const
@@ -4377,10 +4371,8 @@ void HTMLMediaElement::playInternal()
     if (!m_player || m_networkState == NETWORK_EMPTY)
         selectMediaResource();
 
-    if (endedPlayback()) {
-        m_seekAfterPlaybackEnded = true;
+    if (endedPlayback())
         seekInternal(MediaTime::zeroTime());
-    }
 
     if (RefPtr mediaController = m_mediaController)
         mediaController->bringElementUpToSpeed(*this);
@@ -6366,17 +6358,7 @@ void HTMLMediaElement::updatePlayState()
     if (shouldBePlaying) {
         invalidateCachedTime();
 
-        // Play is always allowed, except when seeking (to avoid unpausing the video by mistake until the
-        // target time is reached). However, there are some exceptional situations when we allow playback
-        // during seek. This is because GStreamer-based implementation have a design limitation that doesn't
-        // allow initial seeks (seeking before going to playing state), and these exceptions make things
-        // work for those platforms.
-        bool isLooping = loop() && m_lastSeekTime == MediaTime::zeroTime();
-        bool playExceptionsWhenSeeking = m_seeking && (m_firstTimePlaying
-            || isLooping || m_isResumingPlayback || m_seekAfterPlaybackEnded);
-        bool allowPlay = !m_seeking || playExceptionsWhenSeeking;
-
-        if (playerPaused && allowPlay) {
+        if (playerPaused) {
             mediaSession().clientWillBeginPlayback();
 
             // Set rate, muted and volume before calling play in case they were set before the media engine was set up.
@@ -8927,11 +8909,8 @@ void HTMLMediaElement::resumeAutoplaying()
 void HTMLMediaElement::mayResumePlayback(bool shouldResume)
 {
     ALWAYS_LOG(LOGIDENTIFIER, "paused = ", paused());
-    if (!ended() && paused() && shouldResume) {
-        m_isResumingPlayback = true;
+    if (!ended() && paused() && shouldResume)
         play();
-        m_isResumingPlayback = false;
-    }
 }
 
 String HTMLMediaElement::mediaSessionTitle() const

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -1282,8 +1282,6 @@ private:
     bool m_volumeLocked : 1;
     bool m_cachedIsInVisibilityAdjustmentSubtree : 1 { false };
     bool m_requiresTextTrackRepresentation : 1 { false };
-    bool m_isResumingPlayback : 1 { false };
-    bool m_seekAfterPlaybackEnded : 1 { false };
 
     IntRect m_textTrackRepresentationBounds;
 


### PR DESCRIPTION
…eek()"

This reverts commit 6147003a1b205766fdef70f4f89bf6ce8e043733.

The change was reverted upstream and in wpe-2.38. Refer for details https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1423<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/8498b9992cfd03c4f9831557286c9b4b77535dbd

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/204 "Built successfully") | [✅ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/95 "Passed tests") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/205 "Built successfully") | [✅ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/10/builds/97 "Passed tests") 
<!--EWS-Status-Bubble-End-->