### PR TITLE
PropertyCondition::isStillValidAssumingImpurePropertyWatchpoint() sho…

### DIFF
--- a/LayoutTests/fast/dom/non-reified-event-isTrusted-ic-crash-expected.txt
+++ b/LayoutTests/fast/dom/non-reified-event-isTrusted-ic-crash-expected.txt
@@ -1,0 +1,9 @@
+No crash when property 'x' is assigned
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/dom/non-reified-event-isTrusted-ic-crash.html
+++ b/LayoutTests/fast/dom/non-reified-event-isTrusted-ic-crash.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script>
+description("No crash when property 'x' is assigned");
+
+// This structure has a non-reified static property "isTrusted".
+const EVENT = new Event('a');
+
+
+function opt(use_event, proxy) {
+    let tmp = Object.create(null);
+    if (use_event)
+        tmp = Object.create(EVENT);
+
+    tmp.isTrusted = 1;  // Here the compiler expects that it'll transition but at runtime it'll fail due to the setter from EVENT.
+
+    tmp.a0 = 0x1111;
+    tmp.a1 = 0x2222;
+    tmp.a2 = 0x3333;
+    tmp.a3 = 0x4444;
+    tmp.a4 = 0x5555;
+    tmp.a5 = 0x6666;
+    
+    proxy.set_getter_on = tmp;
+
+    const value = tmp.a5;
+
+    return value;
+}
+
+
+function initialize() {
+    {
+        const object = Object.create(EVENT);
+        Object.defineProperty(object, 'isTrusted', {value: 1, writable: true, enumerable: true, configurable: true});
+
+        object.a0 = 1;
+        object.a1 = 1;
+        object.a2 = 1;
+        object.a3 = 1;
+        object.a4 = 1;
+        object.a5 = 1;
+    }
+
+    {
+        const object = Object.create(EVENT);
+
+        object.a0 = 1;
+        object.a1 = 1;
+        object.a2 = 1;
+        object.a3 = 1;
+        object.a4 = 1;
+        object.a5 = 1;
+    }
+}
+
+
+function main() {
+    const proxy = new Proxy({}, {
+        set: (object, property, value) => {
+            const tmp = {};
+            tmp[26] = 2.3023e-320;
+            value[26] = 1.1;
+
+            return true;
+        }
+    });
+
+    initialize();
+
+    for (let i = 0; i < 1000; i++) {
+        opt(/* use_event */ false, /* proxy */ 1.1);
+        opt(/* use_event */ true, /* proxy */ 1.1);
+    }
+    
+    if (window.testRunner)
+        testRunner.waitUntilDone();
+
+    setTimeout(() => {
+        const value = opt(/* use_event */ true, proxy);
+
+        // Should crash here.
+        value.x = 1234;
+
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }, 100);
+}
+
+main();
+
+</script>

--- a/Source/JavaScriptCore/bytecode/PropertyCondition.cpp
+++ b/Source/JavaScriptCore/bytecode/PropertyCondition.cpp
@@ -205,6 +205,14 @@ bool PropertyCondition::isStillValidAssumingImpurePropertyWatchpoint(
             if (PropertyConditionInternal::verbose)
                 dataLog("Invalid because its put() override may treat ", uid(), " property as read-only.\n");
             return false;
+        } else if (structure->hasNonReifiedStaticProperties()) {
+            if (auto entry = structure->findPropertyHashEntry(uid())) {
+                if (entry->value->attributes() & (PropertyAttribute::ReadOnlyOrAccessorOrCustomAccessor | PropertyAttribute::CustomValue)) {
+                    if (PropertyConditionInternal::verbose)
+                        dataLog("Invalid because we expected not to have a setter, but we have one in non-reified static property table: ", uid(), ".\n");
+                    return false;
+                }
+            }
         }
 
         if (structure->hasPolyProto()) {


### PR DESCRIPTION
…uld take non-reified static properties into account https://bugs.webkit.org/show_bug.cgi?id=255952 <rdar://108334411>

Reviewed by Yusuke Suzuki.

Currently, PropertyCondition::isStillValidAssumingImpurePropertyWatchpoint() is not checking the structure's non-reified static properties against the condition. This can lead to incorrect analysis of side effects: AbsenceOfSetEffect condition with a non-reified static setter is considered pure even though a setter with arbitrary code can be invoked.

This patch fixes AbsenceOfSetEffect validity check for structures with non-reified static properties while takes extra care to make the fix as precise as possible to avoid unnecessary slowdowns.

* LayoutTests/fast/dom/non-reified-event-isTrusted-ic-crash-expected.txt: Added.
* LayoutTests/fast/dom/non-reified-event-isTrusted-ic-crash.html: Added.
* Source/JavaScriptCore/bytecode/PropertyCondition.cpp: (JSC::PropertyCondition::isStillValidAssumingImpurePropertyWatchpoint const):

Originally-landed-as: 259548.775@safari-7615-branch (ffe32d106cb2). rdar://113160398
Canonical link: https://commits.webkit.org/266582@main

# Pull Request Template

## File a Bug

All changes should be associated with a bug. The WebKit project is currently using [Bugzilla](https://bugs.webkit.org) as our bug tracker. Note that multiple changes may be associated with a single bug.

## Provided Tooling

The WebKit Project strongly recommends contributors use [`Tools/Scripts/git-webkit`](https://github.com/WebKit/WebKit/tree/main/Tools/Scripts/git-webkit) to generate pull requests. See [Setup](https://github.com/WebKit/WebKit/wiki/Contributing#setup) and [Contributing Code](https://github.com/WebKit/WebKit/wiki/Contributing#contributing-code) for how to do this.

## Template

If a contributor wishes to file a pull request manually, the template is below. Manually-filed pull requests should contain their commit message as the pull request description, and their commit message should be formatted like the template below.

Additionally, the pull request should be mentioned on [Bugzilla](https://bugs.webkit.org), labels applied to the pull request matching the component and version of the [Bugzilla](https://bugs.webkit.org) associated with the pull request and the pull request assigned to its author.

<pre>
< bug title >
<a href="https://bugs.webkit.org/enter_bug.cgi">https://bugs.webkit.org/show_bug.cgi?id=#####</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* path/changed.ext:
(function):
(class.function):

</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/57370704bffa6958a2f9b5531494e6931b25fc15

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| [✅ 🛠 wpe-238-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/1/builds/218 "Built successfully") | [✅ 🧪 wpe-238-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/5/builds/88 "Passed tests") 
| [✅ 🛠 wpe-238-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/8/builds/216 "Built successfully") | [✅ 🧪 wpe-238-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/6/builds/98 "Passed tests") 
| | 
| | 
<!--EWS-Status-Bubble-End-->