### PR TITLE
HTML audio element currentTime property too high when setting srcObje…

### DIFF
--- a/LayoutTests/fast/mediastream/media-element-current-time.html
+++ b/LayoutTests/fast/mediastream/media-element-current-time.html
@@ -16,6 +16,8 @@ promise_test(async() => {
     let currentTime = video.currentTime;
     assert_not_equals(currentTime, 0, "Playback has started, currentTime must not be zero");
 
+    assert_less_than(currentTime, 3, "currentTime should be small initially");
+
     await waitForVideoFrame(video);
     await waitForVideoFrame(video);
     assert_greater_than(video.currentTime, currentTime, "video is playing, time should advance");

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
@@ -137,6 +137,7 @@ void MediaPlayerPrivateMediaStreamAVFObjC::setNativeImageCreator(NativeImageCrea
 
 MediaPlayerPrivateMediaStreamAVFObjC::MediaPlayerPrivateMediaStreamAVFObjC(MediaPlayer* player)
     : m_player(player)
+    , m_startTime(MediaTime::invalidTime())
     , m_videoRotation { VideoFrameRotation::None }
     , m_logger(player->mediaPlayerLogger())
     , m_logIdentifier(player->mediaPlayerLogIdentifier())

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -183,6 +183,7 @@ MediaPlayerPrivateGStreamer::MediaPlayerPrivateGStreamer(MediaPlayer* player)
     , m_logger(player->mediaPlayerLogger())
     , m_logIdentifier(player->mediaPlayerLogIdentifier())
 #endif
+    , m_startTime(MediaTime::invalidTime())
 #if USE(TEXTURE_MAPPER_DMABUF)
     , m_swapchain(adoptRef(new GBMBufferSwapchain(GBMBufferSwapchain::BufferSwapchainSize::Eight)))
 #endif


### PR DESCRIPTION
…ct to MediaStream (macOS and iOS)

https://bugs.webkit.org/show_bug.cgi?id=285391
rdar://142465970

Reviewed by Jean-Yves Avenard.

We were not initializing m_startTime to an invalid value since MediaPlayerPrivateMediaStreamAVFObjC::play is checking for whether it is valid or not. We initialize m_startTime to an invalid value so that it can be correctly initialized in MediaPlayerPrivateMediaStreamAVFObjC::play.

Covered by updated test.

* LayoutTests/fast/mediastream/media-element-current-time.html:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm: (WebCore::MediaPlayerPrivateMediaStreamAVFObjC::MediaPlayerPrivateMediaStreamAVFObjC):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp: (WebCore::MediaPlayerPrivateGStreamer::MediaPlayerPrivateGStreamer):

Canonical link: https://commits.webkit.org/288519@main<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/85b92f411f83efccc8a6b603b195d62437673bbb

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/248 "Built successfully") | [✅ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/106 "Passed tests") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/248 "Built successfully") | [✅ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/10/builds/110 "Passed tests") 
<!--EWS-Status-Bubble-End-->