### PR TITLE
[GStreamer] Auto-detect USAC support via GStreamer registry

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
@@ -499,6 +499,10 @@ void GStreamerRegistryScanner::initializeDecoders(const GStreamerRegistryScanner
         // USAC AOT, is not yet widely available enough to be enabled by default.
         const char* value = g_getenv("WEBKIT_GST_CAN_PLAY_USAC");
         bool canPlayUsac = value && (!g_strcmp0(value, "true") || !g_strcmp0(value, "1"));
+        if (!value) {
+            // Env is not set. Fall back to gst elements query
+            canPlayUsac = factories.hasElementForMediaType(ElementFactories::Type::AudioDecoder, "audio/mpeg, mpegversion=(int)4, stream-format=(string)usac"_s).isSupported;
+        }
         if (canPlayUsac)
             m_decoderCodecMap.add("mp4a.40.42"_s, result); // MPEG-4 Extended HE-AAC and xHE-AAC (USAC AOT)
     }


### PR DESCRIPTION
Add a fallback check for USAC (xHE-AAC) codec support by probing the GStreamer registry for a decoder matching
"audio/mpeg, mpegversion=(int)4, stream-format=(string)usac".

The stream-format=usac caps field is not part of the standard GStreamer audio/mpeg caps definition, but some custom audio sinks advertise it, so it can be used as an indicator of USAC decoding capability.

The WEBKIT_GST_CAN_PLAY_USAC environment variable still takes precedence as a manual override.<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/d8522c27441c0faf0f024c41adaddf59d4258da3

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/224 "Built successfully") | [✅ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/101 "Passed tests") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/224 "Built successfully") | [✅ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/10/builds/105 "Passed tests") 
<!--EWS-Status-Bubble-End-->