### PR TITLE
MemoryPressureHandler/glib: Disable GPU memory accounting for service…

### DIFF
--- a/Source/WTF/wtf/MemoryPressureHandler.cpp
+++ b/Source/WTF/wtf/MemoryPressureHandler.cpp
@@ -264,8 +264,17 @@ size_t MemoryPressureHandler::calculateFootprintForPolicyDecision(size_t footpri
     // Some devices accounts video memory into the process memory footprint (as file mappings - RSSFile).
     // In such cases, we need to subtract the video memory from the process memory footprint
     // to make the memory pressure policy decision based on the process memory footprint only.
-    if (s_videoMemoryInFootprint)
+    if (s_videoMemoryInFootprint) {
+        if (footprintVideo > footprint) {
+            // This means that s_videoMemoryInFootprint should not be set for this device
+            // or footprint and footprintVideo are coming from two different processes
+            // and shouldn't be compared with each other. Both cases are misconfigurations.
+            WTFLogAlways("Video memory footprint (%zu MB) is larger than total memory footprint (%zu MB). "
+                         "Check MemoryPressureHandler configuration\n", footprintVideo / MB, footprint / MB);
+            return footprint;
+        }
         footprint -= footprintVideo;
+    }
     return footprint;
 }
 
@@ -460,6 +469,16 @@ void MemoryPressureHandler::setConfiguration(const Configuration& configuration)
         m_configuration.strictThresholdFraction,
         m_configuration.killThresholdFraction ? *(m_configuration.killThresholdFraction) : -1.0,
         m_configuration.pollInterval.value());
+}
+
+void MemoryPressureHandler::disableGPUMemoryAccounting()
+{
+    // Reset the GPU memory file to stop accounting video memory for this process
+    s_GPUMemoryFile = String();
+    s_envBaseThresholdVideo = 0;
+    s_videoMemoryInFootprint = false;
+
+    RELEASE_LOG(MemoryPressure, "GPU memory accounting disabled (PID=%d)", getpid());
 }
 
 void MemoryPressureHandler::releaseMemory(Critical critical, Synchronous synchronous)

--- a/Source/WTF/wtf/MemoryPressureHandler.h
+++ b/Source/WTF/wtf/MemoryPressureHandler.h
@@ -198,6 +198,7 @@ public:
 
     void setConfiguration(Configuration&&);
     void setConfiguration(const Configuration&);
+    void disableGPUMemoryAccounting();
 
     WTF_EXPORT_PRIVATE void releaseMemory(Critical, Synchronous = Synchronous::No);
 

--- a/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
+++ b/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
@@ -219,6 +219,10 @@ void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& para
     if (parameters.memoryPressureHandlerConfiguration)
         MemoryPressureHandler::singleton().setConfiguration(WTFMove(*parameters.memoryPressureHandlerConfiguration));
 
+    // Service worker processes are not expected to use GPU - disable GPU memory accounting
+    if (parameters.isServiceWorkerProcess)
+        MemoryPressureHandler::singleton().disableGPUMemoryAccounting();
+
     if (!parameters.applicationID.isEmpty())
         WebCore::setApplicationID(parameters.applicationID);
 


### PR DESCRIPTION
… workers.

MemoryPressureHandler accounts for GPU memory in every WPEWebProcess and has no way to distinguish whether it is the main web process or a service worker. In conjunction with s_videoMemoryInFootprint, footprint calculations subtract high GPU memory usage of the main web process from the low RSS memory value of a service worker, which results in an overflow and triggers critical memory pressure for the service worker.

Resolve this by disabling GPU memory accounting for service workers

Original author: Andrzej Surdej (https://github.com/asurdej-comcast)<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/a000eb109f04116ccb0ed4e292d8fe4192f523ea

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/210 "Built successfully") | [✅ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/98 "Passed tests") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/211 "Built successfully") | [✅ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/10/builds/101 "Passed tests") 
<!--EWS-Status-Bubble-End-->