### PR TITLE
[WebRTC] Queue frames till Video Frame Observer is ready

### DIFF
--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
@@ -338,6 +338,26 @@ void RealtimeMediaSource::videoFrameAvailable(VideoFrame& videoFrame, VideoFrame
     updateHasStartedProducingData();
 
     Locker locker { m_videoFrameObserversLock };
+    if (m_videoFrameObservers.isEmpty()) {
+        if (m_pendingVideoFrames.size() < maxPendingVideoFramesBeforeAddTrack) {
+             m_pendingVideoFrames.append(PendingVideoFrame { &videoFrame, metadata });
+        }
+        else {
+            WTFLogAlways("RealtimeMediaSource: Dropping video frame (queue is full) %zu frames", m_pendingVideoFrames.size());
+        }
+        return;
+    }
+    if (!m_pendingVideoFrames.isEmpty()) {
+        WTFLogAlways("RealtimeMediaSource: Delivering %zu queued frame(s) (pipeline ready)", m_pendingVideoFrames.size());
+        for (auto& pending : m_pendingVideoFrames) {
+            if (pending.frame) {
+                for (auto* obs : m_videoFrameObservers)
+                    obs->videoFrameAvailable(*pending.frame, pending.metadata);
+            }
+        }
+        m_pendingVideoFrames.clear();
+    }
+
     for (auto& [key, value] : m_videoFrameObservers) {
         if (auto* adaptor = value.get()) {
             if (adaptor->frameDecimation > 1 && ++adaptor->frameDecimationCounter % adaptor->frameDecimation)

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
@@ -391,6 +391,13 @@ private:
     mutable Lock m_videoFrameObserversLock;
     HashMap<VideoFrameObserver*, std::unique_ptr<VideoFrameAdaptor>> m_videoFrameObservers WTF_GUARDED_BY_LOCK(m_videoFrameObserversLock);
 
+    struct PendingVideoFrame {
+        RefPtr<VideoFrame> frame;
+        VideoFrameTimeMetadata metadata;
+    };
+    static constexpr size_t maxPendingVideoFramesBeforeAddTrack = 30;
+    Vector<PendingVideoFrame> m_pendingVideoFrames WTF_GUARDED_BY_LOCK(m_videoFrameObserversLock);
+
     CaptureDevice m_device;
 
     // Set on the main thread from constraints.


### PR DESCRIPTION
    https://bugs.webkit.org/show_bug.cgi?id=317111
    Reviewed by: E. Ocaña González

    Problem: WebRTC playback doesnot recover from a black screen and the issue is seen Intermittently

     Cause: The first video frame(s) (containing SPS/PPS/IDR) being dropped
     because libwebrtc starts delivering decoded frames before the downstream
     GStreamer pipeline's InternalSource registers as a VideoFrameObserver.

     Without first having the SPS/PPS and the first sync frame, the decoder
     cannot decode any subsequent delta frames.

     In Following code snippet from mediastream/gstreamer/GStreamerMediaStreamSource.cpp,
     frames received while m_isObserving is false might be dropped.

    void videoFrameAvailable(VideoFrame& videoFrame, VideoFrameTimeMetadata) final
    {
        if (!m_parent || !m_isObserving)
           return;

        updateFirstVideoSampleSeenFlag();

    Change: While this patch does not address the root cause of delayed start of
     VideoFrameObserver, add a small frame buffer to hold frames
     (currently max size set to 30 frames) that arrive before any observer registers.
     deliver the frames when observer is registered
    Note: From tests it is observed that only the first frame or 2 is actually needed to be queued.

    * Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp: (RealtimeMediaSource::videoFrameAvailable): Queue frames till observer are ready
    * Source/WebCore/platform/mediastream/RealtimeMediaSource.h: (struct PendingVideoFrame): Added a buffer to hold the frames<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/617daa5e3ad58c3503c07e1f2307a90c9c335711

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [❌ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/258 "Hash 617daa5e for PR 1690 does not build (failure)") | [❌ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/258 "Hash 617daa5e for PR 1690 does not build (failure)") 
| [❌ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/258 "Hash 617daa5e for PR 1690 does not build (failure)") | [❌ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/258 "Hash 617daa5e for PR 1690 does not build (failure)") 
<!--EWS-Status-Bubble-End-->