### PR TITLE
Fix gcc crash due to hoisted load from butterfly and drive-by build fix

### DIFF
--- a/Source/JavaScriptCore/runtime/ButterflyInlines.h
+++ b/Source/JavaScriptCore/runtime/ButterflyInlines.h
@@ -138,9 +138,15 @@ inline Butterfly* Butterfly::createOrGrowPropertyStorage(
     if (!oldButterfly)
         return create(vm, intendedOwner, 0, newPropertyCapacity, false, IndexingHeader(), 0);
 
-    size_t preCapacity = oldButterfly->indexingHeader()->preCapacity(structure);
-    size_t indexingPayloadSizeInBytes = oldButterfly->indexingHeader()->indexingPayloadSizeInBytes(structure);
     bool hasIndexingHeader = structure->hasIndexingHeader(intendedOwner);
+    size_t preCapacity = 0;
+    size_t indexingPayloadSizeInBytes = 0;
+    // A property-only butterfly allocates no indexing header, so reading one reads off the front of
+    // the allocation. That faults when the butterfly is the last cell before an unmapped page.
+    if (hasIndexingHeader) {
+        preCapacity = oldButterfly->indexingHeader()->preCapacity(structure);
+        indexingPayloadSizeInBytes = oldButterfly->indexingHeader()->indexingPayloadSizeInBytes(structure);
+    }
     Butterfly* result = createUninitialized(vm, intendedOwner, preCapacity, newPropertyCapacity, hasIndexingHeader, indexingPayloadSizeInBytes);
     // Use memcpy since this butterfly is not tied to any object yet.
     memcpy(

--- a/Source/cmake/WebKitCompilerFlags.cmake
+++ b/Source/cmake/WebKitCompilerFlags.cmake
@@ -137,11 +137,12 @@ if (DEVELOPER_MODE AND DEVELOPER_MODE_FATAL_WARNINGS)
 endif ()
 
 if (COMPILER_IS_GCC_OR_CLANG)
-    if (COMPILER_IS_CLANG OR DEVELOPER_MODE)
+    if (COMPILER_IS_CLANG OR (DEVELOPER_MODE AND NOT WTF_CPU_ARM))
         # Split debug information in ".debug_types" / ".debug_info" sections - this leads
         # to a smaller overall size of the debug information, and avoids linker relocation
         # errors on e.g. aarch64 (relocation R_AARCH64_ABS32 out of range: 4312197985 is not in [-2147483648, 4294967295])
         # But when using GCC this breaks Linux distro debuginfo generation, so limit to DEVELOPER_MODE.
+        # On ARM32 the extra sections exhaust the linker's 32-bit address space, so skip it there.
         WEBKIT_PREPEND_GLOBAL_COMPILER_FLAGS(-fdebug-types-section)
     endif ()
 


### PR DESCRIPTION
Fix gcc crash due to hoisted load from butterfly and drive-by build fix<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/7050c6294f9d670ccd4f8f4c8c86fb35fa42d675

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/281 "Built successfully") | [✅ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/129 "Passed tests") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/281 "Built successfully") | [✅ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/10/builds/134 "Passed tests") 
<!--EWS-Status-Bubble-End-->