### PR TITLE
Fix aliasing with scratch register on 32-bit bbq i64 div

### DIFF
--- a/JSTests/wasm/stress/armv7-i64-div-by-constant.js
+++ b/JSTests/wasm/stress/armv7-i64-div-by-constant.js
@@ -1,0 +1,52 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+// The i32 operand of the outer add is evaluated first, so it holds a register while the
+// dividend is loaded. That pushes the dividend into a register pair overlapping the pair
+// the C call passes it in, which is what makes the argument shuffle need a temporary.
+let wat = `
+(module
+    (func (export "divS") (param $x i64) (param $k i32) (result i32)
+        (i32.add (local.get $k) (i32.wrap_i64 (i64.div_s (local.get $x) (i64.const 1000)))))
+    (func (export "divU") (param $x i64) (param $k i32) (result i32)
+        (i32.add (local.get $k) (i32.wrap_i64 (i64.div_u (local.get $x) (i64.const 1000)))))
+    (func (export "remS") (param $x i64) (param $k i32) (result i32)
+        (i32.add (local.get $k) (i32.wrap_i64 (i64.rem_s (local.get $x) (i64.const 1000)))))
+    (func (export "remU") (param $x i64) (param $k i32) (result i32)
+        (i32.add (local.get $k) (i32.wrap_i64 (i64.rem_u (local.get $x) (i64.const 1000)))))
+    (func (export "divSLeft") (param $x i64) (param $k i32) (result i32)
+        (i32.add (local.get $k) (i32.wrap_i64 (i64.div_s (i64.const 1000) (local.get $x)))))
+    (func (export "remSLeft") (param $x i64) (param $k i32) (result i32)
+        (i32.add (local.get $k) (i32.wrap_i64 (i64.rem_s (i64.const 1000) (local.get $x)))))
+    (func (export "divS32") (param $x i32) (param $k i32) (result i32)
+        (i32.add (local.get $k) (i32.div_s (local.get $x) (i32.const 1000))))
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {}, { simd: true })
+    const { divS, divU, remS, remU, divSLeft, remSLeft, divS32 } = instance.exports
+
+    for (let i = 1; i <= 10000; ++i) {
+        let x = i * 7919
+        assert.eq(divS(BigInt(x), 5), 5 + (x / 1000 | 0))
+        assert.eq(divU(BigInt(x), 5), 5 + (x / 1000 | 0))
+        assert.eq(remS(BigInt(x), 5), 5 + x % 1000)
+        assert.eq(remU(BigInt(x), 5), 5 + x % 1000)
+        assert.eq(divSLeft(BigInt(x), 5), 5 + (1000 / x | 0))
+        assert.eq(remSLeft(BigInt(x), 5), 5 + 1000 % x)
+        assert.eq(divS32(x, 5), 5 + (x / 1000 | 0))
+    }
+
+    // A zero dividend with a non-zero constant divisor emits no zero check, so losing the
+    // divisor makes the runtime helper divide zero by zero and take SIGFPE.
+    for (let i = 0; i < 10000; ++i) {
+        assert.eq(divS(0n, 5), 5)
+        assert.eq(divU(0n, 5), 5)
+        assert.eq(remS(0n, 5), 5)
+        assert.eq(remU(0n, 5), 5)
+        assert.eq(divS32(0, 5), 5)
+    }
+}
+
+await assert.asyncTest(test())

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT32_64.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT32_64.h
@@ -227,8 +227,8 @@ void BBQJIT::emitModOrDiv(Value& lhs, Location lhsLocation, Value& rhs, Location
         }
     }
 
-    auto lhsArg = Value::pinned(argType, lhsLocation);
-    auto rhsArg = Value::pinned(argType, rhsLocation);
+    auto lhsArg = lhs.isConst() ? lhs : Value::pinned(argType, lhsLocation);
+    auto rhsArg = rhs.isConst() ? rhs : Value::pinned(argType, rhsLocation);
     consume(result);
     emitCCall(modOrDiv, ArgumentList { lhsArg, rhsArg }, result);
 }


### PR DESCRIPTION
Fix aliasing with scratch register on 32-bit bbq i64 div<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/3d39ac2e0d2bf3fcac48674aae62e17a506496aa

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/282 "Built successfully") | [✅ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/130 "Passed tests") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/282 "Built successfully") | [❌ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/10/builds/135 "Found 1 new test failure: imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-noopener.html (failure)") 
<!--EWS-Status-Bubble-End-->