### PR TITLE
Avoid dangling pointers in WeakBlock list https://bugs.webkit.org/sho…

### DIFF
--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -2534,6 +2534,7 @@ bool Heap::shouldDoFullCollection()
 
 void Heap::addLogicallyEmptyWeakBlock(WeakBlock* block)
 {
+    RELEASE_ASSERT(!block->next() && !block->prev());
     m_logicallyEmptyWeakBlocks.append(block);
 }
 
@@ -2552,6 +2553,7 @@ bool Heap::sweepNextLogicallyEmptyWeakBlock()
         return false;
 
     WeakBlock* block = m_logicallyEmptyWeakBlocks[m_indexOfNextLogicallyEmptyWeakBlockToSweep];
+    RELEASE_ASSERT(!block->next() && !block->prev());
 
     block->sweep();
     if (block->isEmpty()) {

--- a/Source/JavaScriptCore/heap/WeakBlock.cpp
+++ b/Source/JavaScriptCore/heap/WeakBlock.cpp
@@ -45,6 +45,7 @@ WeakBlock* WeakBlock::create(Heap& heap, CellContainer container)
 
 void WeakBlock::destroy(Heap& heap, WeakBlock* block)
 {
+    RELEASE_ASSERT(!block->next() && !block->prev());
     block->~WeakBlock();
     WeakBlockMalloc::free(block);
     heap.didFreeBlock(WeakBlock::blockSize);

--- a/Source/JavaScriptCore/heap/WeakSet.cpp
+++ b/Source/JavaScriptCore/heap/WeakSet.cpp
@@ -37,12 +37,9 @@ WeakSet::~WeakSet()
         remove();
     
     Heap& heap = *this->heap();
-    WeakBlock* next = nullptr;
-    for (WeakBlock* block = m_blocks.head(); block; block = next) {
-        next = block->next();
+    while (WeakBlock* block = m_blocks.removeHead())
         WeakBlock::destroy(heap, block);
-    }
-    m_blocks.clear();
+    ASSERT(m_blocks.isEmpty());
 }
 
 void WeakSet::sweep()

--- a/Source/WTF/wtf/DoublyLinkedList.h
+++ b/Source/WTF/wtf/DoublyLinkedList.h
@@ -41,8 +41,8 @@ public:
 
 template<typename T> inline DoublyLinkedListNode<T>::DoublyLinkedListNode()
 {
-    setPrev(0);
-    setNext(0);
+    setPrev(nullptr);
+    setNext(nullptr);
 }
 
 template<typename T> inline void DoublyLinkedListNode<T>::setPrev(T* prev)
@@ -84,14 +84,16 @@ public:
     void remove(T*);
     void append(DoublyLinkedList<T>&);
 
+    DoublyLinkedList<T> splitAt(size_t);
+
 private:
     T* m_head;
     T* m_tail;
 };
 
 template<typename T> inline DoublyLinkedList<T>::DoublyLinkedList()
-    : m_head(0)
-    , m_tail(0)
+    : m_head(nullptr)
+    , m_tail(nullptr)
 {
 }
 
@@ -126,38 +128,57 @@ template<typename T> inline T* DoublyLinkedList<T>::tail() const
 
 template<typename T> inline void DoublyLinkedList<T>::push(T* node)
 {
+    ASSERT(!node->prev() && !node->next());
     if (!m_head) {
         ASSERT(!m_tail);
         m_head = node;
         m_tail = node;
-        node->setPrev(0);
-        node->setNext(0);
         return;
     }
 
     ASSERT(m_tail);
     m_head->setPrev(node);
     node->setNext(m_head);
-    node->setPrev(0);
     m_head = node;
 }
 
 template<typename T> inline void DoublyLinkedList<T>::append(T* node)
 {
+    ASSERT(!node->prev() && !node->next());
     if (!m_tail) {
         ASSERT(!m_head);
         m_head = node;
         m_tail = node;
-        node->setPrev(0);
-        node->setNext(0);
         return;
     }
 
     ASSERT(m_head);
     m_tail->setNext(node);
     node->setPrev(m_tail);
-    node->setNext(0);
     m_tail = node;
+}
+
+template<typename T> inline DoublyLinkedList<T> DoublyLinkedList<T>::splitAt(size_t toKeep)
+{
+    auto* p = head();
+
+    if (!p || !p->next())
+        return { };
+    for (size_t i = 1; i < toKeep; i++) {
+        p = p->next();
+        if (!p->next())
+            return { };
+    }
+
+    DoublyLinkedList<T> newList { };
+    newList.m_head = p->next();
+    newList.m_tail = m_tail;
+    newList.m_head->setPrev(nullptr);
+
+    m_tail = p;
+    m_tail->setNext(nullptr);
+
+    return newList;
 }
 
 template<typename T> inline void DoublyLinkedList<T>::remove(T* node)
@@ -177,6 +198,8 @@ template<typename T> inline void DoublyLinkedList<T>::remove(T* node)
         ASSERT(node == m_tail);
         m_tail = node->prev();
     }
+    node->setNext(nullptr);
+    node->setPrev(nullptr);
 }
 
 template<typename T> inline T* DoublyLinkedList<T>::removeHead()


### PR DESCRIPTION
…w_bug.cgi?id=298236 rdar://157587352

Reviewed by Keith Miller.

Before this change, DoublyLinkedList leaves the next/prev pointers in a dangling state when removing a node from the list. Then, if the node is re-added, the next/prev pointers are reset when necessary.

Let's make a stronger invariant: if the node is not in the list, then the prev/next pointers are nullptr. (Note that the converse is not true for single element lists.)

Then, add some asserts to verify the WeakSet's WeakBlock list lifecycle to try to help track down a mysterious crash. The WeakBlock ownership can be transferred from the WeakSet to the Heap, at which point the prev/next should be nulled out and, after this change, no longer dangling.

Bonus: remove MarkedSpace::freeOrShrinkBlock() since it's never called.
Canonical link: https://commits.webkit.org/299454@main

# Pull Request Template

## File a Bug

All changes should be associated with a bug. The WebKit project is currently using [Bugzilla](https://bugs.webkit.org) as our bug tracker. Note that multiple changes may be associated with a single bug.

## Provided Tooling

The WebKit Project strongly recommends contributors use [`Tools/Scripts/git-webkit`](https://github.com/WebKit/WebKit/tree/main/Tools/Scripts/git-webkit) to generate pull requests. See [Setup](https://github.com/WebKit/WebKit/wiki/Contributing#setup) and [Contributing Code](https://github.com/WebKit/WebKit/wiki/Contributing#contributing-code) for how to do this.

## Template

If a contributor wishes to file a pull request manually, the template is below. Manually-filed pull requests should contain their commit message as the pull request description, and their commit message should be formatted like the template below.

Additionally, the pull request should be mentioned on [Bugzilla](https://bugs.webkit.org), labels applied to the pull request matching the component and version of the [Bugzilla](https://bugs.webkit.org) associated with the pull request and the pull request assigned to its author.

<pre>
< bug title >
<a href="https://bugs.webkit.org/enter_bug.cgi">https://bugs.webkit.org/show_bug.cgi?id=#####</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* path/changed.ext:
(function):
(class.function):

</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/578321a8019eed33fdc42bdf884853f73286f4dc

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| [✅ 🛠 wpe-238-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/1/builds/216 "Built successfully") | [✅ 🧪 wpe-238-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/5/builds/86 "Passed tests") 
| [✅ 🛠 wpe-238-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/8/builds/214 "Built successfully") | [✅ 🧪 wpe-238-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/6/builds/96 "Passed tests") 
| | 
| | 
<!--EWS-Status-Bubble-End-->