### PR TITLE
[MSE] Crashfix on seeking MediaSource re-opening

### DIFF
--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -1201,6 +1201,7 @@ void MediaSource::detachFromElement()
         m_seekTargetPromise->reject(PlatformMediaError::Cancelled);
         m_seekTargetPromise.reset();
     }
+    m_pendingSeekTarget.reset();
 }
 
 void MediaSource::sourceBufferDidChangeActiveState(SourceBuffer&, bool)


### PR DESCRIPTION
When a seek was pending at detach time, m_seekTargetPromise was correctly rejected and cleared but m_pendingSeekTarget was left set. On the next attach/append cycle, monitorSourceBuffers() would call completeSeek() with a live m_pendingSeekTarget but an empty m_seekTargetPromise, causing a crash dereferencing the empty optional.

Fixes crash when HTMLMediaElement reuses the same MediaSource for a new source after a seek-then-detach sequence.<!--EWS-Status-Bubble-Start-->
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/3daf0357f097ac578aba0d68aa98d1e648839382

| Build-Tests | Layout-Tests |
| ----------- | ------------ |
| | 
| | 
| [✅ 🛠 wpe-246-amd64-build](https://ews-wpe-rdk.igalia.com/#/builders/11/builds/287 "Built successfully") | [✅ 🧪 wpe-246-amd64-layout](https://ews-wpe-rdk.igalia.com/#/builders/9/builds/135 "Passed tests") 
| [✅ 🛠 wpe-246-arm32-build](https://ews-wpe-rdk.igalia.com/#/builders/12/builds/287 "Built successfully") | [✅ 🧪 wpe-246-arm32-layout](https://ews-wpe-rdk.igalia.com/#/builders/10/builds/140 "Passed tests") 
<!--EWS-Status-Bubble-End-->