### PR TITLE
[MiniBrowser] fixing displaying the window in case of shm buffer

### DIFF
--- a/Tools/wpe/backends/PlatformWPE.cmake
+++ b/Tools/wpe/backends/PlatformWPE.cmake
@@ -4,11 +4,13 @@ find_package(WaylandProtocols 1.12 REQUIRED)
 find_package(WPEBackend_fdo 1.3.0 REQUIRED)
 
 list(APPEND WPEToolingBackends_PUBLIC_HEADERS
+    ${WPEToolingBackends_DERIVED_SOURCES_DIR}/xdg-shell-client-protocol.h
     ${WPEToolingBackends_DERIVED_SOURCES_DIR}/xdg-shell-unstable-v6-client-protocol.h
     fdo/WindowViewBackend.h
 )
 
 list(APPEND WPEToolingBackends_SOURCES
+    ${WPEToolingBackends_DERIVED_SOURCES_DIR}/xdg-shell-protocol.c
     ${WPEToolingBackends_DERIVED_SOURCES_DIR}/xdg-shell-unstable-v6-protocol.c
 
     atk/WebKitAccessibleApplication.cpp
@@ -41,6 +43,19 @@ list(APPEND WPEToolingBackends_LIBRARIES
 
 list(APPEND WPEToolingBackends_DEFINITIONS USE_GLIB=1)
 list(APPEND WPEToolingBackends_PRIVATE_DEFINITIONS ${LIBEPOXY_DEFINITIONS})
+
+add_custom_command(
+    OUTPUT ${WPEToolingBackends_DERIVED_SOURCES_DIR}/xdg-shell-protocol.c
+    MAIN_DEPENDENCY ${WAYLAND_PROTOCOLS_DATADIR}/stable/xdg-shell/xdg-shell.xml
+    DEPENDS ${WPEToolingBackends_DERIVED_SOURCES_DIR}/xdg-shell-client-protocol.h
+    COMMAND ${WAYLAND_SCANNER} code ${WAYLAND_PROTOCOLS_DATADIR}/stable/xdg-shell/xdg-shell.xml ${WPEToolingBackends_DERIVED_SOURCES_DIR}/xdg-shell-protocol.c
+    VERBATIM)
+
+add_custom_command(
+    OUTPUT ${WPEToolingBackends_DERIVED_SOURCES_DIR}/xdg-shell-client-protocol.h
+    MAIN_DEPENDENCY ${WAYLAND_PROTOCOLS_DATADIR}/stable/xdg-shell/xdg-shell.xml
+    COMMAND ${WAYLAND_SCANNER} client-header ${WAYLAND_PROTOCOLS_DATADIR}/stable/xdg-shell/xdg-shell.xml ${WPEToolingBackends_DERIVED_SOURCES_DIR}/xdg-shell-client-protocol.h
+    VERBATIM)
 
 add_custom_command(
     OUTPUT ${WPEToolingBackends_DERIVED_SOURCES_DIR}/xdg-shell-unstable-v6-protocol.c

--- a/Tools/wpe/backends/fdo/WindowViewBackend.cpp
+++ b/Tools/wpe/backends/fdo/WindowViewBackend.cpp
@@ -143,8 +143,11 @@ const struct wl_registry_listener WindowViewBackend::s_registryListener = {
         if (!std::strcmp(interface, "wl_compositor"))
             window->m_compositor = static_cast<struct wl_compositor*>(wl_registry_bind(registry, name, &wl_compositor_interface, 1));
 
+        if (!std::strcmp(interface, "xdg_wm_base"))
+            window->m_xdg.wm = static_cast<struct xdg_wm_base*>(wl_registry_bind(registry, name, &xdg_wm_base_interface, 1));
+
         if (!std::strcmp(interface, "zxdg_shell_v6"))
-            window->m_xdg = static_cast<struct zxdg_shell_v6*>(wl_registry_bind(registry, name, &zxdg_shell_v6_interface, 1));
+            window->m_zxdg.shell = static_cast<struct zxdg_shell_v6*>(wl_registry_bind(registry, name, &zxdg_shell_v6_interface, 1));
 
         if (!std::strcmp(interface, "wl_seat"))
             window->m_seat = static_cast<struct wl_seat*>(wl_registry_bind(registry, name, &wl_seat_interface, 5));
@@ -153,7 +156,15 @@ const struct wl_registry_listener WindowViewBackend::s_registryListener = {
     [](void*, struct wl_registry*, uint32_t) { },
 };
 
-const struct zxdg_shell_v6_listener WindowViewBackend::s_xdgWmBaseListener = {
+const struct xdg_wm_base_listener WindowViewBackend::XDGStable::s_wmListener = {
+    // ping
+    [](void*, struct xdg_wm_base* xdgWM, uint32_t serial)
+    {
+        xdg_wm_base_pong(xdgWM, serial);
+    },
+};
+
+const struct zxdg_shell_v6_listener WindowViewBackend::XDGUnstable::s_shellListener = {
     // ping
     [](void*, struct zxdg_shell_v6* shell, uint32_t serial)
     {
@@ -512,7 +523,64 @@ const struct wl_seat_listener WindowViewBackend::s_seatListener = {
     [](void*, struct wl_seat*, const char*) { }
 };
 
-const struct zxdg_surface_v6_listener WindowViewBackend::s_xdgSurfaceListener = {
+const struct xdg_surface_listener WindowViewBackend::XDGStable::s_surfaceListener = {
+    // configure
+    [](void*, struct xdg_surface* surface, uint32_t serial)
+    {
+        xdg_surface_ack_configure(surface, serial);
+    },
+};
+
+const struct xdg_toplevel_listener WindowViewBackend::XDGStable::s_toplevelListener = {
+    // configure
+    [](void* data, struct xdg_toplevel*, int32_t width, int32_t height, struct wl_array* states)
+    {
+        auto& window = *static_cast<WindowViewBackend*>(data);
+        window.resize(std::max(0, width), std::max(0, height));
+
+        bool isFocused = false;
+        bool isFullscreen = false;
+        // FIXME: It would be nice if the following loop could use
+        // wl_array_for_each, but at the time of writing it relies on
+        // GCC specific extension to work properly:
+        // https://gitlab.freedesktop.org/wayland/wayland/issues/34
+        uint32_t* pos = static_cast<uint32_t*>(states->data);
+        uint32_t* end = static_cast<uint32_t*>(states->data) + states->size;
+
+        for (; pos < end; pos++) {
+            uint32_t state = *pos;
+
+            switch (state) {
+            case XDG_TOPLEVEL_STATE_ACTIVATED:
+                isFocused = true;
+                break;
+            case XDG_TOPLEVEL_STATE_FULLSCREEN:
+                isFullscreen = true;
+                break;
+            case XDG_TOPLEVEL_STATE_MAXIMIZED:
+            case XDG_TOPLEVEL_STATE_RESIZING:
+            default:
+                break;
+            }
+        }
+
+        if (isFocused)
+            window.addActivityState(wpe_view_activity_state_focused);
+        else
+            window.removeActivityState(wpe_view_activity_state_focused);
+
+        if (window.m_is_fullscreen != isFullscreen)
+            window.onFullscreenChanged(isFullscreen);
+    },
+    // close
+    [](void* data, struct xdg_toplevel*)
+    {
+        auto& window = *static_cast<WindowViewBackend*>(data);
+        window.removeActivityState(wpe_view_activity_state_visible | wpe_view_activity_state_focused | wpe_view_activity_state_in_window);
+    },
+};
+
+const struct zxdg_surface_v6_listener WindowViewBackend::XDGUnstable::s_surfaceListener = {
     // configure
     [](void*, struct zxdg_surface_v6* surface, uint32_t serial)
     {
@@ -520,7 +588,7 @@ const struct zxdg_surface_v6_listener WindowViewBackend::s_xdgSurfaceListener = 
     },
 };
 
-const struct zxdg_toplevel_v6_listener WindowViewBackend::s_xdgToplevelListener = {
+const struct zxdg_toplevel_v6_listener WindowViewBackend::XDGUnstable::s_toplevelListener = {
     // configure
     [](void* data, struct zxdg_toplevel_v6*, int32_t width, int32_t height, struct wl_array* states)
     {
@@ -584,10 +652,17 @@ bool WindowViewBackend::onDOMFullscreenRequest(void* data, bool fullscreen)
     }
 
     window.m_waiting_fullscreen_notify = true;
-    if (fullscreen)
-        zxdg_toplevel_v6_set_fullscreen(window.m_xdgToplevel, nullptr);
-    else
-        zxdg_toplevel_v6_unset_fullscreen(window.m_xdgToplevel);
+    if (window.m_xdg.toplevel) {
+        if (fullscreen)
+            xdg_toplevel_set_fullscreen(window.m_xdg.toplevel, nullptr);
+        else
+            xdg_toplevel_unset_fullscreen(window.m_xdg.toplevel);
+    } else if (window.m_zxdg.toplevel) {
+        if (fullscreen)
+            zxdg_toplevel_v6_set_fullscreen(window.m_zxdg.toplevel, nullptr);
+        else
+            zxdg_toplevel_v6_unset_fullscreen(window.m_zxdg.toplevel);
+    }
 
     return true;
 }
@@ -643,8 +718,10 @@ WindowViewBackend::WindowViewBackend(uint32_t width, uint32_t height)
         wl_registry_add_listener(registry, &s_registryListener, this);
         wl_display_roundtrip(connection.display);
 
-        if (m_xdg)
-            zxdg_shell_v6_add_listener(m_xdg, &s_xdgWmBaseListener, nullptr);
+        if (m_xdg.wm)
+            xdg_wm_base_add_listener(m_xdg.wm, &XDGStable::s_wmListener, nullptr);
+        else if (m_zxdg.shell)
+            zxdg_shell_v6_add_listener(m_zxdg.shell, &XDGUnstable::s_shellListener, nullptr);
 
         if (m_seat)
             wl_seat_add_listener(m_seat, &s_seatListener, this);
@@ -666,13 +743,23 @@ WindowViewBackend::WindowViewBackend(uint32_t width, uint32_t height)
     }
 
     m_surface = wl_compositor_create_surface(m_compositor);
-    if (m_xdg) {
-        m_xdgSurface = zxdg_shell_v6_get_xdg_surface(m_xdg, m_surface);
-        zxdg_surface_v6_add_listener(m_xdgSurface, &s_xdgSurfaceListener, nullptr);
-        m_xdgToplevel = zxdg_surface_v6_get_toplevel(m_xdgSurface);
-        if (m_xdgToplevel) {
-            zxdg_toplevel_v6_add_listener(m_xdgToplevel, &s_xdgToplevelListener, this);
-            zxdg_toplevel_v6_set_title(m_xdgToplevel, "WPE");
+    if (m_xdg.wm) {
+        m_xdg.surface = xdg_wm_base_get_xdg_surface(m_xdg.wm, m_surface);
+        xdg_surface_add_listener(m_xdg.surface, &XDGStable::s_surfaceListener, nullptr);
+        m_xdg.toplevel = xdg_surface_get_toplevel(m_xdg.surface);
+        if (m_xdg.toplevel) {
+            xdg_toplevel_add_listener(m_xdg.toplevel, &XDGStable::s_toplevelListener, this);
+            xdg_toplevel_set_title(m_xdg.toplevel, "WPE");
+            wl_surface_commit(m_surface);
+            addActivityState(wpe_view_activity_state_visible | wpe_view_activity_state_in_window);
+        }
+    } else if (m_zxdg.shell) {
+        m_zxdg.surface = zxdg_shell_v6_get_xdg_surface(m_zxdg.shell, m_surface);
+        zxdg_surface_v6_add_listener(m_zxdg.surface, &XDGUnstable::s_surfaceListener, nullptr);
+        m_zxdg.toplevel = zxdg_surface_v6_get_toplevel(m_zxdg.surface);
+        if (m_zxdg.toplevel) {
+            zxdg_toplevel_v6_add_listener(m_zxdg.toplevel, &XDGUnstable::s_toplevelListener, this);
+            zxdg_toplevel_v6_set_title(m_zxdg.toplevel, "WPE");
             wl_surface_commit(m_surface);
             addActivityState(wpe_view_activity_state_visible | wpe_view_activity_state_in_window);
         }
@@ -743,11 +830,15 @@ WindowViewBackend::~WindowViewBackend()
         g_source_unref(m_eventSource);
     }
 
-    if (m_xdgToplevel)
-        zxdg_toplevel_v6_destroy(m_xdgToplevel);
+    if (m_xdg.toplevel)
+        xdg_toplevel_destroy(m_xdg.toplevel);
+    if (m_xdg.surface)
+        xdg_surface_destroy(m_xdg.surface);
 
-    if (m_xdgSurface)
-        zxdg_surface_v6_destroy(m_xdgSurface);
+    if (m_zxdg.toplevel)
+        zxdg_toplevel_v6_destroy(m_zxdg.toplevel);
+    if (m_zxdg.surface)
+        zxdg_surface_v6_destroy(m_zxdg.surface);
 
     if (m_surface)
         wl_surface_destroy(m_surface);
@@ -755,8 +846,11 @@ WindowViewBackend::~WindowViewBackend()
     if (m_eglWindow)
         wl_egl_window_destroy(m_eglWindow);
 
-    if (m_xdg)
-        zxdg_shell_v6_destroy(m_xdg);
+    if (m_xdg.wm)
+        xdg_wm_base_destroy(m_xdg.wm);
+
+    if (m_zxdg.shell)
+        zxdg_shell_v6_destroy(m_zxdg.shell);
 
     if (m_seat)
         wl_seat_destroy(m_seat);

--- a/Tools/wpe/backends/fdo/WindowViewBackend.cpp
+++ b/Tools/wpe/backends/fdo/WindowViewBackend.cpp
@@ -32,12 +32,17 @@
 #include <mutex>
 #include <sys/mman.h>
 #include <unistd.h>
+#include <vector>
 
 // This include order is necessary to enforce the Wayland EGL platform.
 #include <wayland-egl.h>
 #include <epoxy/egl.h>
 #include <wpe/fdo-egl.h>
 #include <xkbcommon/xkbcommon.h>
+
+#if WPE_FDO_CHECK_VERSION(1, 5, 0)
+#include <wayland-server.h>
+#endif
 
 #ifndef EGL_WL_bind_wayland_display
 #define EGL_WL_bind_wayland_display 1
@@ -1051,9 +1056,85 @@ void WindowViewBackend::displayBuffer(struct wpe_fdo_egl_exported_image* image)
 }
 
 #if WPE_FDO_CHECK_VERSION(1, 5, 0)
-void WindowViewBackend::displayBuffer(struct wpe_fdo_shm_exported_buffer*)
+void WindowViewBackend::displayBuffer(struct wpe_fdo_shm_exported_buffer* buffer)
 {
-    g_warning("WindowViewBackend: cannot yet handle wpe_fdo_shm_exported_buffer.");
+    struct wl_shm_buffer* shmBuffer = wpe_fdo_shm_exported_buffer_get_shm_buffer(buffer);
+    uint32_t format = wl_shm_buffer_get_format(shmBuffer);
+    if (format != WL_SHM_FORMAT_ARGB8888 && format != WL_SHM_FORMAT_XRGB8888) {
+        g_warning("WindowViewBackend: unsupported shm buffer format %u.", format);
+        wpe_view_backend_exportable_fdo_egl_dispatch_release_shm_exported_buffer(m_exportable, buffer);
+        wpe_view_backend_exportable_fdo_dispatch_frame_complete(m_exportable);
+        return;
+    }
+
+    int32_t width = wl_shm_buffer_get_width(shmBuffer);
+    int32_t height = wl_shm_buffer_get_height(shmBuffer);
+    int32_t stride = wl_shm_buffer_get_stride(shmBuffer);
+
+    // wl_shm ARGB8888/XRGB8888 buffers are stored in memory as B, G, R, A (little-endian);
+    // swap to R, G, B, A here since the GL texture below is uploaded as plain GL_RGBA.
+    std::vector<uint8_t> pixels(static_cast<size_t>(width) * height * 4);
+    wl_shm_buffer_begin_access(shmBuffer);
+    auto* src = static_cast<uint8_t*>(wl_shm_buffer_get_data(shmBuffer));
+    for (int32_t y = 0; y < height; ++y) {
+        auto* srcRow = src + stride * y;
+        auto* dstRow = pixels.data() + width * 4 * y;
+        for (int32_t x = 0; x < width; ++x) {
+            dstRow[4 * x + 0] = srcRow[4 * x + 2];
+            dstRow[4 * x + 1] = srcRow[4 * x + 1];
+            dstRow[4 * x + 2] = srcRow[4 * x + 0];
+            dstRow[4 * x + 3] = srcRow[4 * x + 3];
+        }
+    }
+    wl_shm_buffer_end_access(shmBuffer);
+    wpe_view_backend_exportable_fdo_egl_dispatch_release_shm_exported_buffer(m_exportable, buffer);
+
+    if (!m_eglContext)
+        return;
+
+    auto& connection = WaylandEGLConnection::singleton();
+    eglMakeCurrent(connection.eglDisplay, m_eglSurface, m_eglSurface, m_eglContext);
+
+    glViewport(0, 0, m_width, m_height);
+    glClearColor(1, 0, 0, 1);
+    glClear(GL_COLOR_BUFFER_BIT);
+
+    glUseProgram(m_program);
+
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D, m_viewTexture);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, pixels.data());
+    glUniform1i(m_textureUniform, 0);
+
+    static const GLfloat vertices[4][2] = {
+        { -1.0, 1.0 },
+        { 1.0, 1.0 },
+        { -1.0, -1.0 },
+        { 1.0, -1.0 },
+    };
+
+    static const GLfloat texturePos[4][2] = {
+        { 0, 0 },
+        { 1, 0 },
+        { 0, 1 },
+        { 1, 1 },
+    };
+
+    glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 0, vertices);
+    glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 0, texturePos);
+
+    glEnableVertexAttribArray(0);
+    glEnableVertexAttribArray(1);
+
+    glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+
+    glDisableVertexAttribArray(0);
+    glDisableVertexAttribArray(1);
+
+    struct wl_callback* callback = wl_surface_frame(m_surface);
+    wl_callback_add_listener(callback, &s_frameListener, this);
+
+    eglSwapBuffers(connection.eglDisplay, m_eglSurface);
 }
 #endif
 

--- a/Tools/wpe/backends/fdo/WindowViewBackend.h
+++ b/Tools/wpe/backends/fdo/WindowViewBackend.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "ViewBackend.h"
+#include "xdg-shell-client-protocol.h"
 #include "xdg-shell-unstable-v6-client-protocol.h"
 #include <glib.h>
 #include <unordered_map>
@@ -66,14 +67,11 @@ private:
 #endif
 
     static const struct wl_registry_listener s_registryListener;
-    static const struct zxdg_shell_v6_listener s_xdgWmBaseListener;
     static const struct wl_pointer_listener s_pointerListener;
     static const struct wl_keyboard_listener s_keyboardListener;
     static const struct wl_touch_listener s_touchListener;
     static const struct wl_seat_listener s_seatListener;
     static const struct wl_callback_listener s_frameListener;
-    static const struct zxdg_surface_v6_listener s_xdgSurfaceListener;
-    static const struct zxdg_toplevel_v6_listener s_xdgToplevelListener;
 
 #if WPE_CHECK_VERSION(1, 11, 1)
     static bool onDOMFullscreenRequest(void* data, bool fullscreen);
@@ -134,12 +132,9 @@ private:
 
     struct wl_display* m_display { nullptr };
     struct wl_compositor* m_compositor { nullptr };
-    struct zxdg_shell_v6* m_xdg { nullptr };
     struct wl_seat* m_seat { nullptr };
     GSource* m_eventSource { nullptr };
     struct wl_surface* m_surface { nullptr };
-    struct zxdg_surface_v6* m_xdgSurface { nullptr };
-    struct zxdg_toplevel_v6* m_xdgToplevel { nullptr };
     struct wl_egl_window* m_eglWindow { nullptr };
     EGLContext m_eglContext { nullptr };
     EGLConfig m_eglConfig;
@@ -152,6 +147,26 @@ private:
 #if WPE_CHECK_VERSION(1, 11, 1)
     bool m_waiting_fullscreen_notify { false };
 #endif
+
+    struct XDGStable {
+        static const struct xdg_wm_base_listener s_wmListener;
+        static const struct xdg_surface_listener s_surfaceListener;
+        static const struct xdg_toplevel_listener s_toplevelListener;
+
+        struct xdg_wm_base* wm { nullptr };
+        struct xdg_surface* surface { nullptr };
+        struct xdg_toplevel* toplevel { nullptr };
+    } m_xdg;
+
+    struct XDGUnstable {
+        static const struct zxdg_shell_v6_listener s_shellListener;
+        static const struct zxdg_surface_v6_listener s_surfaceListener;
+        static const struct zxdg_toplevel_v6_listener s_toplevelListener;
+
+        struct zxdg_shell_v6* shell { nullptr };
+        struct zxdg_surface_v6* surface { nullptr };
+        struct zxdg_toplevel_v6* toplevel { nullptr };
+    } m_zxdg;
 };
 
 } // WPEToolingBackends


### PR DESCRIPTION
It fixes displaying the window of MiniBrowser when we build and run in SDK.<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/a4b49fd8391319700c78ed391556753babf8d203

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| [✅ 🛠 wpe-238-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/1/builds/260 "Built successfully") | [✅ 🧪 wpe-238-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/5/builds/100 "Passed tests") 
| [✅ 🛠 wpe-238-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/8/builds/259 "Built successfully") | [✅ 🧪 wpe-238-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/6/builds/109 "Passed tests") 
| | 
| | 
<!--EWS-Status-Bubble-End-->