### PR TITLE
[GStreamer] Video element with canvas captureStream source should not…

### DIFF
--- a/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp
@@ -76,7 +76,7 @@ Ref<CanvasCaptureMediaStreamTrack::Source> CanvasCaptureMediaStreamTrack::Source
 
 // FIXME: Give source id and name
 CanvasCaptureMediaStreamTrack::Source::Source(HTMLCanvasElement& canvas, std::optional<double>&& frameRequestRate)
-    : RealtimeMediaSource(CaptureDevice { { }, CaptureDevice::DeviceType::Camera, "CanvasCaptureMediaStreamTrack"_s })
+    : RealtimeMediaSource(CaptureDevice { { }, CaptureDevice::DeviceType::Canvas, "CanvasCaptureMediaStreamTrack"_s })
     , m_frameRequestRate(WTFMove(frameRequestRate))
     , m_requestFrameTimer(*this, &Source::requestFrameTimerFired)
     , m_captureCanvasTimer(*this, &Source::captureCanvas)

--- a/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.h
+++ b/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.h
@@ -85,6 +85,7 @@ private:
         void scheduleCaptureCanvas();
         void captureCanvas();
         void requestFrameTimerFired();
+        CaptureDevice::DeviceType deviceType() const final { return CaptureDevice::DeviceType::Canvas; }
 
         bool m_shouldEmitFrame { true };
         std::optional<double> m_frameRequestRate;

--- a/Source/WebCore/Modules/mediastream/MediaDeviceInfo.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaDeviceInfo.cpp
@@ -55,6 +55,7 @@ MediaDeviceInfo::Kind toMediaDeviceInfoKind(CaptureDevice::DeviceType type)
     case CaptureDevice::DeviceType::Speaker:
         return MediaDeviceInfo::Kind::Audiooutput;
     case CaptureDevice::DeviceType::Camera:
+    case CaptureDevice::DeviceType::Canvas:
     case CaptureDevice::DeviceType::Screen:
     case CaptureDevice::DeviceType::Window:
         return MediaDeviceInfo::Kind::Videoinput;

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
@@ -434,6 +434,14 @@ MediaProducerMediaStateFlags MediaStreamTrack::captureState(const RealtimeMediaS
         if (source.isProducingData())
             return MediaProducerMediaState::HasActiveVideoCaptureDevice;
         break;
+    case CaptureDevice::DeviceType::Canvas:
+        if (source.muted())
+            return MediaProducerMediaState::HasMutedVideoCaptureDevice;
+        if (source.interrupted())
+            return MediaProducerMediaState::HasInterruptedVideoCaptureDevice;
+        if (source.isProducingData())
+            return MediaProducerMediaState::HasActiveVideoCaptureDevice;
+        break;
     case CaptureDevice::DeviceType::Screen:
         if (source.muted())
             return MediaProducerMediaState::HasMutedScreenCaptureDevice;

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -5419,6 +5419,7 @@ static void updateCaptureSourceToPageMutedState(Document& document, Page& page, 
         source.setMuted(page.mutedState().contains(MediaProducerMutedState::AudioCaptureIsMuted) || (document.hidden() && document.settings().interruptAudioOnPageVisibilityChangeEnabled()));
         break;
     case CaptureDevice::DeviceType::Camera:
+    case CaptureDevice::DeviceType::Canvas:
         source.setMuted(page.mutedState().contains(MediaProducerMutedState::VideoCaptureIsMuted) || (document.hidden() && document.settings().interruptVideoOnPageVisibilityChangeEnabled()));
         break;
     case CaptureDevice::DeviceType::Screen:

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -4501,6 +4501,16 @@ bool MediaPlayerPrivateGStreamer::isHolePunchRenderingEnabled() const
     if (m_quirksManagerForTesting)
         return m_quirksManagerForTesting->supportsVideoHolePunchRendering();
 
+#if ENABLE(MEDIA_STREAM)
+    if (m_streamPrivate) {
+        auto* videoTrack = m_streamPrivate->activeVideoTrack();
+        if (!videoTrack)
+            return false;
+
+        return videoTrack->deviceType() != CaptureDevice::DeviceType::Canvas && GStreamerQuirksManager::singleton().supportsVideoHolePunchRendering();
+    }
+#endif
+
     auto& quirksManager = GStreamerQuirksManager::singleton();
     return quirksManager.supportsVideoHolePunchRendering();
 }

--- a/Source/WebCore/platform/mediastream/CaptureDevice.h
+++ b/Source/WebCore/platform/mediastream/CaptureDevice.h
@@ -32,7 +32,7 @@ namespace WebCore {
 
 class CaptureDevice {
 public:
-    enum class DeviceType : uint8_t { Unknown, Microphone, Speaker, Camera, Screen, Window, SystemAudio };
+    enum class DeviceType : uint8_t { Unknown, Microphone, Speaker, Camera, Screen, Window, SystemAudio, Canvas };
 
     CaptureDevice(const String& persistentId, DeviceType type, const String& label, const String& groupId = emptyString(), bool isEnabled = false, bool isDefault = false, bool isMock = false, bool isEphemeral = false)
         : m_persistentId(persistentId)

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
@@ -86,6 +86,7 @@ static RealtimeMediaSource::Type toSourceType(CaptureDevice::DeviceType type)
     case CaptureDevice::DeviceType::SystemAudio:
         return RealtimeMediaSource::Type::Audio;
     case CaptureDevice::DeviceType::Camera:
+    case CaptureDevice::DeviceType::Canvas:
     case CaptureDevice::DeviceType::Screen:
     case CaptureDevice::DeviceType::Window:
         return RealtimeMediaSource::Type::Video;

--- a/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp
+++ b/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp
@@ -85,6 +85,7 @@ CaptureSourceOrError DisplayCaptureSourceCocoa::create(const CaptureDevice& devi
     case CaptureDevice::DeviceType::Microphone:
     case CaptureDevice::DeviceType::Speaker:
     case CaptureDevice::DeviceType::Camera:
+    case CaptureDevice::DeviceType::Canvas:
     case CaptureDevice::DeviceType::Unknown:
         ASSERT_NOT_REACHED();
         break;

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDevice.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDevice.cpp
@@ -59,6 +59,7 @@ GstDevice* webkitMockDeviceCreate(const CaptureDevice& captureDevice)
 
     switch (captureDevice.type()) {
     case CaptureDevice::DeviceType::Camera:
+    case CaptureDevice::DeviceType::Canvas:
     case CaptureDevice::DeviceType::Screen:
     case CaptureDevice::DeviceType::Window:
         deviceClass = "Video/Source";

--- a/Source/WebCore/platform/mediastream/mac/DisplayCaptureManagerCocoa.cpp
+++ b/Source/WebCore/platform/mediastream/mac/DisplayCaptureManagerCocoa.cpp
@@ -92,6 +92,7 @@ std::optional<CaptureDevice> DisplayCaptureManagerCocoa::captureDeviceWithPersis
 
     case CaptureDevice::DeviceType::SystemAudio:
     case CaptureDevice::DeviceType::Camera:
+    case CaptureDevice::DeviceType::Canvas:
     case CaptureDevice::DeviceType::Microphone:
     case CaptureDevice::DeviceType::Speaker:
     case CaptureDevice::DeviceType::Unknown:

--- a/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp
@@ -249,6 +249,7 @@ public:
         case CaptureDevice::DeviceType::Microphone:
         case CaptureDevice::DeviceType::Speaker:
         case CaptureDevice::DeviceType::Camera:
+        case CaptureDevice::DeviceType::Canvas:
         case CaptureDevice::DeviceType::SystemAudio:
         case CaptureDevice::DeviceType::Unknown:
             ASSERT_NOT_REACHED();

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -203,6 +203,7 @@ private:
         case CaptureDevice::DeviceType::Microphone:
             return m_process.get()->allowsAudioCapture();
         case CaptureDevice::DeviceType::Camera:
+        case CaptureDevice::DeviceType::Canvas:
             if (!m_process.get()->allowsVideoCapture())
                 return false;
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
@@ -526,6 +526,7 @@ void UserMediaCaptureManagerProxy::createMediaSourceForCaptureDeviceWithConstrai
         sourceOrError = createMicrophoneSource(device, WTFMove(hashSalts), constraints, pageIdentifier);
         break;
     case WebCore::CaptureDevice::DeviceType::Camera:
+    case WebCore::CaptureDevice::DeviceType::Canvas:
         sourceOrError = createCameraSource(device, WTFMove(hashSalts), pageIdentifier);
         break;
     case WebCore::CaptureDevice::DeviceType::Screen:


### PR DESCRIPTION
… use holepunch rendering

https://bugs.webkit.org/show_bug.cgi?id=316297

Reviewed by Philippe Normand.

Introduce a dedicated Canvas device type in CaptureDevice::DeviceType to distinguish CanvasCaptureMediaStreamTrack sources from Camera sources. Update all switch statements and type checks across the mediastream stack to handle Canvas as a video type.
Disable GStreamer hole-punch rendering for canvas-captured streams since they render via a different path.

No new tests.

There is: ManualTests/mediastream/mediastream-canvas-to-video.html, which can be used to test this change. It should behave in the same way with: WEBKIT_GST_HOLE_PUNCH_QUIRK=fake and without it.

* Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp: (WebCore::CanvasCaptureMediaStreamTrack::Source::Source):
* Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.h:
* Source/WebCore/Modules/mediastream/MediaDeviceInfo.cpp: (WebCore::toMediaDeviceInfoKind):
* Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp: (WebCore::MediaStreamTrack::captureState):
* Source/WebCore/dom/Document.cpp: (WebCore::updateCaptureSourceToPageMutedState):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp: (WebCore::MediaPlayerPrivateGStreamer::isHolePunchRenderingEnabled const):
* Source/WebCore/platform/mediastream/CaptureDevice.h:
* Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp: (WebCore::toSourceType):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.cpp: (WebCore::GStreamerCaptureDeviceManager::refreshCaptureDevices):
* Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp:

Canonical link: https://commits.webkit.org/315089@main