### PR TITLE
PolymorphicCallNode should unchain itself first in unlink https://bug…

### DIFF
--- a/Source/JavaScriptCore/jit/PolymorphicCallStubRoutine.cpp
+++ b/Source/JavaScriptCore/jit/PolymorphicCallStubRoutine.cpp
@@ -45,13 +45,16 @@ PolymorphicCallNode::~PolymorphicCallNode()
 
 void PolymorphicCallNode::unlink(VM& vm)
 {
+    // We first remove itself from the linked-list before unlinking m_callLinkInfo.
+    // The reason is that m_callLinkInfo can potentially link PolymorphicCallNode's stub itself, and it may destroy |this| (the other CallLinkInfo
+    // does not do it since it is not chained in PolymorphicCallStubRoutine).
+    if (isOnList())
+        remove();
+
     if (m_callLinkInfo) {
         dataLogLnIf(Options::dumpDisassembly(), "Unlinking polymorphic call at ", m_callLinkInfo->doneLocation(), ", bc#", m_callLinkInfo->codeOrigin().bytecodeIndex());
         m_callLinkInfo->unlink(vm);
     }
-
-    if (isOnList())
-        remove();
 }
 
 void PolymorphicCallNode::clearCallLinkInfo()


### PR DESCRIPTION
…s.webkit.org/show_bug.cgi?id=265475 rdar://118893186

Reviewed by Mark Lam.

PolymorphicCallNode::unlinkImpl calls m_callLinkInfo->unlink. But it is possible that this CallLinkInfo is holding PolymorphicCallNode's owner stub and it may clear stub. Previously, we are always deferring this stub destruction until JITStubRoutineSet destroys it. But now, it is possible that they get deleted immediately when owner CodeBlock is dead. This means that after calling m_callLinkInfo->unlink, it is possible that PolymorphicCallNode |this| is already destroyed.

This patch reorders unlink's operation in PolymorphicCallNode so that we first unlink it from linked-list. This is OK since we are not expecting that this is in the linked-list in unlink calls. So after m_callLinkInfo->unlink, we no longer touch anything in PolymorphicCallNode.

* Source/JavaScriptCore/jit/PolymorphicCallStubRoutine.cpp: (JSC::PolymorphicCallNode::unlinkImpl):

Canonical link: https://commits.webkit.org/271246@main

# Pull Request Template

## File a Bug

All changes should be associated with a bug. The WebKit project is currently using [Bugzilla](https://bugs.webkit.org) as our bug tracker. Note that multiple changes may be associated with a single bug.

## Provided Tooling

The WebKit Project strongly recommends contributors use [`Tools/Scripts/git-webkit`](https://github.com/WebKit/WebKit/tree/main/Tools/Scripts/git-webkit) to generate pull requests. See [Setup](https://github.com/WebKit/WebKit/wiki/Contributing#setup) and [Contributing Code](https://github.com/WebKit/WebKit/wiki/Contributing#contributing-code) for how to do this.

## Template

If a contributor wishes to file a pull request manually, the template is below. Manually-filed pull requests should contain their commit message as the pull request description, and their commit message should be formatted like the template below.

Additionally, the pull request should be mentioned on [Bugzilla](https://bugs.webkit.org), labels applied to the pull request matching the component and version of the [Bugzilla](https://bugs.webkit.org) associated with the pull request and the pull request assigned to its author.

<pre>
< bug title >
<a href="https://bugs.webkit.org/enter_bug.cgi">https://bugs.webkit.org/show_bug.cgi?id=#####</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* path/changed.ext:
(function):
(class.function):

</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/06a5eaf6bf3473ac41ce7fc289d463e925db40b8

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| [✅ 🛠 wpe-238-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/1/builds/211 "Built successfully") | [✅ 🧪 wpe-238-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/5/builds/82 "Passed tests") 
| [✅ 🛠 wpe-238-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/8/builds/209 "Built successfully") | [✅ 🧪 wpe-238-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/6/builds/92 "Passed tests") 
| | 
| | 
<!--EWS-Status-Bubble-End-->