### PR TITLE
MemoryPressureHandler/glib: Disable GPU memory accounting for service…

### DIFF
--- a/Source/WTF/wtf/MemoryPressureHandler.cpp
+++ b/Source/WTF/wtf/MemoryPressureHandler.cpp
@@ -258,8 +258,17 @@ size_t MemoryPressureHandler::calculateFootprintForPolicyDecision(size_t footpri
     // Some devices accounts video memory into the process memory footprint (as file mappings - RSSFile).
     // In such cases, we need to subtract the video memory from the process memory footprint
     // to make the memory pressure policy decision based on the process memory footprint only.
-    if (s_videoMemoryInFootprint)
+    if (s_videoMemoryInFootprint) {
+        if (footprintVideo > footprint) {
+            // This means that s_videoMemoryInFootprint should not be set for this device
+            // or footprint and footprintVideo are coming from two different processes
+            // and shouldn't be compared with each other. Both cases are misconfigurations.
+            WTFLogAlways("Video memory footprint (%zu MB) is larger than total memory footprint (%zu MB). "
+                         "Check MemoryPressureHandler configuration\n", footprintVideo / MB, footprint / MB);
+            return footprint;
+        }
         footprint -= footprintVideo;
+    }
     return footprint;
 }
 
@@ -410,6 +419,16 @@ void MemoryPressureHandler::setConfiguration(const Configuration& configuration)
         m_configuration.strictThresholdFraction,
         m_configuration.killThresholdFraction ? *(m_configuration.killThresholdFraction) : -1.0,
         m_configuration.pollInterval.value());         
+}
+
+void MemoryPressureHandler::disableGPUMemoryAccounting()
+{
+    // Reset the GPU memory file to stop accounting video memory for this process
+    s_GPUMemoryFile = String();
+    s_envBaseThresholdVideo = 0;
+    s_videoMemoryInFootprint = false;
+
+    RELEASE_LOG(MemoryPressure, "GPU memory accounting disabled (PID=%d)", getpid());
 }
 
 void MemoryPressureHandler::releaseMemory(Critical critical, Synchronous synchronous)

--- a/Source/WTF/wtf/MemoryPressureHandler.h
+++ b/Source/WTF/wtf/MemoryPressureHandler.h
@@ -227,6 +227,7 @@ public:
     };
     void setConfiguration(Configuration&& configuration);
     void setConfiguration(const Configuration& configuration);
+    void disableGPUMemoryAccounting();
 
     WTF_EXPORT_PRIVATE void releaseMemory(Critical, Synchronous = Synchronous::No);
 

--- a/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
+++ b/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
@@ -150,6 +150,10 @@ void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& para
     if (parameters.memoryPressureHandlerConfiguration)
         MemoryPressureHandler::singleton().setConfiguration(WTFMove(*parameters.memoryPressureHandlerConfiguration));
 
+    // Service worker processes are not expected to use GPU - disable GPU memory accounting
+    if (parameters.isServiceWorkerProcess)
+        MemoryPressureHandler::singleton().disableGPUMemoryAccounting();
+
     if (!parameters.applicationID.isEmpty())
         WebCore::setApplicationID(parameters.applicationID);
 


### PR DESCRIPTION
… workers.

MemoryPressureHandler accounts for GPU memory in every WPEWebProcess and has no way to distinguish whether it is the main web process or a service worker. In conjunction with s_videoMemoryInFootprint, footprint calculations subtract high GPU memory usage of the main web process from the low RSS memory value of a service worker, which results in an overflow and triggers critical memory pressure for the service worker.

Resolve this by disabling GPU memory accounting for service workers<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/116f85fc956cbe733ddd15ee5392c500525df8da

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| [✅ 🛠 wpe-238-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/1/builds/194 "Built successfully") | [✅ 🧪 wpe-238-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/5/builds/71 "Passed tests") 
| [✅ 🛠 wpe-238-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/8/builds/192 "Built successfully") | [✅ 🧪 wpe-238-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/6/builds/81 "Passed tests") 
| | 
| | 
<!--EWS-Status-Bubble-End-->