### PR TITLE
DFG might force a local to be double even if we store non-numeric val…

### DIFF
--- a/JSTests/stress/double-inlined-call-argument.js
+++ b/JSTests/stress/double-inlined-call-argument.js
@@ -1,0 +1,22 @@
+function foo(a, b, c, p) {
+    a = b + c;
+    if (p) {
+        a++;
+        return a;
+    }
+}
+
+function bar(a, b) {
+    return foo("hello", a, b, a <= b);
+}
+
+noInline(bar);
+
+for (var i = 0; i < 100000; ++i) {
+    var result = bar(2000000000, 2000000000.5);
+    if (result != 4000000001.5)
+        throw new Error(`Bad result: ${result}!`);
+}
+
+if (reoptimizationRetryCount(bar) != 0)
+    throw new Error(`Should not have reoptimized bar, but reoptimized ${reoptimizationRetryCount(bar)} times.`);

--- a/JSTests/stress/regress-116397731.js
+++ b/JSTests/stress/regress-116397731.js
@@ -1,0 +1,16 @@
+var out;
+
+function func0(value) {
+  if (value) {}
+  out = value;
+  value = value + 1 + 2;
+}
+
+function main() {
+  for (let i = 0; i < 0x100000; i++)
+    func0(undefined);
+  if (out !== undefined)
+    throw new Error(`Bad value: ${out}!`);
+}
+
+main();

--- a/Source/JavaScriptCore/dfg/DFGVariableAccessData.cpp
+++ b/Source/JavaScriptCore/dfg/DFGVariableAccessData.cpp
@@ -131,7 +131,7 @@ bool VariableAccessData::tallyVotesForShouldUseDoubleFormat()
     if (!newValueOfShouldUseDoubleFormat) {
         // We monotonically convert to double. Hence, if the fixpoint leads us to conclude that we should
         // switch back to int, we instead ignore this and stick with double.
-        return false;
+        return DFG::mergeDoubleFormatState(m_doubleFormatState, NotUsingDoubleFormat);
     }
         
     if (m_doubleFormatState == UsingDoubleFormat)


### PR DESCRIPTION
…ues into it https://bugs.webkit.org/show_bug.cgi?id=263090 <rdar://116397731>

Reviewed by Keith Miller.

This changes fixes tallyVotesForShouldUseDoubleFormat() to set NotUsingDoubleFormat if the variable is no longer predicted to hold only doubles.

* JSTests/stress/double-inlined-call-argument.js: Added.
* JSTests/stress/regress-116397731.js: Added.
* Source/JavaScriptCore/dfg/DFGVariableAccessData.cpp: (JSC::DFG::VariableAccessData::tallyVotesForShouldUseDoubleFormat):

Originally-landed-as: 267815.352@safari-7617-branch (11987a2c00bf). rdar://119597752
Canonical link: https://commits.webkit.org/272168@main

# Pull Request Template

## File a Bug

All changes should be associated with a bug. The WebKit project is currently using [Bugzilla](https://bugs.webkit.org) as our bug tracker. Note that multiple changes may be associated with a single bug.

## Provided Tooling

The WebKit Project strongly recommends contributors use [`Tools/Scripts/git-webkit`](https://github.com/WebKit/WebKit/tree/main/Tools/Scripts/git-webkit) to generate pull requests. See [Setup](https://github.com/WebKit/WebKit/wiki/Contributing#setup) and [Contributing Code](https://github.com/WebKit/WebKit/wiki/Contributing#contributing-code) for how to do this.

## Template

If a contributor wishes to file a pull request manually, the template is below. Manually-filed pull requests should contain their commit message as the pull request description, and their commit message should be formatted like the template below.

Additionally, the pull request should be mentioned on [Bugzilla](https://bugs.webkit.org), labels applied to the pull request matching the component and version of the [Bugzilla](https://bugs.webkit.org) associated with the pull request and the pull request assigned to its author.

<pre>
< bug title >
<a href="https://bugs.webkit.org/enter_bug.cgi">https://bugs.webkit.org/show_bug.cgi?id=#####</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* path/changed.ext:
(function):
(class.function):

</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/103e56eb63e7bd290bb1aeea6c714bd3d13dd89d

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| [✅ 🛠 wpe-238-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/1/builds/201 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 wpe-238-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/5/builds/73 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 82 flakes 454 failures; Uploaded test results; Running layout-tests-repeat-failures") 
| [✅ 🛠 wpe-238-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/8/builds/199 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 wpe-238-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/6/builds/83 "Build is in progress. Recent messages:") 
| | 
| | 
<!--EWS-Status-Bubble-End-->