### PR TITLE
Queue frames till Video Frame Observer is ready

### DIFF
--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
@@ -218,6 +218,25 @@ void RealtimeMediaSource::videoFrameAvailable(VideoFrame& videoFrame, VideoFrame
     updateHasStartedProducingData();
 
     Locker locker { m_videoFrameObserversLock };
+    if (m_videoFrameObservers.isEmpty()) {
+        if (m_pendingVideoFrames.size() < maxPendingVideoFramesBeforeAddTrack) {
+            m_pendingVideoFrames.append(PendingVideoFrame { &videoFrame, metadata });
+        }
+        else {
+            WTFLogAlways("RealtimeMediaSource: Dropping video frame (queue is full) %zu frames", m_pendingVideoFrames.size());
+        }
+        return;
+    }
+    if (!m_pendingVideoFrames.isEmpty()) {
+        WTFLogAlways("RealtimeMediaSource: Delivering %zu queued frame(s) (pipeline ready)", m_pendingVideoFrames.size());
+        for (auto& pending : m_pendingVideoFrames) {
+            if (pending.frame) {
+                for (auto* obs : m_videoFrameObservers)
+                    obs->videoFrameAvailable(*pending.frame, pending.metadata);
+            }
+        }
+        m_pendingVideoFrames.clear();
+    }
     for (auto* observer : m_videoFrameObservers)
         observer->videoFrameAvailable(videoFrame, metadata);
 }

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
@@ -300,6 +300,13 @@ private:
     mutable Lock m_videoFrameObserversLock;
     HashSet<VideoFrameObserver*> m_videoFrameObservers WTF_GUARDED_BY_LOCK(m_videoFrameObserversLock);
 
+    struct PendingVideoFrame {
+        RefPtr<VideoFrame> frame;
+        VideoFrameTimeMetadata metadata;
+    };
+    static constexpr size_t maxPendingVideoFramesBeforeAddTrack = 30;
+    Vector<PendingVideoFrame> m_pendingVideoFrames WTF_GUARDED_BY_LOCK(m_videoFrameObserversLock);
+
     // Set on the main thread from constraints.
     IntSize m_size;
     // Set on sample generation thread.


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=317111
Reviewed by: E. Ocaña González

Problem : WebRTC playback doesnot recover from a black screen and the issue is seen Intermittently

 Cause: The first video frame(s) (containing SPS/PPS/IDR) being dropped
 because libwebrtc starts delivering decoded frames before the downstream
 GStreamer pipeline's InternalSource registers as a VideoFrameObserver.

 Without first having the SPS/PPS and the first sync frame , the decoder
 can not decode any subsequent delta frames.

 In Following code snippet from mediastream/gstreamer/GStreamerMediaStreamSource.cpp,
 frames received while m_isObserving is false might be dropped.

void videoFrameAvailable(VideoFrame& videoFrame, VideoFrameTimeMetadata) final {
       return;

    updateFirstVideoSampleSeenFlag();

Change : While this patch doesnot address the root cause of delayed start of
 VideoFrameObserver, add a small frame buffer to hold frames
 (currently max size set to 30 frames) that arrive before any observer registers.
 deliver the frames when observer is registered
Note: From tests it is observed that only the first frame or 2 is actually needed to be queued.

* Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp: (RealtimeMediaSource::videoFrameAvailable) : Queue frames till observer is ready
* Source/WebCore/platform/mediastream/RealtimeMediaSource.h: (struct PendingVideoFrame): Added a buffer to hold the frames<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/737e7dcc396352966dbc075f62aed2b5b16ae257

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| [✅ 🛠 wpe-238-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/1/builds/242 "Built successfully") | [❌ 🧪 wpe-238-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/5/builds/95 "Found 4 new test failures: fast/mediastream/mediastreamtrack-video-frameRate-clone-decreasing.html, fast/mediastream/mediastreamtrack-video-frameRate-clone-increasing.html, fast/mediastream/mediastreamtrack-video-frameRate-decreasing.html, fast/mediastream/mediastreamtrack-video-frameRate-increasing.html (failure)") 
| [✅ 🛠 wpe-238-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/8/builds/241 "Built successfully") | [❌ 🧪 wpe-238-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/6/builds/104 "Found 4 new test failures: fast/mediastream/mediastreamtrack-video-frameRate-clone-decreasing.html, fast/mediastream/mediastreamtrack-video-frameRate-clone-increasing.html, fast/mediastream/mediastreamtrack-video-frameRate-decreasing.html, fast/mediastream/mediastreamtrack-video-frameRate-increasing.html (failure)") 
| | 
| | 
<!--EWS-Status-Bubble-End-->