### PR TITLE
disallow rialtomseaudio in webaudio

### DIFF
--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.cpp
@@ -66,6 +66,10 @@ GStreamerQuirkRialto::GStreamerQuirkRialto()
                 m_sinkCaps = WTFMove(templateCaps);
         }
     }
+
+    m_disallowedWebAudioDecoders = {
+        "rialtomseaudiosink"_s
+    };
 }
 
 bool GStreamerQuirkRialto::isPlatformSupported() const

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.h
@@ -41,10 +41,12 @@ public:
     GstElement* createAudioSink() final;
     GstElement* createWebAudioSink() final;
     std::optional<bool> isHardwareAccelerated(GstElementFactory*) final;
+    Vector<String> disallowedWebAudioDecoders() const final { return m_disallowedWebAudioDecoders; }
     bool shouldParseIncomingLibWebRTCBitStream() const final { return false; }
     unsigned getAdditionalPlaybinFlags() const { return getGstPlayFlag("text") | getGstPlayFlag("native-audio") | getGstPlayFlag("native-video"); }
 
 private:
+    Vector<String> m_disallowedWebAudioDecoders;
     GRefPtr<GstCaps> m_sinkCaps;
 };
 


### PR DESCRIPTION
this affects `AudioContext.decodeAudioData` usage when there is a discrepancy between `rialtomseaudiosink` and software decoding plugins available on the platform. such a situation causes `HTMLMediaElement::canPlayType` declare support for content type but it should be understood as playback and not decoding to `PCM`. in turn it makes `autoplug-select` as used in [AudioFileReaderGStreamer.cpp](https://github.com/WebPlatformForEmbedded/WPEWebKit/blob/wpe-2.38/Source/WebCore/platform/audio/gstreamer/AudioFileReaderGStreamer.cpp#L413C42-L413C57) to pick `rialtomseaudiosink` which is invalid as per case when:
* non-`PCM` content is used - get stuck in sample passing loop, it will be waiting to play which doesn't really happen in this scenario as samples were to be pulled and passed to another pipeline 
* `PCM` content is used - crash as the samples pulled won't be available to be taken

adding `rialtomseaudiosink` to disallowed plugins list in quirks corrects the situation and in case of missing browser side decoding plugin makes it simply fail. when they are present however they will be the only and right choice for decoding making it work as expected.<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/d50c86ffec2a4b9ccf40b51512ac175c2f63bcc2

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| [✅ 🛠 wpe-238-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/1/builds/227 "Built successfully") | [✅ 🧪 wpe-238-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/5/builds/94 "Passed tests") 
| [✅ 🛠 wpe-238-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/8/builds/226 "Built successfully") | [✅ 🧪 wpe-238-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/6/builds/103 "Passed tests") 
| | 
| | 
<!--EWS-Status-Bubble-End-->