### PR TITLE
Backport fix for arm64 lto build

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h
@@ -111,7 +111,7 @@ WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(call_indirect, CallFrame* callFrame, Wasm::Fun
 // We can't use FunctionSpaceIndex here since ARMv7 ABI always passes structs on th stack...
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(prepare_call, unsigned functionSpaceIndex, EncodedJSValue* callee);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(prepare_call_indirect, CallFrame* callFrame, Wasm::FunctionSpaceIndex* functionIndex, CallIndirectMetadata* call);
-WASM_IPINT_EXTERN_CPP_DECL(prepare_call_ref, CallFrame*, Wasm::TypeIndex, IPIntStackEntry*);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(prepare_call_ref, CallFrame*, Wasm::TypeIndex, IPIntStackEntry*);
 
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(set_global_ref, uint32_t globalIndex, JSValue value);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(get_global_64, unsigned);


### PR DESCRIPTION
Original change https://github.com/WebKit/WebKit/pull/39463

REGRESSION(287403@main): Unable to link libjavascriptcoregtk: undefined reference to `ipint_extern_prepare_call_ref' https://bugs.webkit.org/show_bug.cgi?id=286433

Reviewed by Yusuke Suzuki.

The names of these macros are a little confusing, but I gather that HIDDEN is supposed to be used for declarations in header files.

* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h:

Canonical link: https://commits.webkit.org/289320@main
<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/5eb06c8a8a490ae2cb4f8bf47e47e0ddbbda6473

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/260 "Built successfully") | [✅ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/116 "Passed tests") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/260 "Built successfully") | [✅ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/10/builds/120 "Passed tests") 
<!--EWS-Status-Bubble-End-->