### PR TITLE
[GStreamer][MediaStream] Fix time metadata handling in CanvasCaptureM…

### DIFF
--- a/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp
@@ -201,6 +201,9 @@ void CanvasCaptureMediaStreamTrack::Source::captureCanvas()
     if (!videoFrame)
         return;
 
+    VideoFrameTimeMetadata metadata;
+    metadata.captureTime = MonotonicTime::now().secondsSinceEpoch();
+
 #if USE(GSTREAMER)
     auto& gstVideoFrame = downcast<VideoFrameGStreamer>(*videoFrame);
     static const double s_fixedFrameRate = 60.0;
@@ -218,10 +221,9 @@ void CanvasCaptureMediaStreamTrack::Source::captureCanvas()
 
     gstVideoFrame.setFrameRate(frameRate);
     gstVideoFrame.setPresentationTime(fromGstClockTime(gst_clock_get_time(m_clock.get())));
+    gstVideoFrame.setMetadata({ metadata });
 #endif
 
-    VideoFrameTimeMetadata metadata;
-    metadata.captureTime = MonotonicTime::now().secondsSinceEpoch();
     videoFrameAvailable(*videoFrame, metadata);
 }
 

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
@@ -395,11 +395,7 @@ VideoFrameGStreamer::VideoFrameGStreamer(GRefPtr<GstSample>&& sample, const Floa
     if (!metadata)
         return;
 
-    GRefPtr buffer = gst_sample_get_buffer(m_sample.get());
-    RELEASE_ASSERT(buffer);
-    auto modifiedBuffer = webkitGstBufferSetVideoFrameTimeMetadata(WTFMove(buffer), WTFMove(metadata));
-    m_sample = adoptGRef(gst_sample_make_writable(m_sample.leakRef()));
-    gst_sample_set_buffer(m_sample.get(), modifiedBuffer.get());
+    setMetadata(WTFMove(metadata));
 }
 
 VideoFrameGStreamer::VideoFrameGStreamer(const GRefPtr<GstSample>& sample, const FloatSize& presentationSize, const MediaTime& presentationTime, Rotation videoRotation, PlatformVideoColorSpace&& colorSpace)
@@ -439,6 +435,15 @@ void VideoFrameGStreamer::setPresentationTime(const MediaTime& presentationTime)
     updateTimestamp(presentationTime, VideoFrame::ShouldCloneWithDifferentTimestamp::No);
     auto buffer = gst_sample_get_buffer(m_sample.get());
     GST_BUFFER_PTS(buffer) = GST_BUFFER_DTS(buffer) = toGstClockTime(presentationTime);
+}
+
+void VideoFrameGStreamer::setMetadata(std::optional<VideoFrameTimeMetadata>&& metadata)
+{
+    GRefPtr buffer = gst_sample_get_buffer(m_sample.get());
+    RELEASE_ASSERT(buffer);
+    auto modifiedBuffer = webkitGstBufferSetVideoFrameTimeMetadata(WTFMove(buffer), WTFMove(metadata));
+    m_sample = adoptGRef(gst_sample_make_writable(m_sample.leakRef()));
+    gst_sample_set_buffer(m_sample.get(), modifiedBuffer.get());
 }
 
 static void copyPlane(uint8_t* destination, const uint8_t* source, uint64_t sourceStride, const ComputedPlaneLayout& spanPlaneLayout)

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.h
@@ -53,6 +53,8 @@ public:
 
     void setPresentationTime(const MediaTime&);
 
+    void setMetadata(std::optional<VideoFrameTimeMetadata>&&);
+
     RefPtr<VideoFrameGStreamer> resizeTo(const IntSize&);
 
     GRefPtr<GstSample> resizedSample(const IntSize&);


### PR DESCRIPTION
…ediaStreamTrack

https://bugs.webkit.org/show_bug.cgi?id=295466

Reviewed by Xabier Rodriguez-Calvar.

Metadata is attached to the GStreamer buffer associated with each video frame. In case of canvas capture the captureTime was lost, because our implementation of videoFrameAvailable doesn't use it.

* Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp: (WebCore::CanvasCaptureMediaStreamTrack::Source::captureCanvas):
* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp: (WebCore::VideoFrameGStreamer::VideoFrameGStreamer): (WebCore::VideoFrameGStreamer::setMetadata):
* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.h:

Canonical link: https://commits.webkit.org/297043@main<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/d9a2faa7ffaa41120307297c651251c9a5551473

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/254 "Built successfully") | [✅ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/112 "Passed tests") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/254 "Built successfully") | [✅ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/10/builds/116 "Passed tests") 
<!--EWS-Status-Bubble-End-->