### PR TITLE
ASSERTION FAILED: CacheableIdentifier::isCacheableIdentifierCell(fiel…

### DIFF
--- a/JSTests/stress/get-private-name-cell.js
+++ b/JSTests/stress/get-private-name-cell.js
@@ -1,0 +1,19 @@
+function __f_0() {}
+__v_0 = 0
+class __c_0 {
+  #field = this.init()
+  init() {
+    if (__v_0 % 2)
+      this.anotherField = 0
+    return 0
+  }
+  getField() { this.#field }
+}
+for (; ; __v_0++) {
+  __v_9 = new __c_0
+  __f_0(__v_9.getField())
+  __v_9.__proto__ = []
+  __v_9.getField0
+  if (__v_0 == 1000)
+    break;
+}

--- a/Source/JavaScriptCore/bytecode/StructureStubInfo.cpp
+++ b/Source/JavaScriptCore/bytecode/StructureStubInfo.cpp
@@ -261,6 +261,9 @@ void StructureStubInfo::reset(const ConcurrentJSLockerBase& locker, CodeBlock* c
     case AccessType::GetPrivateName:
         resetGetBy(codeBlock, *this, GetByKind::PrivateName);
         break;
+    case AccessType::GetPrivateNameById:
+        resetGetBy(codeBlock, *this, GetByKind::PrivateNameById);
+        break;
     case AccessType::PutById:
         resetPutBy(codeBlock, *this, PutByKind::ById);
         break;
@@ -440,6 +443,8 @@ static FunctionPtr<OperationPtrTag> slowOperationFromUnlinkedStructureStubInfo(c
         return operationHasPrivateBrandOptimize;
     case AccessType::GetPrivateName:
         return operationGetPrivateNameOptimize;
+    case AccessType::GetPrivateNameById:
+        return operationGetPrivateNameByIdOptimize;
     case AccessType::PutById:
         switch (unlinkedStubInfo.putKind) {
         case PutKind::NotDirect:
@@ -584,6 +589,7 @@ void StructureStubInfo::initializeFromUnlinkedStructureStubInfo(const BaselineUn
     case AccessType::TryGetById:
     case AccessType::GetByIdDirect:
     case AccessType::GetById:
+    case AccessType::GetPrivateNameById:
         hasConstantIdentifier = true;
         m_extraGPR = InvalidGPRReg;
         m_baseGPR = BaselineJITRegisters::GetById::baseJSR.payloadGPR();

--- a/Source/JavaScriptCore/bytecode/StructureStubInfo.h
+++ b/Source/JavaScriptCore/bytecode/StructureStubInfo.h
@@ -71,6 +71,7 @@ enum class AccessType : int8_t {
     DeleteByID,
     DeleteByVal,
     GetPrivateName,
+    GetPrivateNameById,
     CheckPrivateBrand,
     SetPrivateBrand,
 };
@@ -100,8 +101,8 @@ public:
     }
 
     StructureStubInfo()
-        : StructureStubInfo(AccessType::GetById, { })
-    { }
+    {
+    }
 
     ~StructureStubInfo();
 
@@ -372,7 +373,7 @@ public:
     GPRReg propertyTagGPR() const { return m_extraTagGPR; }
 #endif
 
-    CodeOrigin codeOrigin;
+    CodeOrigin codeOrigin { };
     PropertyOffset byIdSelfOffset;
     std::unique_ptr<PolymorphicAccess> m_stub;
     WriteBarrierStructureID m_inlineAccessBaseStructureID;
@@ -412,7 +413,7 @@ public:
     GPRReg m_extraTagGPR { InvalidGPRReg };
 #endif
 
-    AccessType accessType;
+    AccessType accessType { AccessType::GetById };
 private:
     CacheType m_cacheType { CacheType::Unset };
 public:
@@ -452,7 +453,7 @@ inline auto appropriateOptimizingGetByIdFunction(AccessType type) -> decltype(&o
         return operationTryGetByIdOptimize;
     case AccessType::GetByIdDirect:
         return operationGetByIdDirectOptimize;
-    case AccessType::GetPrivateName:
+    case AccessType::GetPrivateNameById:
         return operationGetPrivateNameByIdOptimize;
     case AccessType::GetByIdWithThis:
     default:
@@ -470,7 +471,7 @@ inline auto appropriateGenericGetByIdFunction(AccessType type) -> decltype(&oper
         return operationTryGetByIdGeneric;
     case AccessType::GetByIdDirect:
         return operationGetByIdDirectGeneric;
-    case AccessType::GetPrivateName:
+    case AccessType::GetPrivateNameById:
         return operationGetPrivateNameByIdGeneric;
     case AccessType::GetByIdWithThis:
     default:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -4217,7 +4217,7 @@ void SpeculativeJIT::compileGetPrivateNameById(Node* node)
         JSValueRegs baseRegs = JSValueRegs::payloadOnly(base.gpr());
         JSValueRegs resultRegs = result.regs();
 
-        cachedGetById(node->origin.semantic, baseRegs, resultRegs, stubInfoGPR, scratchGPR, node->cacheableIdentifier(), JITCompiler::Jump(), NeedToSpill, AccessType::GetPrivateName);
+        cachedGetById(node->origin.semantic, baseRegs, resultRegs, stubInfoGPR, scratchGPR, node->cacheableIdentifier(), JITCompiler::Jump(), NeedToSpill, AccessType::GetPrivateNameById);
 
         jsValueResult(resultRegs, node, DataFormatJS);
         break;
@@ -4242,7 +4242,7 @@ void SpeculativeJIT::compileGetPrivateNameById(Node* node)
 
         JITCompiler::Jump notCell = m_jit.branchIfNotCell(baseRegs);
 
-        cachedGetById(node->origin.semantic, baseRegs, resultRegs, stubInfoGPR, scratchGPR, node->cacheableIdentifier(), notCell, NeedToSpill, AccessType::GetPrivateName);
+        cachedGetById(node->origin.semantic, baseRegs, resultRegs, stubInfoGPR, scratchGPR, node->cacheableIdentifier(), notCell, NeedToSpill, AccessType::GetPrivateNameById);
 
         jsValueResult(resultRegs, node, DataFormatJS);
         break;

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -4128,7 +4128,7 @@ private:
     {
         JSGlobalObject* globalObject = m_graph.globalObjectFor(m_node->origin.semantic);
         if (m_node->child1().useKind() == CellUse)
-            setJSValue(getById(lowCell(m_node->child1()), AccessType::GetPrivateName));
+            setJSValue(getById(lowCell(m_node->child1()), AccessType::GetPrivateNameById));
         else {
             LValue base = lowJSValue(m_node->child1());
 
@@ -4141,7 +4141,7 @@ private:
 
             LBasicBlock lastNext = m_out.appendTo(baseCellCase, notCellCase);
 
-            ValueFromBlock cellResult = m_out.anchor(getById(base, AccessType::GetPrivateName));
+            ValueFromBlock cellResult = m_out.anchor(getById(base, AccessType::GetPrivateNameById));
             m_out.jump(continuation);
 
             m_out.appendTo(notCellCase, continuation);

--- a/Source/JavaScriptCore/jit/GPRInfo.h
+++ b/Source/JavaScriptCore/jit/GPRInfo.h
@@ -180,14 +180,14 @@ public:
     {
     }
     
-    static constexpr JSValueRegs withTwoAvailableRegs(GPRReg gpr1, GPRReg gpr2)
+    static constexpr JSValueRegs withTwoAvailableRegs(GPRReg tagGPR, GPRReg payloadGPR)
     {
-        return JSValueRegs(gpr1, gpr2);
+        return JSValueRegs(tagGPR, payloadGPR);
     }
     
-    static constexpr JSValueRegs payloadOnly(GPRReg gpr)
+    static constexpr JSValueRegs payloadOnly(GPRReg payloadGPR)
     {
-        return JSValueRegs(InvalidGPRReg, gpr);
+        return JSValueRegs(InvalidGPRReg, payloadGPR);
     }
     
     bool operator!() const { return !static_cast<bool>(*this); }

--- a/Source/JavaScriptCore/jit/ICStats.h
+++ b/Source/JavaScriptCore/jit/ICStats.h
@@ -65,8 +65,8 @@ namespace JSC {
     macro(OperationPutByIdDirectNonStrictOptimize) \
     macro(OperationPutByIdStrictBuildList) \
     macro(OperationPutByIdNonStrictBuildList) \
-    macro(OperationPutByIdDefinePrivateFieldFieldStrictOptimize) \
-    macro(OperationPutByIdPutPrivateFieldFieldStrictOptimize) \
+    macro(OperationPutByIdDefinePrivateFieldStrictOptimize) \
+    macro(OperationPutByIdPutPrivateFieldStrictOptimize) \
     macro(PutByAddAccessCase) \
     macro(PutByReplaceWithJump) \
     macro(PutBySelfPatch) \
@@ -80,7 +80,8 @@ namespace JSC {
     macro(CheckPrivateBrandAddAccessCase) \
     macro(SetPrivateBrandAddAccessCase) \
     macro(CheckPrivateBrandReplaceWithJump) \
-    macro(SetPrivateBrandReplaceWithJump)
+    macro(SetPrivateBrandReplaceWithJump) \
+    macro(OperationPutByIdSetPrivateFieldStrictOptimize)
 
 class ICEvent {
 public:

--- a/Source/JavaScriptCore/jit/JITOperations.cpp
+++ b/Source/JavaScriptCore/jit/JITOperations.cpp
@@ -992,7 +992,7 @@ JSC_DEFINE_JIT_OPERATION(operationPutByIdDefinePrivateFieldStrictOptimize, void,
     
     definePrivateField(vm, globalObject, callFrame, baseValue, identifier, value, [=](VM& vm, CodeBlock* codeBlock, Structure* oldStructure, PutPropertySlot& putSlot, const Identifier& ident) {
         JSObject* baseObject = asObject(baseValue);
-        LOG_IC((ICEvent::OperationPutByIdDefinePrivateFieldFieldStrictOptimize, baseObject->classInfo(), ident, putSlot.base() == baseObject));
+        LOG_IC((ICEvent::OperationPutByIdDefinePrivateFieldStrictOptimize, baseObject->classInfo(), ident, putSlot.base() == baseObject));
 
         ASSERT_UNUSED(accessType, accessType == static_cast<AccessType>(stubInfo->accessType));
 
@@ -1028,7 +1028,7 @@ JSC_DEFINE_JIT_OPERATION(operationPutByIdSetPrivateFieldStrictOptimize, void, (J
 
     setPrivateField(vm, globalObject, callFrame, baseValue, identifier, value, [&](VM& vm, CodeBlock* codeBlock, Structure* oldStructure, PutPropertySlot& putSlot, const Identifier& ident) {
         JSObject* baseObject = asObject(baseValue);
-        LOG_IC((ICEvent::OperationPutByIdPutPrivateFieldFieldStrictOptimize, baseObject->classInfo(), ident, putSlot.base() == baseObject));
+        LOG_IC((ICEvent::OperationPutByIdSetPrivateFieldStrictOptimize, baseObject->classInfo(), ident, putSlot.base() == baseObject));
 
         ASSERT_UNUSED(accessType, accessType == static_cast<AccessType>(stubInfo->accessType));
 
@@ -2514,7 +2514,7 @@ JSC_DEFINE_JIT_OPERATION(operationGetPrivateNameByIdOptimize, EncodedJSValue, (J
         base->getPrivateField(globalObject, fieldName, slot);
         RETURN_IF_EXCEPTION(scope, encodedJSValue());
 
-        LOG_IC((ICEvent::OperationGetPrivateNameOptimize, baseValue.classInfoOrNull(), fieldName, true));
+        LOG_IC((ICEvent::OperationGetPrivateNameByIdOptimize, baseValue.classInfoOrNull(), fieldName, true));
 
         CodeBlock* codeBlock = callFrame->codeBlock();
         if (stubInfo->considerCachingBy(vm, codeBlock, baseValue.structureOrNull(), identifier))


### PR DESCRIPTION
…dNameValue) https://bugs.webkit.org/show_bug.cgi?id=242640

Reviewed by Yusuke Suzuki.

This patch adds AccessType::GetPrivateNameById, the corresponding slow path code, and changes compileGetPrivateNameById to use it when calling cachedGetById.

The patch also includes some minor changes:
1. Adds default member initializer to StructureStubInfo
2. Rename argument names in JSValueRegs::withTwoAvailableRegs to be clearer
3. Fix typos in ICEVENT and where they are called

* JSTests/stress/get-private-name-cell.js: Added. (__f_0):
(__v_0.0.__c_0.prototype.field.this.init.init):
(__v_0.0.__c_0.prototype.getField):
(__v_0.0.__c_0):
* Source/JavaScriptCore/bytecode/StructureStubInfo.cpp: (JSC::StructureStubInfo::reset):
(JSC::slowOperationFromUnlinkedStructureStubInfo): (JSC::StructureStubInfo::initializeFromUnlinkedStructureStubInfo):
* Source/JavaScriptCore/bytecode/StructureStubInfo.h: (JSC::StructureStubInfo::StructureStubInfo):
(JSC::appropriateOptimizingGetByIdFunction):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/jit/GPRInfo.h: (JSC::JSValueRegs::withTwoAvailableRegs):
(JSC::JSValueRegs::payloadOnly):
* Source/JavaScriptCore/jit/ICStats.h:
* Source/JavaScriptCore/jit/JITOperations.cpp: (JSC::JSC_DEFINE_JIT_OPERATION):

Canonical link: https://commits.webkit.org/254938@main

# Pull Request Template

## File a Bug

All changes should be associated with a bug. The WebKit project is currently using [Bugzilla](https://bugs.webkit.org) as our bug tracker. Note that multiple changes may be associated with a single bug.

## Provided Tooling

The WebKit Project strongly recommends contributors use [`Tools/Scripts/git-webkit`](https://github.com/WebKit/WebKit/tree/main/Tools/Scripts/git-webkit) to generate pull requests. See [Setup](https://github.com/WebKit/WebKit/wiki/Contributing#setup) and [Contributing Code](https://github.com/WebKit/WebKit/wiki/Contributing#contributing-code) for how to do this.

## Template

If a contributor wishes to file a pull request manually, the template is below. Manually-filed pull requests should contain their commit message as the pull request description, and their commit message should be formatted like the template below.

Additionally, the pull request should be mentioned on [Bugzilla](https://bugs.webkit.org), labels applied to the pull request matching the component and version of the [Bugzilla](https://bugs.webkit.org) associated with the pull request and the pull request assigned to its author.

<pre>
< bug title >
<a href="https://bugs.webkit.org/enter_bug.cgi">https://bugs.webkit.org/show_bug.cgi?id=#####</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* path/changed.ext:
(function):
(class.function):

</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/87dd61563abaf28ddaaa0ea775af838597f18794

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| [✅ 🛠 wpe-238-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/1/builds/217 "Built successfully") | [✅ 🧪 wpe-238-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/5/builds/87 "Passed tests") 
| [✅ 🛠 wpe-238-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/8/builds/215 "Built successfully") | [✅ 🧪 wpe-238-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/6/builds/97 "Passed tests") 
| | 
| | 
<!--EWS-Status-Bubble-End-->