### PR TITLE
Sync wpe-46 with upstream MSE edit lists code

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3343,7 +3343,6 @@ webkit.org/b/211614 imported/w3c/web-platform-tests/wasm/jsapi/constructor/insta
 webkit.org/b/211940 fast/text/multiple-codeunit-vertical-upright-2.html [ ImageOnlyFailure ]
 webkit.org/b/211940 fast/text/multiple-codeunit-vertical-upright.html [ ImageOnlyFailure ]
 
-webkit.org/b/167108 imported/w3c/web-platform-tests/media-source/mediasource-sequencemode-append-buffer.html [ Failure ]
 webkit.org/b/197711 imported/w3c/web-platform-tests/media-source/mediasource-correct-frames.html [ Failure ]
 webkit.org/b/214349 imported/w3c/web-platform-tests/media-source/mediasource-changetype-play-negative.html [ Crash Failure Timeout Pass ]
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/media-source/mediasource-remove-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/media-source/mediasource-remove-expected.txt
@@ -1,0 +1,18 @@
+
+PASS Test remove with an negative start.
+PASS Test remove with non-finite start.
+PASS Test remove with a start beyond the duration.
+PASS Test remove with a start larger than the end.
+PASS Test remove with a NEGATIVE_INFINITY end.
+PASS Test remove with a NaN end.
+PASS Test remove after SourceBuffer removed from mediaSource.
+PASS Test remove with a NaN duration.
+PASS Test remove while update pending.
+PASS Test aborting a remove operation.
+PASS Test remove with a start at the duration.
+PASS Test remove transitioning readyState from 'ended' to 'open'.
+PASS Test removing all appended data.
+PASS Test removing beginning of appended data.
+FAIL Test removing the middle of appended data. assert_equals: Buffered ranges after remove(). expected "{ [0.095, 0.997) [3.298, 6.548) }" but got "{ [0.095, 0.963) [3.298, 6.548) }"
+PASS Test removing the end of appended data.
+

--- a/Source/WebCore/platform/graphics/PlatformTimeRanges.cpp
+++ b/Source/WebCore/platform/graphics/PlatformTimeRanges.cpp
@@ -59,7 +59,8 @@ const PlatformTimeRanges& PlatformTimeRanges::emptyRanges()
 
 MediaTime PlatformTimeRanges::timeFudgeFactor()
 {
-    return { 1, 10 };
+    // Allow hasCurrentTime() to be off by as much as 0.083416s.
+    return { 2002, 24000 };
 }
 
 void PlatformTimeRanges::invert()

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -699,6 +699,15 @@ uint64_t toGstUnsigned64Time(const MediaTime& mediaTime)
     return time.timeValue();
 }
 
+GstClockTime toGstClockTime(const WTF::MediaTime& mediaTime)
+{
+    if (mediaTime.isInvalid())
+        return GST_CLOCK_TIME_NONE;
+    if (mediaTime < MediaTime::zeroTime())
+        return 0;
+    return static_cast<GstClockTime>(toGstUnsigned64Time(mediaTime));
+}
+
 RefPtr<GstMappedOwnedBuffer> GstMappedOwnedBuffer::create(GRefPtr<GstBuffer>&& buffer)
 {
     auto* mappedBuffer = new GstMappedOwnedBuffer(WTFMove(buffer));

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -89,14 +89,7 @@ void deinitializeGStreamer();
 unsigned getGstPlayFlag(const char* nick);
 uint64_t toGstUnsigned64Time(const MediaTime&);
 
-inline GstClockTime toGstClockTime(const MediaTime& mediaTime)
-{
-    if (mediaTime.isInvalid())
-        return GST_CLOCK_TIME_NONE;
-    if (mediaTime < MediaTime::zeroTime())
-        return 0;
-    return static_cast<GstClockTime>(toGstUnsigned64Time(mediaTime));
-}
+GstClockTime toGstClockTime(const WTF::MediaTime&);
 
 inline GstClockTime toGstClockTime(const Seconds& seconds)
 {

--- a/Source/WebCore/platform/graphics/gstreamer/MediaSampleGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaSampleGStreamer.cpp
@@ -38,7 +38,11 @@ MediaSampleGStreamer::MediaSampleGStreamer(GRefPtr<GstSample>&& sample, const Fl
     , m_presentationSize(presentationSize)
 {
     ASSERT(sample);
-    m_sample = WTFMove(sample);
+
+    GRefPtr writableSample = adoptGRef(gst_sample_make_writable(sample.leakRef()));
+    gst_sample_set_segment(writableSample.get(), nullptr);
+    m_sample = WTFMove(writableSample);
+
     const GstClockTime minimumDuration = 1000; // 1 us
     auto* buffer = gst_sample_get_buffer(m_sample.get());
     RELEASE_ASSERT(buffer);
@@ -91,15 +95,6 @@ Ref<MediaSampleGStreamer> MediaSampleGStreamer::createFakeSample(GstCaps*, const
     gstreamerMediaSample->m_duration = duration;
     gstreamerMediaSample->m_flags = MediaSample::IsNonDisplaying;
     return adoptRef(*gstreamerMediaSample);
-}
-
-void MediaSampleGStreamer::extendToTheBeginning()
-{
-    // Only to be used with the first sample, as a hack for lack of support for edit lists.
-    // See AppendPipeline::appsinkNewSample()
-    ASSERT(m_dts == MediaTime::zeroTime());
-    m_duration += m_pts;
-    m_pts = MediaTime::zeroTime();
 }
 
 void MediaSampleGStreamer::setTimestamps(const MediaTime& presentationTime, const MediaTime& decodeTime)

--- a/Source/WebCore/platform/graphics/gstreamer/MediaSampleGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaSampleGStreamer.cpp
@@ -97,6 +97,15 @@ Ref<MediaSampleGStreamer> MediaSampleGStreamer::createFakeSample(GstCaps*, const
     return adoptRef(*gstreamerMediaSample);
 }
 
+void MediaSampleGStreamer::extendToTheBeginning()
+{
+    // Only to be used with the first sample, as a hack for lack of support for edit lists.
+    // See AppendPipeline::appsinkNewSample()
+    ASSERT(m_dts == MediaTime::zeroTime());
+    m_duration += m_pts;
+    m_pts = MediaTime::zeroTime();
+}
+
 void MediaSampleGStreamer::setTimestamps(const MediaTime& presentationTime, const MediaTime& decodeTime)
 {
     m_pts = presentationTime;

--- a/Source/WebCore/platform/graphics/gstreamer/MediaSampleGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaSampleGStreamer.h
@@ -39,7 +39,6 @@ public:
 
     static Ref<MediaSampleGStreamer> createFakeSample(GstCaps*, const MediaTime& pts, const MediaTime& dts, const MediaTime& duration, const FloatSize& presentationSize, TrackID);
 
-    void extendToTheBeginning();
     MediaTime presentationTime() const override { return m_pts; }
     MediaTime decodeTime() const override { return m_dts; }
     MediaTime duration() const override { return m_duration; }

--- a/Source/WebCore/platform/graphics/gstreamer/MediaSampleGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaSampleGStreamer.h
@@ -39,6 +39,7 @@ public:
 
     static Ref<MediaSampleGStreamer> createFakeSample(GstCaps*, const MediaTime& pts, const MediaTime& dts, const MediaTime& duration, const FloatSize& presentationSize, TrackID);
 
+    void extendToTheBeginning();
     MediaTime presentationTime() const override { return m_pts; }
     MediaTime decodeTime() const override { return m_dts; }
     MediaTime duration() const override { return m_duration; }

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -499,7 +499,7 @@ static MediaTime bufferTimeToStreamTime(const GstSegment& segment, GstClockTime 
         GST_ERROR("Couldn't map buffer time %" GST_TIME_FORMAT " to segment %" GST_PTR_FORMAT, GST_TIME_ARGS(bufferTime), &segment);
         return MediaTime::invalidTime();
     }
-    return sign * fromGstClockTime(streamTime);
+    return MediaTime(sign * streamTime, GST_SECOND);
 }
 
 void AppendPipeline::appsinkNewSample(const Track& track, GRefPtr<GstSample>&& sample)
@@ -532,16 +532,24 @@ void AppendPipeline::appsinkNewSample(const Track& track, GRefPtr<GstSample>&& s
         GST_TRACE_OBJECT(track.appsinkPad.get(), "Mapped buffer to segment, PTS %" GST_TIME_FORMAT " -> %s DTS %" GST_TIME_FORMAT " -> %s",
             GST_TIME_ARGS(GST_BUFFER_PTS(buffer)), pts.toString().utf8().data(), GST_TIME_ARGS(GST_BUFFER_DTS(buffer)), dts.toString().utf8().data());
         mediaSample->setTimestamps(pts, dts);
-    } else if (!GST_BUFFER_DTS(buffer) && GST_BUFFER_PTS(buffer) > 0
-        && GST_BUFFER_PTS(buffer) <= toGstClockTime(PlatformTimeRanges::timeFudgeFactor())) {
+     } else if (!GST_BUFFER_DTS(buffer) && GST_BUFFER_PTS(buffer) > 0
+        && GST_BUFFER_PTS(buffer) <= toGstClockTime(PlatformTimeRanges::timeFudgeFactor())
+        && mediaSample->isSync()) {
         // Because a track presentation time starting at some close to zero, but not exactly zero time can cause unexpected
         // results for applications, we used to extend the duration of this first sample to the left so that it starts at zero.
         // This should be relevant for files that should have an edit list but don't, but we think those files don't exist in
         // the wild anymore. Instead of correcting the sample, we log a warning. If many users report issues that trigger this
         // warning, we can consider to return to the old behaviour.
-        GST_WARNING_OBJECT(pipeline(), "Detected first sample of track '%" PRIu64 "' eligible to be extended to "
-            "start at PTS=0 %" GST_PTR_FORMAT ", but extending the first sample has been deprecated after the addition of "
-            "edit lists support. Please report this video for analysis.", track.trackId, buffer);
+        if (webkitGstCheckVersion(1, 20, 0)) {
+            GST_WARNING_OBJECT(pipeline(), "Detected first sample of track '%" PRIu64 "' eligible to be extended to "
+            "start at PTS=0 %" GST_PTR_FORMAT ", but extending the first sample has been deprecated for GStreamer 1.20 and above "
+            "after the addition of edit lists support. Please report this video for analysis.", track.trackId, buffer);
+        } else {
+            GST_WARNING_OBJECT(pipeline(), "Detected first sample of track '%" PRIu64 "' eligible to be extended to "
+            "start at PTS=0 %" GST_PTR_FORMAT ". Extending the first sample for GStreamer <1.20 for backwards compatibility. "
+            "Please report this video for analysis.", track.trackId, buffer);
+            mediaSample->extendToTheBeginning();
+        }
     }
 
     GST_TRACE_OBJECT(pipeline(), "append: trackId=%" PRIu64 " PTS=%s DTS=%s DUR=%s presentationSize=%.0fx%.0f",

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -488,18 +488,18 @@ void AppendPipeline::handleEndOfAppend()
     sourceBufferPrivate().didReceiveAllPendingSamples();
 }
 
-static MediaTime bufferTimeToStreamTime(const GstSegment* segment, GstClockTime bufferTime)
+static MediaTime bufferTimeToStreamTime(const GstSegment& segment, GstClockTime bufferTime)
 {
     if (bufferTime == GST_CLOCK_TIME_NONE)
         return MediaTime::invalidTime();
 
     guint64 streamTime;
-    int sign = gst_segment_to_stream_time_full(segment, GST_FORMAT_TIME, bufferTime, &streamTime);
+    int sign = gst_segment_to_stream_time_full(&segment, GST_FORMAT_TIME, bufferTime, &streamTime);
     if (!sign) {
-        GST_ERROR("Couldn't map buffer time %" GST_TIME_FORMAT " to segment %" GST_PTR_FORMAT, GST_TIME_ARGS(bufferTime), segment);
+        GST_ERROR("Couldn't map buffer time %" GST_TIME_FORMAT " to segment %" GST_PTR_FORMAT, GST_TIME_ARGS(bufferTime), &segment);
         return MediaTime::invalidTime();
     }
-    return MediaTime(sign * streamTime, GST_SECOND);
+    return sign * fromGstClockTime(streamTime);
 }
 
 void AppendPipeline::appsinkNewSample(const Track& track, GRefPtr<GstSample>&& sample)
@@ -518,25 +518,30 @@ void AppendPipeline::appsinkNewSample(const Track& track, GRefPtr<GstSample>&& s
         return;
     }
 
-    GstSegment* segment = gst_sample_get_segment(sample.get());
+    GstSegment segment;
+    gst_segment_init(&segment, GST_FORMAT_UNDEFINED);
+    gst_segment_copy_into(gst_sample_get_segment(sample.get()), &segment);
+
     auto mediaSample = MediaSampleGStreamer::create(WTFMove(sample), track.presentationSize, track.trackId);
 
-    if (segment && (segment->time || segment->start)) {
+    if (segment.format == GST_FORMAT_TIME && (segment.time || segment.start) && GST_BUFFER_PTS_IS_VALID(buffer)) {
         // MP4 has the concept of edit lists, where some buffer time needs to be offsetted, often very slightly,
         // to get exact timestamps.
         MediaTime pts = bufferTimeToStreamTime(segment, GST_BUFFER_PTS(buffer));
-        MediaTime dts = bufferTimeToStreamTime(segment, GST_BUFFER_DTS(buffer));
+        MediaTime dts = bufferTimeToStreamTime(segment, GST_BUFFER_DTS_IS_VALID(buffer) ? GST_BUFFER_DTS(buffer) : GST_BUFFER_DTS_OR_PTS(buffer));
         GST_TRACE_OBJECT(track.appsinkPad.get(), "Mapped buffer to segment, PTS %" GST_TIME_FORMAT " -> %s DTS %" GST_TIME_FORMAT " -> %s",
             GST_TIME_ARGS(GST_BUFFER_PTS(buffer)), pts.toString().utf8().data(), GST_TIME_ARGS(GST_BUFFER_DTS(buffer)), dts.toString().utf8().data());
         mediaSample->setTimestamps(pts, dts);
-    } else if (!GST_BUFFER_DTS(buffer) && GST_BUFFER_PTS(buffer) > 0 && GST_BUFFER_PTS(buffer) <= 100'000'000 && mediaSample->isSync()) {
+    } else if (!GST_BUFFER_DTS(buffer) && GST_BUFFER_PTS(buffer) > 0
+        && GST_BUFFER_PTS(buffer) <= toGstClockTime(PlatformTimeRanges::timeFudgeFactor())) {
         // Because a track presentation time starting at some close to zero, but not exactly zero time can cause unexpected
-        // results for applications, we extend the duration of this first sample to the left so that it starts at zero.
-        // This is relevant for files that should have an edit list but don't, or when using GStreamer < 1.16, where
-        // edit lists are not parsed in push-mode.
-
-        GST_DEBUG("Extending first sample of track '%" PRIu64 "' to make it start at PTS=0 %" GST_PTR_FORMAT, track.trackId, buffer);
-        mediaSample->extendToTheBeginning();
+        // results for applications, we used to extend the duration of this first sample to the left so that it starts at zero.
+        // This should be relevant for files that should have an edit list but don't, but we think those files don't exist in
+        // the wild anymore. Instead of correcting the sample, we log a warning. If many users report issues that trigger this
+        // warning, we can consider to return to the old behaviour.
+        GST_WARNING_OBJECT(pipeline(), "Detected first sample of track '%" PRIu64 "' eligible to be extended to "
+            "start at PTS=0 %" GST_PTR_FORMAT ", but extending the first sample has been deprecated after the addition of "
+            "edit lists support. Please report this video for analysis.", track.trackId, buffer);
     }
 
     GST_TRACE_OBJECT(pipeline(), "append: trackId=%" PRIu64 " PTS=%s DTS=%s DUR=%s presentationSize=%.0fx%.0f",


### PR DESCRIPTION
Edit list support had been present in wpe-2.38 and wpe-2.46 for a long time. It has had a history of landings and reverts upstream:
- Landed:  https://github.com/WebKit/WebKit/commit/1d40c25a2a07f57ee739c87b84df29c3452723b0
- Reverted: https://github.com/WebKit/WebKit/commit/70be9d3a5f373c6177f8b34357e6e43998199534
- Landed: https://github.com/WebKit/WebKit/commit/4104220de30031e16457b20dd360bd153aa514de
- Reverted: https://github.com/WebKit/WebKit/commit/70a24fa9d9280669b0ef93628064a98c0a0705ce
- Landed: https://github.com/WebKit/WebKit/commit/bf69bf7f9edc397b39b76d90a861362b8182088a
- Reverted: https://github.com/WebKit/WebKit/commit/9baf78c78689868f87c5eb3d38b8ceb4de0ca1e2
- Landed (finally!): https://github.com/WebKit/WebKit/commit/554e6641135858b62758e095cf7157533d9052ae

To check for regressions, I've backported to wpe-2.46 the latest version of the patch that is currently in place upstream. I've detected some regressions on [YouTube MSE Conformance Tests 2019](https://ytlr-cert.appspot.com/2019/main.html?novp9=true), identified the problem and landed a follow-up patch upstream:

https://github.com/WebKit/WebKit/commit/1fff76c0299c8f06095f170363464e994a11eba7

This Pull Request backports to wpe-2.46 the two commits currently upstream, in order to have the same code in both places. It's in our best interest to have a similar environment on this regard, so that any bug or strange behaviour is reproducible in both places.<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/96e9d159aace62f4de4f62b0418d2fdff4421315

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/285 "Built successfully") | [  ~~🧪 wpe-246-amd64-layout~~](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/285 "Built successfully") | [  ~~🧪 wpe-246-arm32-layout~~](https://ews-wpe-rdk.igalia.com/#/builders/10/builds/138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
<!--EWS-Status-Bubble-End-->