### PR TITLE
navigator.mediaCapabilities wrapper should not become GC-collectable …

### DIFF
--- a/LayoutTests/fast/dom/navigator-property-gc-after-frame-detach-expected.txt
+++ b/LayoutTests/fast/dom/navigator-property-gc-after-frame-detach-expected.txt
@@ -3,16 +3,19 @@ Tests that Navigator properties do not get GC'd before their Navigator object.
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
+PASS frameNavigator.mediaCapabilities.foo is 1
 PASS frameNavigator.geolocation.foo is 1
 PASS frameNavigator.mimeTypes.foo is 1
 PASS frameNavigator.plugins.foo is 1
 PASS frameNavigator.serviceWorker.foo is 1
 
+PASS frameNavigator.mediaCapabilities.foo is 1
 PASS frameNavigator.geolocation.foo is 1
 PASS frameNavigator.mimeTypes.foo is 1
 PASS frameNavigator.plugins.foo is 1
 PASS frameNavigator.serviceWorker.foo is 1
 
+PASS frameNavigator.mediaCapabilities.foo is 1
 PASS frameNavigator.geolocation.foo is 1
 PASS frameNavigator.mimeTypes.foo is 1
 PASS frameNavigator.plugins.foo is 1

--- a/LayoutTests/fast/dom/navigator-property-gc-after-frame-detach.html
+++ b/LayoutTests/fast/dom/navigator-property-gc-after-frame-detach.html
@@ -7,7 +7,7 @@
 description("Tests that Navigator properties do not get GC'd before their Navigator object.");
 jsTestIsAsync = true;
 
-var navigatorProperties = [ "geolocation", "mimeTypes", "plugins" ];
+var navigatorProperties = [ "mediaCapabilities", "geolocation", "mimeTypes", "plugins" ];
 if (navigator.serviceWorker)
     navigatorProperties.push("serviceWorker");
 

--- a/Source/WebCore/Modules/mediacapabilities/MediaCapabilities.cpp
+++ b/Source/WebCore/Modules/mediacapabilities/MediaCapabilities.cpp
@@ -39,6 +39,7 @@
 #include "MediaDecodingConfiguration.h"
 #include "MediaEncodingConfiguration.h"
 #include "MediaEngineConfigurationFactory.h"
+#include "NavigatorBase.h"
 #include "Page.h"
 #include "Settings.h"
 #include "WebRTCProvider.h"
@@ -46,6 +47,16 @@
 #include <wtf/SortedArrayMap.h>
 
 namespace WebCore {
+
+MediaCapabilities::MediaCapabilities(NavigatorBase& navigator)
+    : m_navigator(navigator)
+{
+}
+
+NavigatorBase* MediaCapabilities::navigator()
+{
+    return m_navigator.get();
+}
 
 static bool isValidMediaMIMEType(const ContentType& contentType)
 {

--- a/Source/WebCore/Modules/mediacapabilities/MediaCapabilities.h
+++ b/Source/WebCore/Modules/mediacapabilities/MediaCapabilities.h
@@ -33,18 +33,22 @@
 namespace WebCore {
 
 class DeferredPromise;
+class NavigatorBase;
 class ScriptExecutionContext;
 
 class MediaCapabilities : public RefCounted<MediaCapabilities>, public CanMakeWeakPtr<MediaCapabilities> {
 public:
-    static Ref<MediaCapabilities> create() { return adoptRef(*new MediaCapabilities); }
+    static Ref<MediaCapabilities> create(NavigatorBase& navigator) { return adoptRef(*new MediaCapabilities(navigator)); }
+
+    NavigatorBase* navigator();
 
     void decodingInfo(ScriptExecutionContext&, MediaDecodingConfiguration&&, Ref<DeferredPromise>&&);
     void encodingInfo(ScriptExecutionContext&, MediaEncodingConfiguration&&, Ref<DeferredPromise>&&);
 
 private:
-    MediaCapabilities() = default;
+    explicit MediaCapabilities(NavigatorBase&);
 
+    WeakPtr<NavigatorBase> m_navigator;
     uint64_t m_nextTaskIdentifier { 0 };
     HashMap<uint64_t, MediaEngineConfigurationFactory::DecodingConfigurationCallback> m_decodingTasks;
     HashMap<uint64_t, MediaEngineConfigurationFactory::EncodingConfigurationCallback> m_encodingTasks;

--- a/Source/WebCore/Modules/mediacapabilities/MediaCapabilities.idl
+++ b/Source/WebCore/Modules/mediacapabilities/MediaCapabilities.idl
@@ -25,7 +25,8 @@
 
 [
     EnabledBySetting=MediaCapabilitiesEnabled,
-    Exposed=(Window,DedicatedWorker)
+    Exposed=(Window,DedicatedWorker),
+    GenerateIsReachable=ReachableFromNavigator
 ] interface MediaCapabilities {
     [CallWith=CurrentScriptExecutionContext] Promise<MediaCapabilitiesDecodingInfo> decodingInfo(MediaDecodingConfiguration configuration);
     [CallWith=CurrentScriptExecutionContext] Promise<MediaCapabilitiesEncodingInfo> encodingInfo(MediaEncodingConfiguration configuration);

--- a/Source/WebCore/Modules/mediacapabilities/NavigatorMediaCapabilities.cpp
+++ b/Source/WebCore/Modules/mediacapabilities/NavigatorMediaCapabilities.cpp
@@ -31,8 +31,8 @@
 
 namespace WebCore {
 
-NavigatorMediaCapabilities::NavigatorMediaCapabilities()
-    : m_mediaCapabilities(MediaCapabilities::create())
+NavigatorMediaCapabilities::NavigatorMediaCapabilities(Navigator& navigator)
+    : m_mediaCapabilities(MediaCapabilities::create(navigator))
 {
 }
 
@@ -47,7 +47,7 @@ NavigatorMediaCapabilities& NavigatorMediaCapabilities::from(Navigator& navigato
 {
     NavigatorMediaCapabilities* supplement = static_cast<NavigatorMediaCapabilities*>(Supplement<Navigator>::from(&navigator, supplementName()));
     if (!supplement) {
-        auto newSupplement = makeUnique<NavigatorMediaCapabilities>();
+        auto newSupplement = makeUnique<NavigatorMediaCapabilities>(navigator);
         supplement = newSupplement.get();
         provideTo(&navigator, supplementName(), WTFMove(newSupplement));
     }

--- a/Source/WebCore/Modules/mediacapabilities/NavigatorMediaCapabilities.h
+++ b/Source/WebCore/Modules/mediacapabilities/NavigatorMediaCapabilities.h
@@ -35,7 +35,7 @@ class Navigator;
 class NavigatorMediaCapabilities final : public Supplement<Navigator> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    NavigatorMediaCapabilities();
+    explicit NavigatorMediaCapabilities(Navigator&);
     ~NavigatorMediaCapabilities();
 
     static MediaCapabilities& mediaCapabilities(Navigator&);

--- a/Source/WebCore/Modules/mediacapabilities/WorkerNavigatorMediaCapabilities.cpp
+++ b/Source/WebCore/Modules/mediacapabilities/WorkerNavigatorMediaCapabilities.cpp
@@ -31,8 +31,8 @@
 
 namespace WebCore {
 
-WorkerNavigatorMediaCapabilities::WorkerNavigatorMediaCapabilities()
-    : m_mediaCapabilities(MediaCapabilities::create())
+WorkerNavigatorMediaCapabilities::WorkerNavigatorMediaCapabilities(WorkerNavigator& navigator)
+    : m_mediaCapabilities(MediaCapabilities::create(navigator))
 {
 }
 
@@ -47,7 +47,7 @@ WorkerNavigatorMediaCapabilities& WorkerNavigatorMediaCapabilities::from(WorkerN
 {
     auto* supplement = static_cast<WorkerNavigatorMediaCapabilities*>(Supplement<WorkerNavigator>::from(&navigator, supplementName()));
     if (!supplement) {
-        auto newSupplement = makeUnique<WorkerNavigatorMediaCapabilities>();
+        auto newSupplement = makeUnique<WorkerNavigatorMediaCapabilities>(navigator);
         supplement = newSupplement.get();
         provideTo(&navigator, supplementName(), WTFMove(newSupplement));
     }

--- a/Source/WebCore/Modules/mediacapabilities/WorkerNavigatorMediaCapabilities.h
+++ b/Source/WebCore/Modules/mediacapabilities/WorkerNavigatorMediaCapabilities.h
@@ -35,7 +35,7 @@ class WorkerNavigator;
 class WorkerNavigatorMediaCapabilities final : public Supplement<WorkerNavigator> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    WorkerNavigatorMediaCapabilities();
+    explicit WorkerNavigatorMediaCapabilities(WorkerNavigator&);
     ~WorkerNavigatorMediaCapabilities();
 
     static MediaCapabilities& mediaCapabilities(WorkerNavigator&);


### PR DESCRIPTION
…before its navigator object

https://bugs.webkit.org/show_bug.cgi?id=315684

Reviewed by Ryosuke Niwa.

navigator.mediaCapabilities wrapper should not become GC-collectable before its navigator object. The MediaCapabilities interface is annotated [SameObject] in the spec: https://www.w3.org/TR/media-capabilities/#idl-index It means that navigator.mediaCapabilities must return the same object on every access.

See: https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1678

Original author: Andrzej Surdej (https://github.com/asurdej-comcast)

Updated existing LayoutTest with mediaCapabilities case.

* LayoutTests/fast/dom/navigator-property-gc-after-frame-detach-expected.txt:
* LayoutTests/fast/dom/navigator-property-gc-after-frame-detach.html:
* Source/WebCore/Modules/mediacapabilities/MediaCapabilities.cpp: (WebCore::MediaCapabilities::MediaCapabilities):
(WebCore::MediaCapabilities::navigator):
* Source/WebCore/Modules/mediacapabilities/MediaCapabilities.h: (WebCore::MediaCapabilities::create):
* Source/WebCore/Modules/mediacapabilities/MediaCapabilities.idl:
* Source/WebCore/Modules/mediacapabilities/NavigatorMediaCapabilities.cpp: (WebCore::NavigatorMediaCapabilities::NavigatorMediaCapabilities): (WebCore::NavigatorMediaCapabilities::from):
* Source/WebCore/Modules/mediacapabilities/NavigatorMediaCapabilities.h:
* Source/WebCore/Modules/mediacapabilities/WorkerNavigatorMediaCapabilities.cpp: (WebCore::WorkerNavigatorMediaCapabilities::WorkerNavigatorMediaCapabilities): (WebCore::WorkerNavigatorMediaCapabilities::from):
* Source/WebCore/Modules/mediacapabilities/WorkerNavigatorMediaCapabilities.h:

Canonical link: https://commits.webkit.org/315088@main<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/4d0202a47bba5dd0f6f6afcdf443354d94ff550f

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/256 "Built successfully") | [✅ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/114 "Passed tests") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/256 "Built successfully") | [✅ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/10/builds/118 "Passed tests") 
<!--EWS-Status-Bubble-End-->