### PR TITLE
InById / InByVal should reset SP too in Baseline https://bugs.webkit.…

### DIFF
--- a/Source/JavaScriptCore/jit/JITPropertyAccess.cpp
+++ b/Source/JavaScriptCore/jit/JITPropertyAccess.cpp
@@ -1273,6 +1273,7 @@ void JIT::emit_op_in_by_id(const JSInstruction* currentInstruction)
     addSlowCase();
     m_inByIds.append(gen);
 
+    resetSP(); // We might OSR exit here, so we need to conservatively reset SP
     setFastPathResumePoint();
     emitPutVirtualRegister(resultVReg, resultJSR);
 }
@@ -1333,6 +1334,7 @@ void JIT::emit_op_in_by_val(const JSInstruction* currentInstruction)
     addSlowCase();
     m_inByVals.append(gen);
 
+    resetSP(); // We might OSR exit here, so we need to conservatively reset SP
     setFastPathResumePoint();
     emitPutVirtualRegister(dst, resultJSR);
 }
@@ -1385,6 +1387,7 @@ void JIT::emitHasPrivate(VirtualRegister dst, VirtualRegister base, VirtualRegis
     addSlowCase();
     m_inByVals.append(gen);
 
+    resetSP(); // We might OSR exit here, so we need to conservatively reset SP
     setFastPathResumePoint();
     emitPutVirtualRegister(dst, resultJSR);
 }


### PR DESCRIPTION
…org/show_bug.cgi?id=276688 rdar://131869701

Reviewed by Keith Miller.

Now InById / InByVal can call ProxyObject handlers and they get inlined in DFG. Thus we should adjust stack pointer after the calls as the same to GetById / GetByVal.

* Source/JavaScriptCore/jit/JITPropertyAccess.cpp: (JSC::JIT::emit_op_in_by_id):
(JSC::JIT::emit_op_in_by_val):
(JSC::JIT::emitHasPrivate):

Canonical link: https://commits.webkit.org/281024@main

# Pull Request Template

## File a Bug

All changes should be associated with a bug. The WebKit project is currently using [Bugzilla](https://bugs.webkit.org) as our bug tracker. Note that multiple changes may be associated with a single bug.

## Provided Tooling

The WebKit Project strongly recommends contributors use [`Tools/Scripts/git-webkit`](https://github.com/WebKit/WebKit/tree/main/Tools/Scripts/git-webkit) to generate pull requests. See [Setup](https://github.com/WebKit/WebKit/wiki/Contributing#setup) and [Contributing Code](https://github.com/WebKit/WebKit/wiki/Contributing#contributing-code) for how to do this.

## Template

If a contributor wishes to file a pull request manually, the template is below. Manually-filed pull requests should contain their commit message as the pull request description, and their commit message should be formatted like the template below.

Additionally, the pull request should be mentioned on [Bugzilla](https://bugs.webkit.org), labels applied to the pull request matching the component and version of the [Bugzilla](https://bugs.webkit.org) associated with the pull request and the pull request assigned to its author.

<pre>
< bug title >
<a href="https://bugs.webkit.org/enter_bug.cgi">https://bugs.webkit.org/show_bug.cgi?id=#####</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* path/changed.ext:
(function):
(class.function):

</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/d1b5c9f2c385834bab36af4ca8990718a633c644

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| [✅ 🛠 wpe-238-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/1/builds/205 "Built successfully") | [✅ 🧪 wpe-238-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/5/builds/78 "Passed tests") 
| [✅ 🛠 wpe-238-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/8/builds/203 "Built successfully") | [✅ 🧪 wpe-238-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/6/builds/88 "Passed tests") 
| | 
| | 
<!--EWS-Status-Bubble-End-->