### PR TITLE
[GStreamer] webrtc/video-vp8-videorange.html is flaky failing

### DIFF
--- a/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp
@@ -205,13 +205,19 @@ void CanvasCaptureMediaStreamTrack::Source::captureCanvas()
     auto& gstVideoFrame = downcast<VideoFrameGStreamer>(*videoFrame);
     static const double s_fixedFrameRate = 60.0;
 
+    if (!m_clock)
+        m_clock = adoptGRef(gst_system_clock_obtain());
+    RELEASE_ASSERT(m_clock);
+
     if (!m_frameRequestRate)
         gstVideoFrame.setMaxFrameRate(s_fixedFrameRate);
 
-    auto frameRate = m_frameRequestRate.value_or(s_fixedFrameRate);
+    auto frameRate = s_fixedFrameRate;
+    if (m_frameRequestRate && *m_frameRequestRate)
+        frameRate = *m_frameRequestRate;
+
     gstVideoFrame.setFrameRate(frameRate);
-    gstVideoFrame.setPresentationTime(m_presentationTimeStamp);
-    m_presentationTimeStamp += MediaTime::createWithDouble(1.0 / frameRate);
+    gstVideoFrame.setPresentationTime(fromGstClockTime(gst_clock_get_time(m_clock.get())));
 #endif
 
     VideoFrameTimeMetadata metadata;

--- a/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp
@@ -202,15 +202,16 @@ void CanvasCaptureMediaStreamTrack::Source::captureCanvas()
         return;
 
 #if USE(GSTREAMER)
-    auto gstVideoFrame = downcast<VideoFrameGStreamer>(videoFrame);
-    if (m_frameRequestRate)
-        gstVideoFrame->setFrameRate(*m_frameRequestRate);
-    else {
-        static const double s_frameRate = 60;
-        gstVideoFrame->setMaxFrameRate(s_frameRate);
-        gstVideoFrame->setPresentationTime(m_presentationTimeStamp);
-        m_presentationTimeStamp = m_presentationTimeStamp + MediaTime::createWithDouble(1.0 / s_frameRate);
-    }
+    auto& gstVideoFrame = downcast<VideoFrameGStreamer>(*videoFrame);
+    static const double s_fixedFrameRate = 60.0;
+
+    if (!m_frameRequestRate)
+        gstVideoFrame.setMaxFrameRate(s_fixedFrameRate);
+
+    auto frameRate = m_frameRequestRate.value_or(s_fixedFrameRate);
+    gstVideoFrame.setFrameRate(frameRate);
+    gstVideoFrame.setPresentationTime(m_presentationTimeStamp);
+    m_presentationTimeStamp += MediaTime::createWithDouble(1.0 / frameRate);
 #endif
 
     VideoFrameTimeMetadata metadata;

--- a/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.h
+++ b/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.h
@@ -33,6 +33,10 @@
 #include <wtf/TypeCasts.h>
 #include <wtf/WeakPtr.h>
 
+#if USE(GSTREAMER)
+#include "GRefPtrGStreamer.h"
+#endif
+
 namespace WebCore {
 
 class Document;
@@ -90,7 +94,7 @@ private:
         WeakPtr<HTMLCanvasElement, WeakPtrImplWithEventTargetData> m_canvas;
         RefPtr<Image> m_currentImage;
 #if USE(GSTREAMER)
-        MediaTime m_presentationTimeStamp { MediaTime::zeroTime() };
+        GRefPtr<GstClock> m_clock;
 #endif
     };
 

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
@@ -438,7 +438,7 @@ void VideoFrameGStreamer::setPresentationTime(const MediaTime& presentationTime)
 {
     updateTimestamp(presentationTime, VideoFrame::ShouldCloneWithDifferentTimestamp::No);
     auto buffer = gst_sample_get_buffer(m_sample.get());
-    GST_BUFFER_PTS(buffer) = GST_BUFFER_DTS(buffer) = toGstClockTime(1_s / presentationTime.toDouble());
+    GST_BUFFER_PTS(buffer) = GST_BUFFER_DTS(buffer) = toGstClockTime(presentationTime);
 }
 
 static void copyPlane(uint8_t* destination, const uint8_t* source, uint64_t sourceStride, const ComputedPlaneLayout& spanPlaneLayout)


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=305356

Reviewed by Xabier Rodriguez-Calvar.

The test was timing out sometimes, the vp8 decoder dropping frames it thought were too late. The timestamps of the buffers passed to the encoder were actually incorrect. We now timestamp video frames captured from the canvas in all cases.

* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp: (WebCore::CanvasCaptureMediaStreamTrack::Source::captureCanvas):
* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp: (WebCore::VideoFrameGStreamer::setPresentationTime):

Canonical link: https://commits.webkit.org/305810@main<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/076381d0c0ddb24c732dae92f56d3a259ee91d3c

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/251 "Built successfully") | [✅ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/109 "Passed tests") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/251 "Built successfully") | [✅ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/10/builds/113 "Passed tests") 
<!--EWS-Status-Bubble-End-->