### PR TITLE
[WPE] Extend PROJECT_VERSINO_MICRO with external suffix

### DIFF
--- a/Source/cmake/OptionsWPE.cmake
+++ b/Source/cmake/OptionsWPE.cmake
@@ -1,7 +1,11 @@
 include(GNUInstallDirs)
 include(VersioningUtils)
 
-SET_PROJECT_VERSION(2 46 7)
+# Allow appending a suffix to the micro version from the build system (e.g. bitbake)
+# to distinguish builds with API additions: -DWPE_VERSION_MICRO_SUFFIX=1
+# Result: 2.46.7 + suffix 1 → micro becomes 71, so version is 2.46.71
+set(WPE_VERSION_MICRO_SUFFIX "" CACHE STRING "Suffix to append to PROJECT_VERSION_MICRO for WPE builds")
+SET_PROJECT_VERSION(2 46 "7${WPE_VERSION_MICRO_SUFFIX}")
 
 set(USER_AGENT_BRANDING "" CACHE STRING "Branding to add to user agent string")
 


### PR DESCRIPTION
Webkit exposes APIs to query currently running version:
```
#define WEBKIT_MAJOR_VERSION (@PROJECT_VERSION_MAJOR@)
#define WEBKIT_MINOR_VERSION (@PROJECT_VERSION_MINOR@)
#define WEBKIT_MICRO_VERSION (@PROJECT_VERSION_MICRO@)

#define WEBKIT_CHECK_VERSION(major, minor, micro) \
    (WEBKIT_MAJOR_VERSION > (major) || \
    (WEBKIT_MAJOR_VERSION == (major) && WEBKIT_MINOR_VERSION > (minor)) || \
    (WEBKIT_MAJOR_VERSION == (major) && WEBKIT_MINOR_VERSION == (minor) && \
     WEBKIT_MICRO_VERSION >= (micro)))

WEBKIT_API guint
webkit_get_major_version (void);

WEBKIT_API guint
webkit_get_minor_version (void);

WEBKIT_API guint
webkit_get_micro_version (void);
```
That doesn't change frequently because it corresponds to upstream webkit relase version I believe.

The problem is that WPE webkit constantly receives new updates, new commits, new APIs. Our integration code is separated from webkit and delivered externally to the device so it doesn't stick to any particular webkit version. It loads the library in runtime and we need some way to tell what set of APIs is available in this particular version.
Using webkit versioning API is fine to distinguish between webkit 2.38 and 2.46 but it doesn't tell much on 2.46 patch level.

My proposal here is to extend current versioning with one more number that will be part of MICRO version. We can manually bump it up every "internal release" so we can check exact version in runtime while still keeping original upstream versioning intact.


<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/67826a1434ae2351c73a320e989027c77843b5d1

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/227 "Built successfully") | [✅ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/102 "Passed tests") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/227 "Built successfully") | [✅ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/10/builds/106 "Passed tests") 
<!--EWS-Status-Bubble-End-->