### PR TITLE
[GStreamer] 3 new failures on MVT tests hls-hlsjs-test/HLS_FMP4_MP3 after 310634@main

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
@@ -521,6 +521,14 @@ void GStreamerRegistryScanner::initializeDecoders(const GStreamerRegistryScanner
         // MPEG-2 Part 3 Audio just defines minor extensions of MP3 adding support for more channels and bitrates.
         // GStreamer still considers it mpegversion=1, leaving mpegversion=2 for AAC (MPEG-2 Part 7 Advanced Audio Coding).
         m_decoderCodecMap.add("mp4a.69"_s, result); // Audio ISO/IEC 13818-3 (MPEG-2 Part 3 Audio)
+        // MPEG-1 Audio can be carried inside MPEG-4 Audio, for which there are standard-defined MPEG-4
+        // Audio Object Type (AOT) allocated. This is esoteric in practice and it has very limited player support.
+        // More commonly, some media manifests for MP3 in MP4 mistakingly use these MPEG-4 AOTs in their codec
+        // strings despite the MP4 bytestream actually using the (much more widely supported) MPEG-1 Object Type Indication(s)
+        // described above.
+        m_decoderCodecMap.add("mp4a.40.32"_s, result); // AOT 32: Layer-1
+        m_decoderCodecMap.add("mp4a.40.33"_s, result); // AOT 33: Layer-2
+        m_decoderCodecMap.add("mp4a.40.34"_s, result); // AOT 34: Layer-3
     }
 
     audioMpegSupported |= isContainerTypeSupported(Configuration::Decoding, "audio/mp4"_s);


### PR DESCRIPTION
Backport of https://github.com/WebKit/WebKit/pull/63699

Fixes some remaining failing MVT tests that were still failing after https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/530c9d3c89ad96cdbc8163cb6fe8e92de5e798ce because their HLS manifests were using a different codec string for MP3.<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/6c50149b0e8bc2618ba8bc3b1ded6890d82d9c42

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/209 "Built successfully") | [✅ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/97 "Passed tests") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/210 "Built successfully") | [✅ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/10/builds/99 "Passed tests") 
<!--EWS-Status-Bubble-End-->