### PR TITLE
CodeBlock should reset its StubInfo when jettisoned https://bugs.webk…

### DIFF
--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -2187,6 +2187,15 @@ void CodeBlock::jettison(Profiler::JettisonReason reason, ReoptimizationMode mod
     CODEBLOCK_LOG_EVENT(codeBlock, "jettison", ("due to ", reason, ", counting = ", mode == CountReoptimization, ", detail = ", pointerDump(detail)));
 
     RELEASE_ASSERT(reason != Profiler::NotJettisoned);
+
+#if ENABLE(JIT)
+    ConcurrentJSLocker locker(m_lock);
+    forEachStructureStubInfo([&](StructureStubInfo& stubInfo) {
+        stubInfo.reset(locker, this);
+        return IterationStatus::Continue;
+    });
+#endif
+
     
 #if ENABLE(DFG_JIT)
     if (DFG::shouldDumpDisassembly()) {


### PR DESCRIPTION
…it.org/show_bug.cgi?id=288554 rdar://144072285

Reviewed by Yusuke Suzuki.

CodeBlock's StubInfo can keep watchpoints alive which do not ref data they hold, meaning that when the CodeBlock is jettisoned, we may have dangling pointers to data that was freed during a GC.

* Source/JavaScriptCore/bytecode/CodeBlock.cpp: (JSC::CodeBlock::jettison):

Originally-landed-as: 289651.190@safari-7621-branch (15053072f223). rdar://148056646
Canonical link: https://commits.webkit.org/293230@main

# Pull Request Template

## File a Bug

All changes should be associated with a bug. The WebKit project is currently using [Bugzilla](https://bugs.webkit.org) as our bug tracker. Note that multiple changes may be associated with a single bug.

## Provided Tooling

The WebKit Project strongly recommends contributors use [`Tools/Scripts/git-webkit`](https://github.com/WebKit/WebKit/tree/main/Tools/Scripts/git-webkit) to generate pull requests. See [Setup](https://github.com/WebKit/WebKit/wiki/Contributing#setup) and [Contributing Code](https://github.com/WebKit/WebKit/wiki/Contributing#contributing-code) for how to do this.

## Template

If a contributor wishes to file a pull request manually, the template is below. Manually-filed pull requests should contain their commit message as the pull request description, and their commit message should be formatted like the template below.

Additionally, the pull request should be mentioned on [Bugzilla](https://bugs.webkit.org), labels applied to the pull request matching the component and version of the [Bugzilla](https://bugs.webkit.org) associated with the pull request and the pull request assigned to its author.

<pre>
< bug title >
<a href="https://bugs.webkit.org/enter_bug.cgi">https://bugs.webkit.org/show_bug.cgi?id=#####</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* path/changed.ext:
(function):
(class.function):

</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/c9241c1cab0956f44b6c07523724bd9167d68469

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| [✅ 🛠 wpe-238-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/1/builds/208 "Built successfully") | [✅ 🧪 wpe-238-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/5/builds/81 "Passed tests") 
| [✅ 🛠 wpe-238-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/8/builds/206 "Built successfully") | [✅ 🧪 wpe-238-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/6/builds/91 "Passed tests") 
| | 
| | 
<!--EWS-Status-Bubble-End-->