### PR TITLE
MarkedVector::fill should register itself as a root https://bugs.webk…

### DIFF
--- a/JSTests/stress/marked-buffer-fill-should-be-gc-aware.js
+++ b/JSTests/stress/marked-buffer-fill-should-be-gc-aware.js
@@ -1,0 +1,10 @@
+//@ runDefault("--slowPathAllocsBetweenGCs=10", "--jitPolicyScale=0")
+let a = new BigUint64Array(1000);
+
+function foo(a0) {
+  ~a0;
+}
+
+for (let i = 0; i < 1000; i++) {
+  foo.apply(null, a);
+}

--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
@@ -2315,7 +2315,7 @@ static void handleVarargsCheckpoint(VM& vm, CallFrame* callFrame, JSGlobalObject
     unsigned firstVarArg = bytecode.m_firstVarArg;
 
     MarkedArgumentBuffer args;
-    args.fill(argumentCountIncludingThis - 1, [&] (JSValue* buffer) {
+    args.fill(vm, argumentCountIncludingThis - 1, [&](JSValue* buffer) {
         loadVarargs(globalObject, buffer, callFrame->r(bytecode.m_arguments).jsValue(), firstVarArg, argumentCountIncludingThis - 1);
     });
     if (args.hasOverflowed()) {

--- a/Source/JavaScriptCore/runtime/ArgList.h
+++ b/Source/JavaScriptCore/runtime/ArgList.h
@@ -205,14 +205,21 @@ public:
     }
 
     template<typename Functor>
-    void fill(size_t count, const Functor& func)
+    void fill(VM& vm, size_t count, const Functor& func)
     {
         ASSERT(!m_size);
         ensureCapacity(count);
         if (OverflowHandler::hasOverflowed())
             return;
+        if (LIKELY(!m_markSet)) {
+            m_markSet = &vm.heap.markListSet();
+            m_markSet->add(this);
+        }
         m_size = count;
-        func(reinterpret_cast<JSValue*>(&slotFor(0)));
+        auto* buffer = reinterpret_cast<JSValue*>(&slotFor(0));
+        for (unsigned i = 0; i < count; ++i)
+            buffer[i] = JSValue();
+        func(buffer);
     }
 
 private:


### PR DESCRIPTION
…it.org/show_bug.cgi?id=255951 rdar://108261913

Reviewed by Alexey Shvayka and Justin Michaud.

1. MarkedVector::fill is not registering itself as a strong root of GC. This patch fixes it with m_markSet->add.
2. Initialize buffer with empty value in MarkedVector::fill. This buffer can be scanned via GC when GC is invoked from a passed lambda.

* JSTests/stress/marked-buffer-fill-should-be-gc-aware.js: Added. (foo):
* Source/JavaScriptCore/llint/LLIntSlowPaths.cpp: (JSC::LLInt::handleVarargsCheckpoint):
* Source/JavaScriptCore/runtime/ArgList.h: (JSC::MarkedVector::fill):

Originally-landed-as: 259548.690@safari-7615-branch (b05050e0cc00). rdar://108261913
Canonical link: https://commits.webkit.org/266449@main

# Pull Request Template

## File a Bug

All changes should be associated with a bug. The WebKit project is currently using [Bugzilla](https://bugs.webkit.org) as our bug tracker. Note that multiple changes may be associated with a single bug.

## Provided Tooling

The WebKit Project strongly recommends contributors use [`Tools/Scripts/git-webkit`](https://github.com/WebKit/WebKit/tree/main/Tools/Scripts/git-webkit) to generate pull requests. See [Setup](https://github.com/WebKit/WebKit/wiki/Contributing#setup) and [Contributing Code](https://github.com/WebKit/WebKit/wiki/Contributing#contributing-code) for how to do this.

## Template

If a contributor wishes to file a pull request manually, the template is below. Manually-filed pull requests should contain their commit message as the pull request description, and their commit message should be formatted like the template below.

Additionally, the pull request should be mentioned on [Bugzilla](https://bugs.webkit.org), labels applied to the pull request matching the component and version of the [Bugzilla](https://bugs.webkit.org) associated with the pull request and the pull request assigned to its author.

<pre>
< bug title >
<a href="https://bugs.webkit.org/enter_bug.cgi">https://bugs.webkit.org/show_bug.cgi?id=#####</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* path/changed.ext:
(function):
(class.function):

</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/f79962099856a7ab1b4e17fa12688345c297814f

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| [✅ 🛠 wpe-238-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/1/builds/200 "Built successfully") | [✅ 🧪 wpe-238-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/5/builds/72 "Passed tests") 
| [✅ 🛠 wpe-238-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/8/builds/198 "Built successfully") | [✅ 🧪 wpe-238-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/6/builds/82 "Passed tests") 
| | 
| | 
<!--EWS-Status-Bubble-End-->