### PR TITLE
PropertyCondition::isValidValueForAttributes should handle custom acc…

### DIFF
--- a/JSTests/stress/attribute-custom-accessor.js
+++ b/JSTests/stress/attribute-custom-accessor.js
@@ -1,0 +1,87 @@
+async function asyncSleep(ms) {
+    return new Promise(resolve => {
+        setTimeout(() => {
+            resolve();
+        }, ms);
+    });
+}
+
+function reifyAllStaticProperties(object) {
+    Object.assign({}, object);
+}
+
+function setHasBeenDictionary(object) {
+    for (let i = 0; i < 100; i++) {
+        object.b = 1;
+        delete object.b;
+    }
+
+    for (const x in Object.create(object)) {
+
+    }
+}
+
+function watchToJSONForReplacements(object) {
+    JSON.stringify(Object.create(object));
+}
+
+async function watchLastMatchForReplacements(object) {
+    const tmp = Object.create(object);
+    function getLastMatch() {
+        return tmp.lastMatch;
+    }
+
+    for (let i = 0; i < 2000; i++) {
+        try {
+            getLastMatch();
+        } catch {
+
+        }
+    }
+
+    await asyncSleep(500);
+}
+
+const target = {
+    toJSON: (() => {
+        const object = {};
+        for (let i = 0; i < 10; i++) {
+            object['a' + i] = 1;
+        }
+
+        object.lastMatch = 0x8888;
+
+        return object;
+    })()
+};
+
+function opt() {
+    return target.toJSON.lastMatch;
+}
+
+async function main() {
+    setHasBeenDictionary(target);
+
+    reifyAllStaticProperties(RegExp);
+    await watchLastMatchForReplacements(RegExp);
+
+    for (let i = 0; i < 2000; i++) {
+        opt();
+    }
+
+    await asyncSleep(200);
+
+    target.toJSON = RegExp;
+    target.b = 1;
+
+    watchToJSONForReplacements(target);
+
+    await asyncSleep(1000);
+
+    const custom_getter_setter = opt();
+    describe(custom_getter_setter);
+
+    custom_getter_setter.x = 1;
+}
+
+main();

--- a/Source/JavaScriptCore/bytecode/PropertyCondition.cpp
+++ b/Source/JavaScriptCore/bytecode/PropertyCondition.cpp
@@ -498,9 +498,11 @@ bool PropertyCondition::isValidValueForAttributes(JSValue value, unsigned attrib
 {
     if (!value)
         return false;
-    bool attributesClaimAccessor = !!(attributes & PropertyAttribute::Accessor);
-    bool valueClaimsAccessor = !!jsDynamicCast<GetterSetter*>(value);
-    return attributesClaimAccessor == valueClaimsAccessor;
+    if (value.inherits<GetterSetter>())
+        return attributes & PropertyAttribute::Accessor;
+    if (value.inherits<CustomGetterSetter>())
+        return attributes & PropertyAttribute::CustomAccessorOrValue;
+    return !(attributes & PropertyAttribute::AccessorOrCustomAccessorOrValue);
 }
 
 bool PropertyCondition::isValidValueForPresence(JSValue value) const


### PR DESCRIPTION
…essor and custom value https://bugs.webkit.org/show_bug.cgi?id=266695 rdar://119854137

Reviewed by Mark Lam.

PropertyCondition::isValidValueForAttributes only handled accessors and values. And it didn't handle custom accessor / custom values. This patch changes it so that we can check custom accessor / custom value cases correctly.

* JSTests/stress/attribute-custom-accessor.js: Added. (async asyncSleep):
(setHasBeenDictionary):
(watchToJSONForReplacements):
(async watchLastMatchForReplacements.getLastMatch): (async watchLastMatchForReplacements):
(const.target.toJSON):
(opt):
(async main):
* Source/JavaScriptCore/bytecode/PropertyCondition.cpp: (JSC::PropertyCondition::isValidValueForAttributes):

Originally-landed-as: 272448.6@safari-7618-branch (24d1c08b9dfa). rdar://124557469
Canonical link: https://commits.webkit.org/276183@main

# Pull Request Template

## File a Bug

All changes should be associated with a bug. The WebKit project is currently using [Bugzilla](https://bugs.webkit.org) as our bug tracker. Note that multiple changes may be associated with a single bug.

## Provided Tooling

The WebKit Project strongly recommends contributors use [`Tools/Scripts/git-webkit`](https://github.com/WebKit/WebKit/tree/main/Tools/Scripts/git-webkit) to generate pull requests. See [Setup](https://github.com/WebKit/WebKit/wiki/Contributing#setup) and [Contributing Code](https://github.com/WebKit/WebKit/wiki/Contributing#contributing-code) for how to do this.

## Template

If a contributor wishes to file a pull request manually, the template is below. Manually-filed pull requests should contain their commit message as the pull request description, and their commit message should be formatted like the template below.

Additionally, the pull request should be mentioned on [Bugzilla](https://bugs.webkit.org), labels applied to the pull request matching the component and version of the [Bugzilla](https://bugs.webkit.org) associated with the pull request and the pull request assigned to its author.

<pre>
< bug title >
<a href="https://bugs.webkit.org/enter_bug.cgi">https://bugs.webkit.org/show_bug.cgi?id=#####</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* path/changed.ext:
(function):
(class.function):

</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/827276c2d159a3a2cecc137c623a0eb2425a23e8

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| [✅ 🛠 wpe-238-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/1/builds/203 "Built successfully") | [⏳ 🧪 wpe-238-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/WPE-238-x86-64-bit-LayoutTests-EWS "Waiting to run tests") 
| [✅ 🛠 wpe-238-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/8/builds/201 "Built successfully") | [⏳ 🧪 wpe-238-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/WPE-238-ARM-32-bit-LayoutTests-EWS "Waiting to run tests") 
| | 
| | 
<!--EWS-Status-Bubble-End-->