### PR TITLE
[GStreamer] mediaTime from requestVideoFrameCallback is wrong in case…

### DIFF
--- a/LayoutTests/fast/mediastream/captureStream/canvas-rvfc-metadata-expected.txt
+++ b/LayoutTests/fast/mediastream/captureStream/canvas-rvfc-metadata-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS requestVideoFrameCallback metadata for canvas captureStream (2d context)
+

--- a/LayoutTests/fast/mediastream/captureStream/canvas-rvfc-metadata.html
+++ b/LayoutTests/fast/mediastream/captureStream/canvas-rvfc-metadata.html
@@ -1,0 +1,74 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+    <body>
+        <canvas id="canvas" width=100 height=100></canvas>
+        <video id="video" autoplay width=100 height=100></video>
+        <script src="../../../resources/testharness.js"></script>
+        <script src="../../../resources/testharnessreport.js"></script>
+        <script>
+
+const canvas = document.getElementById("canvas");
+const video  = document.getElementById("video");
+
+function drawFrame(color) {
+    const ctx = canvas.getContext("2d");
+    ctx.fillStyle = color;
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+}
+
+function waitForFrame(v) {
+    return new Promise((resolve, reject) => {
+        const id = v.requestVideoFrameCallback((now, metadata) => resolve({ now, metadata }));
+        setTimeout(() => {
+            v.cancelVideoFrameCallback(id);
+            reject("requestVideoFrameCallback timed out after 5s");
+        }, 5000);
+    });
+}
+
+promise_test(async test => {
+    const stream = canvas.captureStream();
+    video.srcObject = stream;
+
+    // Let the pipeline initialize before registering the first callback.
+    await new Promise(resolve => requestAnimationFrame(() => setTimeout(resolve, 0)));
+
+    drawFrame("green");
+    const { metadata: meta1 } = await waitForFrame(video);
+
+    // Dimensions must match the canvas.
+    assert_equals(meta1.width,  canvas.width,  "width matches canvas");
+    assert_equals(meta1.height, canvas.height, "height matches canvas");
+
+    // presentedFrames must be at least 1.
+    assert_greater_than(meta1.presentedFrames, 0, "presentedFrames > 0");
+
+    // presentationTime is a DOMHighResTimeStamp (ms since time origin), must be positive.
+    assert_greater_than(meta1.presentationTime, 0, "presentationTime > 0");
+
+    // expectedDisplayTime must be at or after presentationTime.
+    assert_greater_than_equal(meta1.expectedDisplayTime, meta1.presentationTime,
+        "expectedDisplayTime >= presentationTime");
+
+    // mediaTime is stream-relative (seconds since stream start), must be non-negative
+    // and well below the system uptime, confirming it is not the raw clock value.
+    assert_greater_than_equal(meta1.mediaTime, 0, "mediaTime >= 0");
+    assert_less_than(meta1.mediaTime, 60, "mediaTime is stream-relative, not an absolute clock value");
+
+    // captureTime must be provided for canvas capture frames.
+    assert_not_equals(meta1.captureTime, undefined, "captureTime is set");
+    assert_greater_than(meta1.captureTime, 0, "captureTime > 0");
+
+    // Draw a second frame and verify all monotonically-increasing fields advance.
+    drawFrame("green");
+    const { metadata: meta2 } = await waitForFrame(video);
+
+    assert_greater_than(meta2.presentedFrames, meta1.presentedFrames, "presentedFrames increases");
+    assert_greater_than(meta2.presentationTime, meta1.presentationTime, "presentationTime increases");
+    assert_greater_than(meta2.mediaTime, meta1.mediaTime, "mediaTime increases");
+
+}, "requestVideoFrameCallback metadata for canvas captureStream (2d context)");
+
+        </script>
+    </body>
+</html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -183,6 +183,7 @@ scrollingcoordinator/non-fast-scrollable-region-scaled-iframe.html [ Skip ]
 scrollingcoordinator/non-fast-scrollable-region-transformed-iframe.html [ Skip ]
 
 imported/w3c/web-platform-tests/video-rvfc [ Pass ]
+fast/mediastream/captureStream/canvas-rvfc-metadata.html [ Failure ]
 fast/mediastream/getUserMedia-rvfc.html [ Pass ]
 webrtc/peerConnection-rvfc.html [ Pass ]
 # Timing out tests until we add XR session.

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -207,6 +207,8 @@ webkit.org/b/61827 fast/events/drag-image-filename.html
 fast/mediastream/microphone-change-while-muted.html [ Pass ]
 
 # Media Stream API is not fully supported.
+fast/mediastream/captureStream/canvas-rvfc-metadata.html [ Failure ]
+
 fast/mediastream/MediaStream-add-ended-tracks.html
 
 fast/mediastream/RTCPeerConnection-ice.html [ Skip ]

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -4900,8 +4900,12 @@ std::optional<VideoFrameMetadata> MediaPlayerPrivateGStreamer::videoFrameMetadat
     metadata.presentedFrames = m_sampleCount;
 
     if (GST_BUFFER_PTS_IS_VALID(buffer)) {
-        auto bufferPts = fromGstClockTime(GST_BUFFER_PTS(buffer));
-        metadata.mediaTime = (bufferPts - m_estimatedVideoFrameDuration).toDouble();
+        if (isMediaStreamPlayer())
+            metadata.mediaTime = currentTime().toDouble();
+        else {
+            auto bufferPts = fromGstClockTime(GST_BUFFER_PTS(buffer));
+            metadata.mediaTime = (bufferPts - m_estimatedVideoFrameDuration).toDouble();
+        }
     }
 
     // FIXME: presentationTime and expectedDisplayTime might not always have the same value, we should try getting more precise values.


### PR DESCRIPTION
… of captureCanvas as source

https://bugs.webkit.org/show_bug.cgi?id=316190

Reviewed by Philippe Normand.

Canvas capture frames have their PTS stamped with the absolute GStreamer system clock time. Because the default GstSegment has start=0, calling gst_segment_to_stream_time on such a buffer returns the raw clock value (system uptime in seconds), not a stream-relative position. To fix that and set the correct value of mediaTime in VideoFrameMetadata provided by requestVideoFrameCallback, this change detects canvas frames via their VideoFrameContentHint and uses currentTime() instead.

A new layout test fast/mediastream/captureStream/canvas-rvfc-metadata.html validates the metadata fields returned by requestVideoFrameCallback for a canvas captureStream, including that mediaTime is stream-relative and not an absolute clock value.

Test: fast/mediastream/captureStream/canvas-rvfc-metadata.html
* LayoutTests/fast/mediastream/captureStream/canvas-rvfc-metadata-expected.txt: Added.
* LayoutTests/fast/mediastream/captureStream/canvas-rvfc-metadata.html: Added.
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp: (WebCore::MediaPlayerPrivateGStreamer::videoFrameMetadata):

Canonical link: https://commits.webkit.org/314533@main<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/4b399f5dba7d133c54b6ed96f65da6dced9566e3

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/253 "Built successfully") | [❌ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/111 "Found 1 new test failure: fast/mediastream/captureStream/canvas-rvfc-metadata.html (failure)") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/253 "Built successfully") | [❌ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/10/builds/115 "Found 1 new test failure: fast/mediastream/captureStream/canvas-rvfc-metadata.html (failure)") 
<!--EWS-Status-Bubble-End-->