### PR TITLE
Fix DFG::AbstractHeap initialization from pointer on armv7 https://bu…

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGAbstractHeap.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractHeap.h
@@ -120,7 +120,7 @@ public:
         
         Payload(const void* pointer)
             : m_isTop(false)
-            , m_value(bitwise_cast<intptr_t>(pointer))
+            , m_value(static_cast<int64_t>(reinterpret_cast<uintptr_t>(pointer)))
         {
         }
 


### PR DESCRIPTION
…gs.webkit.org/show_bug.cgi?id=281378

Reviewed by Justin Michaud.

The previous incantation would cause 32 bit pointers to be sign extended into a int64_t slot. We want to widen then value without sign extension here, as the higher bits will be used for a tag. (See encode())

* Source/JavaScriptCore/dfg/DFGAbstractHeap.h: (JSC::DFG::AbstractHeap::Payload::Payload):

Canonical link: https://commits.webkit.org/285323@main

# Pull Request Template

## File a Bug

All changes should be associated with a bug. The WebKit project is currently using [Bugzilla](https://bugs.webkit.org) as our bug tracker. Note that multiple changes may be associated with a single bug.

## Provided Tooling

The WebKit Project strongly recommends contributors use [`Tools/Scripts/git-webkit`](https://github.com/WebKit/WebKit/tree/main/Tools/Scripts/git-webkit) to generate pull requests. See [Setup](https://github.com/WebKit/WebKit/wiki/Contributing#setup) and [Contributing Code](https://github.com/WebKit/WebKit/wiki/Contributing#contributing-code) for how to do this.

## Template

If a contributor wishes to file a pull request manually, the template is below. Manually-filed pull requests should contain their commit message as the pull request description, and their commit message should be formatted like the template below.

Additionally, the pull request should be mentioned on [Bugzilla](https://bugs.webkit.org), labels applied to the pull request matching the component and version of the [Bugzilla](https://bugs.webkit.org) associated with the pull request and the pull request assigned to its author.

<pre>
< bug title >
<a href="https://bugs.webkit.org/enter_bug.cgi">https://bugs.webkit.org/show_bug.cgi?id=#####</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* path/changed.ext:
(function):
(class.function):

</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/46d45eed352a2c71106e729cb399564b659e5d5e

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| [✅ 🛠 wpe-238-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/1/builds/206 "Built successfully") | [✅ 🧪 wpe-238-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/5/builds/79 "Passed tests") 
| [✅ 🛠 wpe-238-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/8/builds/204 "Built successfully") | [✅ 🧪 wpe-238-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/6/builds/89 "Passed tests") 
| | 
| | 
<!--EWS-Status-Bubble-End-->