### PR TITLE
Do not upgrade CallLinkInfo when the target is also already dead http…

### DIFF
--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -2286,7 +2286,7 @@ void CodeBlock::jettison(Profiler::JettisonReason reason, ReoptimizationMode mod
         return;
 
     // This accomplishes (2).
-    ownerExecutable()->installCode(vm, alternative(), codeType(), specializationKind());
+    ownerExecutable()->installCode(vm, alternative(), codeType(), specializationKind(), reason);
 
 #if ENABLE(DFG_JIT)
     if (DFG::shouldDumpDisassembly())

--- a/Source/JavaScriptCore/runtime/ScriptExecutable.cpp
+++ b/Source/JavaScriptCore/runtime/ScriptExecutable.cpp
@@ -115,10 +115,10 @@ void ScriptExecutable::clearCode(IsoCellSet& clearableCodeSet)
 
 void ScriptExecutable::installCode(CodeBlock* codeBlock)
 {
-    installCode(codeBlock->vm(), codeBlock, codeBlock->codeType(), codeBlock->specializationKind());
+    installCode(codeBlock->vm(), codeBlock, codeBlock->codeType(), codeBlock->specializationKind(), Profiler::JettisonReason::NotJettisoned);
 }
 
-void ScriptExecutable::installCode(VM& vm, CodeBlock* genericCodeBlock, CodeType codeType, CodeSpecializationKind kind)
+void ScriptExecutable::installCode(VM& vm, CodeBlock* genericCodeBlock, CodeType codeType, CodeSpecializationKind kind, Profiler::JettisonReason reason)
 {
     if (genericCodeBlock)
         CODEBLOCK_LOG_EVENT(genericCodeBlock, "installCode", ());
@@ -196,6 +196,17 @@ void ScriptExecutable::installCode(VM& vm, CodeBlock* genericCodeBlock, CodeType
         Debugger* debugger = genericCodeBlock->globalObject()->debugger();
         if (UNLIKELY(debugger))
             debugger->registerCodeBlock(genericCodeBlock);
+    }
+
+    switch (reason) {
+    case Profiler::JettisonReason::JettisonDueToWeakReference:
+    case Profiler::JettisonReason::JettisonDueToOldAge: {
+        if (genericCodeBlock && !vm.heap.isMarked(genericCodeBlock))
+            genericCodeBlock = nullptr;
+        break;
+    }
+    default:
+        break;
     }
 
     if (oldCodeBlock)
@@ -401,7 +412,7 @@ void ScriptExecutable::prepareForExecutionImpl(VM& vm, JSFunction* function, JSS
             setupJIT(vm, codeBlock);
     }
 
-    installCode(vm, codeBlock, codeBlock->codeType(), codeBlock->specializationKind());
+    installCode(vm, codeBlock, codeBlock->codeType(), codeBlock->specializationKind(), Profiler::JettisonReason::NotJettisoned);
 }
 
 ScriptExecutable* ScriptExecutable::topLevelExecutable()

--- a/Source/JavaScriptCore/runtime/ScriptExecutable.h
+++ b/Source/JavaScriptCore/runtime/ScriptExecutable.h
@@ -27,6 +27,7 @@
 
 #include "ExecutableBase.h"
 #include "ParserModes.h"
+#include "ProfilerJettisonReason.h"
 
 namespace JSC {
 
@@ -88,7 +89,7 @@ public:
 
     void recordParse(CodeFeatures, LexicalScopeFeatures, bool hasCapturedVariables, int lastLine, unsigned endColumn);
     void installCode(CodeBlock*);
-    void installCode(VM&, CodeBlock*, CodeType, CodeSpecializationKind);
+    void installCode(VM&, CodeBlock*, CodeType, CodeSpecializationKind, Profiler::JettisonReason);
     CodeBlock* newCodeBlockFor(CodeSpecializationKind, JSFunction*, JSScope*);
     CodeBlock* newReplacementCodeBlockFor(CodeSpecializationKind);
 


### PR DESCRIPTION
…s://bugs.webkit.org/show_bug.cgi?id=270119 rdar://123651394

Reviewed by Justin Michaud.

Probably does not matter much but let's make it defensive. When running unlinkOrUpgrade, if it is invoked through jettisoning due to GC end-phase check, we should check whether the new target CodeBlock is also dead, and if it is dead, not passing it.

* Source/JavaScriptCore/bytecode/CodeBlock.cpp: (JSC::CodeBlock::jettison):
* Source/JavaScriptCore/runtime/ScriptExecutable.cpp: (JSC::ScriptExecutable::installCode):
(JSC::ScriptExecutable::prepareForExecutionImpl):
* Source/JavaScriptCore/runtime/ScriptExecutable.h:

Canonical link: https://commits.webkit.org/275356@main

# Pull Request Template

## File a Bug

All changes should be associated with a bug. The WebKit project is currently using [Bugzilla](https://bugs.webkit.org) as our bug tracker. Note that multiple changes may be associated with a single bug.

## Provided Tooling

The WebKit Project strongly recommends contributors use [`Tools/Scripts/git-webkit`](https://github.com/WebKit/WebKit/tree/main/Tools/Scripts/git-webkit) to generate pull requests. See [Setup](https://github.com/WebKit/WebKit/wiki/Contributing#setup) and [Contributing Code](https://github.com/WebKit/WebKit/wiki/Contributing#contributing-code) for how to do this.

## Template

If a contributor wishes to file a pull request manually, the template is below. Manually-filed pull requests should contain their commit message as the pull request description, and their commit message should be formatted like the template below.

Additionally, the pull request should be mentioned on [Bugzilla](https://bugs.webkit.org), labels applied to the pull request matching the component and version of the [Bugzilla](https://bugs.webkit.org) associated with the pull request and the pull request assigned to its author.

<pre>
< bug title >
<a href="https://bugs.webkit.org/enter_bug.cgi">https://bugs.webkit.org/show_bug.cgi?id=#####</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* path/changed.ext:
(function):
(class.function):

</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/4a334cf546e38fff6285df3e4991dcc047331ad8

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| [✅ 🛠 wpe-238-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/1/builds/212 "Built successfully") | [  ~~🧪 wpe-238-amd64-layout~~](https://ews-wpe-rdk.igalia.com/#/builders/5/builds/83 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🛠 wpe-238-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/8/builds/210 "Built successfully") | [  ~~🧪 wpe-238-arm32-layout~~](https://ews-wpe-rdk.igalia.com/#/builders/6/builds/93 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | 
| | 
<!--EWS-Status-Bubble-End-->